### PR TITLE
Add social media feed detection for Bluesky and Mastodon

### DIFF
--- a/Add Feed/ActionViewController.swift
+++ b/Add Feed/ActionViewController.swift
@@ -165,6 +165,15 @@ struct ActionExtensionView: View {
 
         model.status = .searchingDomain(host)
 
+        // Try page URL discovery first (handles social media profiles and page-level feeds)
+        let pageFeeds = await FeedDiscovery.shared.discoverFeeds(fromPageURL: url)
+        if !pageFeeds.isEmpty {
+            model.discoveredFeeds = pageFeeds
+            model.status = .found(pageFeeds.count)
+            return
+        }
+
+        // Fall back to domain-level discovery
         let feeds = await FeedDiscovery.shared.discoverFeeds(forDomain: host)
 
         if feeds.isEmpty {

--- a/Shared/Domain Options/FeedViewDomains.swift
+++ b/Shared/Domain Options/FeedViewDomains.swift
@@ -10,7 +10,20 @@ nonisolated enum FeedViewDomains {
         "status.cloud.google.com",
         "www.githubstatus.com",
         "status.gitlab.com",
-        "status.claude.com"
+        "status.claude.com",
+        // Bluesky
+        "bsky.app",
+        // Mastodon
+        "mastodon.social",
+        "mastodon.online",
+        "mastodon.world",
+        "mstdn.social",
+        "mstdn.jp",
+        "fosstodon.org",
+        "hachyderm.io",
+        "infosec.exchange",
+        "techhub.social",
+        "mas.to"
     ]
 
     static func shouldPreferFeedView(feedDomain: String) -> Bool {

--- a/Shared/FeedDiscovery.swift
+++ b/Shared/FeedDiscovery.swift
@@ -56,6 +56,11 @@ actor FeedDiscovery {
     }
 
     func discoverFeeds(fromPageURL pageURL: URL) async -> [DiscoveredFeed] {
+        // Check for social media profile URLs first (fast path)
+        if let socialFeed = await detectSocialMediaFeed(url: pageURL) {
+            return [socialFeed]
+        }
+
         let feeds = await discoverFromHTML(url: pageURL)
         if !feeds.isEmpty { return feeds }
 
@@ -240,5 +245,51 @@ actor FeedDiscovery {
         }
 
         return nil
+    }
+
+    // MARK: - Social Media Feed Detection
+
+    /// Detects Bluesky and Mastodon profile URLs and constructs their RSS feed URLs.
+    private func detectSocialMediaFeed(url: URL) async -> DiscoveredFeed? {
+        if let blueskyFeed = await detectBlueskyFeed(url: url) {
+            return blueskyFeed
+        }
+        if let mastodonFeed = await detectMastodonFeed(url: url) {
+            return mastodonFeed
+        }
+        return nil
+    }
+
+    /// Detects Bluesky profile URLs and constructs the RSS feed URL.
+    /// Format: bsky.app/profile/<handle> → bsky.app/profile/<handle>/rss
+    private func detectBlueskyFeed(url: URL) async -> DiscoveredFeed? {
+        guard let host = url.host?.lowercased(),
+              host == "bsky.app" || host.hasSuffix(".bsky.app") else {
+            return nil
+        }
+
+        let path = url.path
+        guard path.hasPrefix("/profile/") else { return nil }
+
+        let afterProfile = String(path.dropFirst("/profile/".count))
+        guard let handle = afterProfile.split(separator: "/").first,
+              !handle.isEmpty else { return nil }
+
+        return await probeFeedAt(domain: "bsky.app", path: "/profile/\(handle)/rss")
+    }
+
+    /// Detects Mastodon profile URLs and constructs the RSS feed URL.
+    /// Format: <instance>/@<username> → <instance>/@<username>.rss
+    private func detectMastodonFeed(url: URL) async -> DiscoveredFeed? {
+        guard let host = url.host?.lowercased() else { return nil }
+
+        let path = url.path
+        guard path.hasPrefix("/@") else { return nil }
+
+        let afterAt = String(path.dropFirst(2))
+        guard let username = afterAt.split(separator: "/").first,
+              !username.isEmpty else { return nil }
+
+        return await probeFeedAt(domain: host, path: "/@\(username).rss")
     }
 }

--- a/Shared/Models.swift
+++ b/Shared/Models.swift
@@ -20,7 +20,14 @@ nonisolated struct Feed: Identifiable, Hashable, Sendable {
     }
 
     var isFeedViewDomain: Bool {
-        FeedViewDomains.shouldPreferFeedView(feedDomain: domain)
+        FeedViewDomains.shouldPreferFeedView(feedDomain: domain) || hasMastodonFeedURL
+    }
+
+    /// Detects Mastodon feeds from unlisted instances by checking for the /@username.rss URL pattern.
+    private var hasMastodonFeedURL: Bool {
+        guard let urlObj = URL(string: url) else { return false }
+        let path = urlObj.path
+        return path.hasPrefix("/@") && path.hasSuffix(".rss")
     }
 }
 


### PR DESCRIPTION
## Summary
This PR adds automatic feed discovery for Bluesky and Mastodon social media profiles, allowing users to subscribe to RSS feeds from these platforms directly through the feed discovery mechanism.

## Key Changes

- **Social Media Feed Detection**: Added `detectSocialMediaFeed()` method that checks for Bluesky and Mastodon profile URLs before attempting HTML-based feed discovery, providing a fast path for these platforms
  
- **Bluesky Support**: Implemented `detectBlueskyFeed()` to recognize `bsky.app/profile/<handle>` URLs and construct the corresponding RSS feed URL at `/profile/<handle>/rss`

- **Mastodon Support**: Implemented `detectMastodonFeed()` to recognize Mastodon instance profile URLs in the format `/@<username>` and construct RSS feed URLs at `/@<username>.rss`

- **Domain Allowlist**: Updated `FeedViewDomains` to include Bluesky and popular Mastodon instances (mastodon.social, fosstodon.org, hachyderm.io, etc.) to ensure feeds from these sources are displayed in feed view

- **Discovery Priority**: Modified the action extension to attempt page URL discovery first (which now includes social media profile detection) before falling back to domain-level discovery

- **Mastodon Feed Detection**: Added `hasMastodonFeedURL` property to the `Feed` model to identify Mastodon feeds by their URL pattern (`/@username.rss`), ensuring they're treated as feed view domains even from unlisted instances

## Implementation Details

- Social media detection uses URL host and path pattern matching to identify profiles
- The detection methods use the existing `probeFeedAt()` mechanism to verify feed availability
- Mastodon support is flexible and works with any Mastodon instance, not just whitelisted ones, through URL pattern detection

https://claude.ai/code/session_01HJHVetwoPogWRkNmCKyFVA