### PR TITLE
Refactor badge count update logic into FeedManager

### DIFF
--- a/SakuraRSS/Classes/FeedManager.swift
+++ b/SakuraRSS/Classes/FeedManager.swift
@@ -1,5 +1,6 @@
 import Foundation
 import SwiftUI
+@preconcurrency import UserNotifications
 
 @Observable
 final class FeedManager {
@@ -152,11 +153,13 @@ final class FeedManager {
     func markRead(_ article: Article) {
         try? database.markArticleRead(id: article.id, read: true)
         loadFromDatabase()
+        updateBadgeCount()
     }
 
     func toggleRead(_ article: Article) {
         try? database.markArticleRead(id: article.id, read: !article.isRead)
         loadFromDatabase()
+        updateBadgeCount()
     }
 
     func toggleBookmark(_ article: Article) {
@@ -167,11 +170,13 @@ final class FeedManager {
     func markAllRead(feed: Feed) {
         try? database.markAllRead(feedID: feed.id)
         loadFromDatabase()
+        updateBadgeCount()
     }
 
     func markAllRead() {
         try? database.markAllRead()
         loadFromDatabase()
+        updateBadgeCount()
     }
 
     func unreadCount(for feed: Feed) -> Int {
@@ -182,6 +187,21 @@ final class FeedManager {
     func totalUnreadCount() -> Int {
         _ = dataRevision
         return (try? database.totalUnreadCount()) ?? 0
+    }
+
+    func updateBadgeCount() {
+        let badgeEnabled = UserDefaults.standard.bool(forKey: "BackgroundRefresh.BadgeEnabled")
+        let center = UNUserNotificationCenter.current()
+        guard badgeEnabled else {
+            Task { try? await center.setBadgeCount(0) }
+            return
+        }
+        Task {
+            let settings = await center.notificationSettings()
+            guard settings.badgeSetting == .enabled else { return }
+            let count = self.totalUnreadCount()
+            try? await center.setBadgeCount(count)
+        }
     }
 
     func feed(forArticle article: Article) -> Feed? {

--- a/SakuraRSS/Views/App.swift
+++ b/SakuraRSS/Views/App.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 import BackgroundTasks
 import TipKit
-@preconcurrency import UserNotifications
 
 @main
 struct SakuraRSSApp: App {
@@ -23,13 +22,13 @@ struct SakuraRSSApp: App {
                         await feedManager.refreshAllFeeds()
                     }
                     UserDefaults.standard.set(false, forKey: "App.StartupInProgress")
-                    updateBadgeCount()
+                    feedManager.updateBadgeCount()
                 }
                 .onReceive(
                     NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)
                 ) { _ in
                     feedManager.loadFromDatabase()
-                    updateBadgeCount()
+                    feedManager.updateBadgeCount()
                 }
                 .onOpenURL { url in
                     handleOpenURL(url)
@@ -111,7 +110,7 @@ struct SakuraRSSApp: App {
         let refreshTask = Task {
             let manager = FeedManager()
             await manager.refreshAllFeeds()
-            updateBadgeCount()
+            manager.updateBadgeCount()
         }
 
         task.expirationHandler = {
@@ -124,18 +123,4 @@ struct SakuraRSSApp: App {
         }
     }
 
-    private func updateBadgeCount() {
-        let badgeEnabled = UserDefaults.standard.bool(forKey: "BackgroundRefresh.BadgeEnabled")
-        let center = UNUserNotificationCenter.current()
-        guard badgeEnabled else {
-            Task { try? await center.setBadgeCount(0) }
-            return
-        }
-        Task {
-            let settings = await center.notificationSettings()
-            guard settings.badgeSetting == .enabled else { return }
-            let count = feedManager.totalUnreadCount()
-            try? await center.setBadgeCount(count)
-        }
-    }
 }


### PR DESCRIPTION
## Summary
Moved the `updateBadgeCount()` method from `SakuraRSSApp` to `FeedManager` to centralize badge management logic and ensure the badge count is updated whenever the read status of articles changes.

## Key Changes
- Moved `updateBadgeCount()` method from `SakuraRSSApp` to `FeedManager` class
- Moved `@preconcurrency import UserNotifications` from `App.swift` to `FeedManager.swift` where it's actually used
- Updated all `updateBadgeCount()` calls to use `feedManager.updateBadgeCount()` or `manager.updateBadgeCount()` depending on context
- Added `updateBadgeCount()` calls to the following methods in `FeedManager`:
  - `markRead(_:)`
  - `toggleRead(_:)`
  - `markAllRead(feed:)`
  - `markAllRead()`

## Implementation Details
This refactoring improves the architecture by:
- Keeping badge-related logic within the `FeedManager` class that manages feed data
- Ensuring the badge count is automatically updated whenever article read status changes, not just at app startup/foreground
- Removing unnecessary imports from the app delegate
- Making the code more maintainable by centralizing notification center interactions

https://claude.ai/code/session_01Lccb15fj8JgVhmNCvsTv4N