### PR TITLE
Add safe mode recovery for unexpected app crashes

### DIFF
--- a/SakuraRSS/Views/App.swift
+++ b/SakuraRSS/Views/App.swift
@@ -9,15 +9,20 @@ struct SakuraRSSApp: App {
     @State private var feedManager = FeedManager()
     @State private var pendingFeedURL: String?
     @State private var pendingArticleID: Int64?
+    @State private var isInSafeMode: Bool
     private let backgroundTaskID = "com.tsubuzaki.SakuraRSS.RefreshFeeds"
 
     var body: some Scene {
         WindowGroup {
-            MainTabView(pendingFeedURL: $pendingFeedURL, pendingArticleID: $pendingArticleID)
+            MainTabView(pendingFeedURL: $pendingFeedURL, pendingArticleID: $pendingArticleID,
+                        isInSafeMode: $isInSafeMode)
                 .environment(\.defaultMinListRowHeight, 10.0)
                 .environment(feedManager)
                 .task {
-                    await feedManager.refreshAllFeeds()
+                    if !isInSafeMode {
+                        await feedManager.refreshAllFeeds()
+                    }
+                    UserDefaults.standard.set(false, forKey: "App.StartupInProgress")
                     updateBadgeCount()
                 }
                 .onReceive(
@@ -57,6 +62,21 @@ struct SakuraRSSApp: App {
     }
 
     init() {
+        let defaults = UserDefaults.standard
+        let wasStartupInProgress = defaults.bool(forKey: "App.StartupInProgress")
+
+        if wasStartupInProgress {
+            _isInSafeMode = State(initialValue: true)
+            defaults.removeObject(forKey: "App.SelectedTab")
+            defaults.removeObject(forKey: "Home.FeedID")
+            defaults.removeObject(forKey: "Home.ArticleID")
+            defaults.removeObject(forKey: "FeedsList.FeedID")
+            defaults.removeObject(forKey: "FeedsList.ArticleID")
+        } else {
+            _isInSafeMode = State(initialValue: false)
+        }
+
+        defaults.set(true, forKey: "App.StartupInProgress")
         registerBackgroundTask()
         try? Tips.configure()
     }

--- a/SakuraRSS/Views/MainTabView.swift
+++ b/SakuraRSS/Views/MainTabView.swift
@@ -16,8 +16,10 @@ struct MainTabView: View {
     @AppStorage("Onboarding.Completed") private var onboardingCompleted: Bool = false
     @Binding var pendingFeedURL: String?
     @Binding var pendingArticleID: Int64?
+    @Binding var isInSafeMode: Bool
     @State private var showingAddFeed = false
     @State private var showingOnboarding = false
+    @State private var showingSafeModeAlert = false
 
     var body: some View {
         TabView(selection: $selectedTab) {
@@ -72,6 +74,16 @@ struct MainTabView: View {
             if !onboardingCompleted {
                 showingOnboarding = true
             }
+            if isInSafeMode {
+                showingSafeModeAlert = true
+            }
+        }
+        .alert(String(localized: "SafeMode.Title"), isPresented: $showingSafeModeAlert) {
+            Button(String(localized: "SafeMode.OK"), role: .cancel) {
+                isInSafeMode = false
+            }
+        } message: {
+            Text("SafeMode.Message")
         }
     }
 }

--- a/Shared/Localizable.xcstrings
+++ b/Shared/Localizable.xcstrings
@@ -5566,6 +5566,147 @@
         }
       }
     },
+    "SafeMode.Message": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die App wurde im abgesicherten Modus gestartet, da sie beim letzten Start unerwartet beendet wurde. Die Aktualisierung beim Start wurde übersprungen und gespeicherte Zustände wurden zurückgesetzt."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The app started in safe mode because it quit unexpectedly during the last launch. Refresh on startup was skipped and saved states were reset."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'application a démarré en mode sans échec car elle s'est fermée de manière inattendue lors du dernier lancement. L'actualisation au démarrage a été ignorée et les états sauvegardés ont été réinitialisés."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "前回の起動時に予期せず終了したため、セーフモードで起動しました。起動時の更新はスキップされ、保存された状態はリセットされました。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "지난 실행 중 예기치 않게 종료되어 안전 모드로 시작되었습니다. 시작 시 새로고침을 건너뛰고 저장된 상태를 초기화했습니다."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "由于上次启动时意外退出，应用已以安全模式启动。已跳过启动时刷新，并已重置保存的状态。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "由於上次啟動時意外結束，應用程式已以安全模式啟動。已跳過啟動時重新整理，並已重設儲存的狀態。"
+          }
+        }
+      }
+    },
+    "SafeMode.OK": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "확인"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "好"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "好"
+          }
+        }
+      }
+    },
+    "SafeMode.Title": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abgesicherter Modus"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Safe Mode"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mode sans échec"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "セーフモード"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "안전 모드"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "安全模式"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "安全模式"
+          }
+        }
+      }
+    },
     "Settings.AppleIntelligence.Footer": {
       "extractionState": "manual",
       "localizations": {


### PR DESCRIPTION
## Summary
Implements a safe mode feature that automatically activates when the app crashes during startup, helping users recover from crash loops by skipping refresh operations and resetting saved navigation state.

## Key Changes
- **Crash Detection**: Added startup progress tracking via `UserDefaults` to detect if the app crashed before completing initialization
- **Safe Mode State**: Introduced `isInSafeMode` state variable that propagates from `SakuraRSSApp` through `MainTabView`
- **State Reset**: When safe mode is triggered, clears saved navigation state (selected tab, feed IDs, article IDs) to prevent re-triggering the crash
- **Skip Refresh**: Prevents automatic feed refresh on startup when in safe mode to avoid potential crash-causing operations
- **User Alert**: Displays a localized alert dialog informing users that safe mode was activated and what actions were taken
- **Localization**: Added complete translations for safe mode UI strings (title, message, OK button) across 7 languages: English, German, French, Japanese, Korean, Simplified Chinese, and Traditional Chinese

## Implementation Details
- Safe mode detection occurs in `SakuraRSSApp.init()` by checking if the previous startup was marked as in-progress
- The app marks startup as in-progress at initialization and clears this flag only after the initial task completes successfully
- Navigation state keys are explicitly cleared to ensure a clean slate when recovering from crashes
- The safe mode alert is shown on first appearance of `MainTabView` and can be dismissed by the user

https://claude.ai/code/session_01GTNHTjdh7VDPofMTQM3qQ3