### PR TITLE
Add feed management features: rules, editing, and open modes

### DIFF
--- a/SakuraRSS/Actors/FaviconCache.swift
+++ b/SakuraRSS/Actors/FaviconCache.swift
@@ -63,6 +63,36 @@ actor FaviconCache {
         try? FileManager.default.createDirectory(at: cacheDirectory, withIntermediateDirectories: true)
     }
 
+    func setCustomFavicon(_ image: UIImage, feedID: Int64) {
+        let key = "custom-feed-\(feedID)"
+        memoryCache[key] = image
+        let filePath = cacheDirectory.appendingPathComponent(sanitizedFileName(key))
+        if let pngData = image.pngData() {
+            try? pngData.write(to: filePath)
+        }
+    }
+
+    func customFavicon(feedID: Int64) -> UIImage? {
+        let key = "custom-feed-\(feedID)"
+        if let cached = memoryCache[key] {
+            return cached
+        }
+        let filePath = cacheDirectory.appendingPathComponent(sanitizedFileName(key))
+        if let data = try? Data(contentsOf: filePath),
+           let image = UIImage(data: data) {
+            memoryCache[key] = image
+            return image
+        }
+        return nil
+    }
+
+    func removeCustomFavicon(feedID: Int64) {
+        let key = "custom-feed-\(feedID)"
+        memoryCache[key] = nil
+        let filePath = cacheDirectory.appendingPathComponent(sanitizedFileName(key))
+        try? FileManager.default.removeItem(at: filePath)
+    }
+
     private func trimAndCache(_ image: UIImage, cacheKey: String, filePath: URL) async -> UIImage {
         let trimmed = await image.trimmed()
         if let pngData = trimmed.pngData() {

--- a/SakuraRSS/Classes/FeedManager.swift
+++ b/SakuraRSS/Classes/FeedManager.swift
@@ -42,6 +42,18 @@ final class FeedManager {
         loadFromDatabase()
     }
 
+    func toggleMuted(_ feed: Feed) {
+        try? database.updateFeedMuted(id: feed.id, isMuted: !feed.isMuted)
+        loadFromDatabase()
+    }
+
+    func updateFeedDetails(_ feed: Feed, title: String, url: String,
+                           customIconURL: String?) {
+        try? database.updateFeedDetails(id: feed.id, title: title, url: url,
+                                        customIconURL: customIconURL)
+        loadFromDatabase()
+    }
+
     func refreshFeed(_ feed: Feed) async throws {
         guard let url = URL(string: feed.url) else { return }
 
@@ -112,7 +124,12 @@ final class FeedManager {
     func todayArticles() -> [Article] {
         _ = dataRevision
         let startOfToday = Calendar.current.startOfDay(for: Date())
-        return (try? database.allArticles(since: startOfToday)) ?? []
+        var all = (try? database.allArticles(since: startOfToday)) ?? []
+        let muted = mutedFeedIDs
+        if !muted.isEmpty {
+            all = all.filter { !muted.contains($0.feedID) }
+        }
+        return applyAllRules(all)
     }
 
     func overnightArticles() -> [Article] {
@@ -133,7 +150,7 @@ final class FeedManager {
 
     private func filterExcludingPodcastsAndVideos(_ articles: [Article]) -> [Article] {
         let excludedFeedIDs = Set(feeds.filter { feed in
-            feed.isPodcast || VideoDomains.shouldPreferVideo(feedDomain: feed.domain)
+            feed.isMuted || feed.isPodcast || VideoDomains.shouldPreferVideo(feedDomain: feed.domain)
         }.map(\.id))
         return articles.filter { !excludedFeedIDs.contains($0.feedID) }
     }
@@ -141,12 +158,18 @@ final class FeedManager {
     func olderArticles(limit: Int = 200) -> [Article] {
         _ = dataRevision
         let startOfToday = Calendar.current.startOfDay(for: Date())
-        return (try? database.allArticles(before: startOfToday, limit: limit)) ?? []
+        var all = (try? database.allArticles(before: startOfToday, limit: limit)) ?? []
+        let muted = mutedFeedIDs
+        if !muted.isEmpty {
+            all = all.filter { !muted.contains($0.feedID) }
+        }
+        return applyAllRules(all)
     }
 
     func articles(for feed: Feed) -> [Article] {
         _ = dataRevision
-        return (try? database.articles(forFeedID: feed.id)) ?? []
+        let all = (try? database.articles(forFeedID: feed.id)) ?? []
+        return applyRules(all, feedID: feed.id)
     }
 
     func markRead(_ article: Article) {
@@ -181,7 +204,74 @@ final class FeedManager {
 
     func totalUnreadCount() -> Int {
         _ = dataRevision
-        return (try? database.totalUnreadCount()) ?? 0
+        let mutedFeedIDs = Set(feeds.filter(\.isMuted).map(\.id))
+        if mutedFeedIDs.isEmpty {
+            return (try? database.totalUnreadCount()) ?? 0
+        }
+        return feeds.filter { !$0.isMuted }.reduce(0) { total, feed in
+            total + ((try? database.unreadCount(forFeedID: feed.id)) ?? 0)
+        }
+    }
+
+    private var mutedFeedIDs: Set<Int64> {
+        Set(feeds.filter(\.isMuted).map(\.id))
+    }
+
+    private func applyRules(_ articles: [Article], feedID: Int64) -> [Article] {
+        let keywords = (try? database.rules(forFeedID: feedID, type: "muted_keyword")) ?? []
+        let authors = Set((try? database.rules(forFeedID: feedID, type: "muted_author")) ?? [])
+        guard !keywords.isEmpty || !authors.isEmpty else { return articles }
+        return articles.filter { article in
+            if let author = article.author, authors.contains(author) {
+                return false
+            }
+            for keyword in keywords {
+                if article.title.localizedCaseInsensitiveContains(keyword) {
+                    return false
+                }
+                if let summary = article.summary,
+                   summary.localizedCaseInsensitiveContains(keyword) {
+                    return false
+                }
+            }
+            return true
+        }
+    }
+
+    private func applyAllRules(_ articles: [Article]) -> [Article] {
+        var rulesByFeed: [Int64: (keywords: [String], authors: Set<String>)] = [:]
+        var result: [Article] = []
+        for article in articles {
+            if rulesByFeed[article.feedID] == nil {
+                let keywords = (try? database.rules(forFeedID: article.feedID, type: "muted_keyword")) ?? []
+                let authors = Set((try? database.rules(forFeedID: article.feedID, type: "muted_author")) ?? [])
+                rulesByFeed[article.feedID] = (keywords, authors)
+            }
+            let rules = rulesByFeed[article.feedID]!
+            guard !rules.keywords.isEmpty || !rules.authors.isEmpty else {
+                result.append(article)
+                continue
+            }
+            if let author = article.author, rules.authors.contains(author) {
+                continue
+            }
+            var matched = false
+            for keyword in rules.keywords {
+                if article.title.localizedCaseInsensitiveContains(keyword) {
+                    matched = true
+                    break
+                }
+                if let summary = article.summary,
+                   summary.localizedCaseInsensitiveContains(keyword) {
+                    matched = true
+                    break
+                }
+            }
+            if !matched {
+                result.append(article)
+            }
+        }
+        return result
     }
 
     func feed(forArticle article: Article) -> Feed? {
@@ -190,6 +280,36 @@ final class FeedManager {
 
     func article(byID id: Int64) -> Article? {
         articles.first { $0.id == id } ?? (try? database.article(byID: id))
+    }
+
+    // MARK: - Feed Rules
+
+    func mutedKeywords(for feed: Feed) -> [String] {
+        (try? database.rules(forFeedID: feed.id, type: "muted_keyword")) ?? []
+    }
+
+    func mutedAuthors(for feed: Feed) -> [String] {
+        (try? database.rules(forFeedID: feed.id, type: "muted_author")) ?? []
+    }
+
+    func saveMutedKeywords(_ keywords: [String], for feed: Feed) {
+        try? database.replaceRules(feedID: feed.id, type: "muted_keyword", values: keywords)
+    }
+
+    func saveMutedAuthors(_ authors: [String], for feed: Feed) {
+        try? database.replaceRules(feedID: feed.id, type: "muted_author", values: authors)
+    }
+
+    func uniqueAuthors(for feed: Feed) -> [String] {
+        let allArticles = (try? database.articles(forFeedID: feed.id)) ?? []
+        var seen = Set<String>()
+        var result: [String] = []
+        for article in allArticles {
+            if let author = article.author, !author.isEmpty, seen.insert(author).inserted {
+                result.append(author)
+            }
+        }
+        return result
     }
 
     // MARK: - OPML Export

--- a/SakuraRSS/Views/Feeds/FeedEditSheet.swift
+++ b/SakuraRSS/Views/Feeds/FeedEditSheet.swift
@@ -1,0 +1,144 @@
+import PhotosUI
+import SwiftUI
+
+struct FeedEditSheet: View {
+
+    @Environment(FeedManager.self) var feedManager
+    @Environment(\.dismiss) var dismiss
+
+    let feed: Feed
+
+    @State private var name: String
+    @State private var url: String
+    @State private var iconURLInput: String
+    @State private var openMode: FeedOpenMode
+    @State private var selectedPhoto: PhotosPickerItem?
+    @State private var customIconImage: UIImage?
+
+    init(feed: Feed) {
+        self.feed = feed
+        _name = State(initialValue: feed.title)
+        _url = State(initialValue: feed.url)
+        let existingIconURL = feed.customIconURL
+        _iconURLInput = State(initialValue: existingIconURL == "photo" ? "" : (existingIconURL ?? ""))
+        let raw = UserDefaults.standard.string(forKey: "openMode-\(feed.id)")
+        _openMode = State(initialValue: raw.flatMap(FeedOpenMode.init(rawValue:)) ?? .inAppViewer)
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    HStack {
+                        Text("FeedEdit.Name")
+                        Spacer()
+                        TextField(String(localized: "FeedEdit.Name"), text: $name)
+                            .multilineTextAlignment(.trailing)
+                            .labelsHidden()
+                    }
+                    HStack {
+                        Text("FeedEdit.URL")
+                        Spacer()
+                        TextField(String(localized: "FeedEdit.URL"), text: $url)
+                            .multilineTextAlignment(.trailing)
+                            .textContentType(.URL)
+                            .autocorrectionDisabled()
+                            .textInputAutocapitalization(.never)
+                            .labelsHidden()
+                    }
+                }
+
+                Section {
+                    HStack {
+                        Text("FeedEdit.IconURL")
+                        Spacer()
+                        TextField(String(localized: "FeedEdit.IconURLPlaceholder"), text: $iconURLInput)
+                            .multilineTextAlignment(.trailing)
+                            .textContentType(.URL)
+                            .autocorrectionDisabled()
+                            .textInputAutocapitalization(.never)
+                            .labelsHidden()
+                    }
+
+                    PhotosPicker(selection: $selectedPhoto, matching: .images) {
+                        HStack {
+                            Text("FeedEdit.ChooseFromPhotos")
+                            Spacer()
+                            if customIconImage != nil {
+                                Image(systemName: "checkmark.circle.fill")
+                                    .foregroundStyle(.green)
+                            }
+                        }
+                    }
+                } header: {
+                    Text("FeedEdit.Icon")
+                }
+
+                Section {
+                    Picker(String(localized: "FeedEdit.OpenIn"), selection: $openMode) {
+                        Text("FeedEdit.OpenIn.InAppViewer")
+                            .tag(FeedOpenMode.inAppViewer)
+                        Text("FeedEdit.OpenIn.InAppBrowser")
+                            .tag(FeedOpenMode.inAppBrowser)
+                        Text("FeedEdit.OpenIn.Browser")
+                            .tag(FeedOpenMode.browser)
+                    }
+                } header: {
+                    Text("FeedEdit.OpenFeedsIn")
+                }
+            }
+            .navigationTitle(String(localized: "FeedEdit.Title"))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button(role: .cancel) {
+                        dismiss()
+                    }
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button(role: .confirm) {
+                        save()
+                    }
+                    .disabled(name.isEmpty || url.isEmpty)
+                }
+            }
+            .onChange(of: selectedPhoto) {
+                Task {
+                    if let selectedPhoto,
+                       let data = try? await selectedPhoto.loadTransferable(type: Data.self),
+                       let image = UIImage(data: data) {
+                        customIconImage = image
+                        iconURLInput = ""
+                    }
+                }
+            }
+        }
+    }
+
+    private func save() {
+        let finalCustomIconURL: String?
+
+        if customIconImage != nil {
+            finalCustomIconURL = "photo"
+        } else if !iconURLInput.isEmpty {
+            finalCustomIconURL = iconURLInput
+        } else {
+            finalCustomIconURL = nil
+        }
+
+        if let customIconImage {
+            Task {
+                await FaviconCache.shared.setCustomFavicon(customIconImage, feedID: feed.id)
+            }
+        } else if finalCustomIconURL == nil && feed.customIconURL != nil {
+            Task {
+                await FaviconCache.shared.removeCustomFavicon(feedID: feed.id)
+            }
+        }
+
+        feedManager.updateFeedDetails(feed, title: name, url: url,
+                                      customIconURL: finalCustomIconURL)
+        UserDefaults.standard.set(openMode.rawValue, forKey: "openMode-\(feed.id)")
+        dismiss()
+    }
+}

--- a/SakuraRSS/Views/Feeds/FeedRulesSheet.swift
+++ b/SakuraRSS/Views/Feeds/FeedRulesSheet.swift
@@ -1,0 +1,146 @@
+import SwiftUI
+
+struct FeedRulesSheet: View {
+
+    @Environment(FeedManager.self) var feedManager
+    @Environment(\.dismiss) var dismiss
+
+    let feed: Feed
+
+    @State private var mutedKeywords: [String]
+    @State private var mutedAuthors: [String]
+    @State private var keywordInput: String = ""
+    @State private var authorInput: String = ""
+    @State private var availableAuthors: [String] = []
+    @FocusState private var isKeywordFieldFocused: Bool
+    @FocusState private var isAuthorFieldFocused: Bool
+
+    init(feed: Feed) {
+        self.feed = feed
+        _mutedKeywords = State(initialValue: [])
+        _mutedAuthors = State(initialValue: [])
+    }
+
+    var suggestedAuthors: [String] {
+        let existing = Set(mutedAuthors)
+        return availableAuthors
+            .filter { !existing.contains($0) }
+            .prefix(8)
+            .map { $0 }
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    HStack {
+                        TextField(String(localized: "FeedRules.KeywordPlaceholder"),
+                                  text: $keywordInput)
+                            .focused($isKeywordFieldFocused)
+                            .onSubmit { addKeyword() }
+                        Button(String(localized: "FeedRules.Add")) {
+                            addKeyword()
+                        }
+                        .disabled(keywordInput.trimmingCharacters(in: .whitespaces).isEmpty)
+                    }
+
+                    ForEach(mutedKeywords, id: \.self) { keyword in
+                        Text(keyword)
+                    }
+                    .onDelete { indexSet in
+                        mutedKeywords.remove(atOffsets: indexSet)
+                    }
+                } header: {
+                    Text("FeedRules.MutedKeywords")
+                } footer: {
+                    Text("FeedRules.MutedKeywords.Footer")
+                }
+
+                Section {
+                    HStack {
+                        TextField(String(localized: "FeedRules.AuthorPlaceholder"),
+                                  text: $authorInput)
+                            .focused($isAuthorFieldFocused)
+                            .onSubmit { addAuthor() }
+                        Button(String(localized: "FeedRules.Add")) {
+                            addAuthor()
+                        }
+                        .disabled(authorInput.trimmingCharacters(in: .whitespaces).isEmpty)
+                    }
+
+                    if !suggestedAuthors.isEmpty {
+                        ScrollView(.horizontal, showsIndicators: false) {
+                            HStack(spacing: 8) {
+                                ForEach(suggestedAuthors, id: \.self) { author in
+                                    Button {
+                                        mutedAuthors.append(author)
+                                    } label: {
+                                        Text(author)
+                                            .font(.subheadline)
+                                            .lineLimit(1)
+                                    }
+                                    .buttonStyle(.bordered)
+                                    .buttonBorderShape(.capsule)
+                                    .controlSize(.small)
+                                }
+                            }
+                            .padding(.vertical, 4)
+                        }
+                    }
+
+                    ForEach(mutedAuthors, id: \.self) { author in
+                        Text(author)
+                    }
+                    .onDelete { indexSet in
+                        mutedAuthors.remove(atOffsets: indexSet)
+                    }
+                } header: {
+                    Text("FeedRules.MutedAuthors")
+                } footer: {
+                    Text("FeedRules.MutedAuthors.Footer")
+                }
+            }
+            .navigationTitle(String(localized: "FeedRules.Title"))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button(role: .cancel) {
+                        dismiss()
+                    }
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button(role: .confirm) {
+                        save()
+                    }
+                }
+            }
+            .onAppear {
+                mutedKeywords = feedManager.mutedKeywords(for: feed)
+                mutedAuthors = feedManager.mutedAuthors(for: feed)
+                availableAuthors = feedManager.uniqueAuthors(for: feed)
+            }
+        }
+    }
+
+    private func addKeyword() {
+        let trimmed = keywordInput.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty, !mutedKeywords.contains(trimmed) else { return }
+        mutedKeywords.append(trimmed)
+        keywordInput = ""
+        isKeywordFieldFocused = true
+    }
+
+    private func addAuthor() {
+        let trimmed = authorInput.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty, !mutedAuthors.contains(trimmed) else { return }
+        mutedAuthors.append(trimmed)
+        authorInput = ""
+        isAuthorFieldFocused = true
+    }
+
+    private func save() {
+        feedManager.saveMutedKeywords(mutedKeywords, for: feed)
+        feedManager.saveMutedAuthors(mutedAuthors, for: feed)
+        dismiss()
+    }
+}

--- a/SakuraRSS/Views/Feeds/FeedsListPage.swift
+++ b/SakuraRSS/Views/Feeds/FeedsListPage.swift
@@ -7,6 +7,9 @@ struct FeedsListPage: View {
     @State private var isShowingAddFeed = false
     @State private var searchText = ""
     @State private var lastAddedFeedURL: String?
+    @State private var feedToEdit: Feed?
+    @State private var feedToDelete: Feed?
+    @State private var feedForRules: Feed?
 
     var filteredFeeds: [Feed] {
         if searchText.isEmpty {
@@ -26,6 +29,38 @@ struct FeedsListPage: View {
                         FeedRowView(feed: feed)
                     }
                     .listRowBackground(Color.clear)
+                    .contextMenu {
+                        Button {
+                            feedManager.toggleMuted(feed)
+                        } label: {
+                            Label(
+                                feed.isMuted
+                                    ? String(localized: "FeedMenu.Unmute")
+                                    : String(localized: "FeedMenu.Mute"),
+                                systemImage: feed.isMuted
+                                    ? "bell" : "bell.slash"
+                            )
+                        }
+                        Button {
+                            feedForRules = feed
+                        } label: {
+                            Label(String(localized: "FeedMenu.Rules"),
+                                  systemImage: "list.bullet.rectangle")
+                        }
+                        Divider()
+                        Button {
+                            feedToEdit = feed
+                        } label: {
+                            Label(String(localized: "FeedMenu.Edit"),
+                                  systemImage: "pencil")
+                        }
+                        Button(role: .destructive) {
+                            feedToDelete = feed
+                        } label: {
+                            Label(String(localized: "FeedMenu.Delete"),
+                                  systemImage: "trash")
+                        }
+                    }
                 }
                 .onDelete { indexSet in
                     for index in indexSet {
@@ -85,6 +120,36 @@ struct FeedsListPage: View {
                 }
             }
         }
+        .sheet(item: $feedToEdit) { feed in
+            FeedEditSheet(feed: feed)
+                .environment(feedManager)
+        }
+        .sheet(item: $feedForRules) { feed in
+            FeedRulesSheet(feed: feed)
+                .environment(feedManager)
+        }
+        .confirmationDialog(
+            String(localized: "FeedMenu.Delete.Title"),
+            isPresented: Binding(
+                get: { feedToDelete != nil },
+                set: { if !$0 { feedToDelete = nil } }
+            ),
+            titleVisibility: .visible
+        ) {
+            Button(String(localized: "FeedMenu.Delete.Confirm"), role: .destructive) {
+                if let feed = feedToDelete {
+                    try? feedManager.deleteFeed(feed)
+                    feedToDelete = nil
+                }
+            }
+            Button(String(localized: "Shared.Cancel"), role: .cancel) {
+                feedToDelete = nil
+            }
+        } message: {
+            if let feed = feedToDelete {
+                Text("FeedMenu.Delete.Message.\(feed.title)")
+            }
+        }
     }
 }
 
@@ -116,6 +181,11 @@ struct FeedRowView: View {
                     Text(feed.title)
                         .font(.body)
                         .lineLimit(1)
+                    if feed.isMuted {
+                        Image(systemName: "bell.slash.fill")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
                     if feed.isPodcast {
                         Image(systemName: "headphones")
                             .font(.caption)
@@ -147,12 +217,31 @@ struct FeedRowView: View {
             }
         }
         .task {
-            favicon = await FaviconCache.shared.favicon(for: feed.domain, siteURL: feed.siteURL)
+            favicon = await loadFavicon()
         }
         .onChange(of: feedManager.faviconRevision) {
             Task {
-                favicon = await FaviconCache.shared.favicon(for: feed.domain, siteURL: feed.siteURL)
+                favicon = await loadFavicon()
             }
         }
+        .onChange(of: feedManager.dataRevision) {
+            Task {
+                favicon = await loadFavicon()
+            }
+        }
+    }
+
+    private func loadFavicon() async -> UIImage? {
+        if let customURL = feed.customIconURL {
+            if customURL == "photo" {
+                return await FaviconCache.shared.customFavicon(feedID: feed.id)
+            }
+            if let url = URL(string: customURL),
+               let (data, _) = try? await URLSession.shared.data(from: url),
+               let image = UIImage(data: data) {
+                return image
+            }
+        }
+        return await FaviconCache.shared.favicon(for: feed.domain, siteURL: feed.siteURL)
     }
 }

--- a/SakuraRSS/Views/Shared/ArticleLink.swift
+++ b/SakuraRSS/Views/Shared/ArticleLink.swift
@@ -5,10 +5,20 @@ import SwiftUI
 struct ArticleLink<Label: View>: View {
 
     @Environment(FeedManager.self) var feedManager
+    @Environment(\.openURL) var openURL
     let article: Article
     @ViewBuilder let label: () -> Label
 
     @State private var showSafari = false
+
+    private var feedOpenMode: FeedOpenMode {
+        guard let feed = feedManager.feed(forArticle: article),
+              let raw = UserDefaults.standard.string(forKey: "openMode-\(feed.id)"),
+              let mode = FeedOpenMode(rawValue: raw) else {
+            return .inAppViewer
+        }
+        return mode
+    }
 
     var body: some View {
         if article.isPodcastEpisode {
@@ -21,6 +31,27 @@ struct ArticleLink<Label: View>: View {
                 YouTubeHelper.openInApp(url: article.url)
             } label: {
                 label()
+            }
+        } else if feedOpenMode == .browser {
+            Button {
+                feedManager.markRead(article)
+                if let url = URL(string: article.url) {
+                    openURL(url)
+                }
+            } label: {
+                label()
+            }
+        } else if feedOpenMode == .inAppBrowser,
+                  let url = URL(string: article.url) {
+            Button {
+                feedManager.markRead(article)
+                showSafari = true
+            } label: {
+                label()
+            }
+            .sheet(isPresented: $showSafari) {
+                SafariView(url: url)
+                    .ignoresSafeArea()
             }
         } else if let url = URL(string: article.url), SafariDomains.shouldOpenInSafari(url: url) {
             Button {

--- a/Shared/DatabaseManager/DatabaseManager+Feeds.swift
+++ b/Shared/DatabaseManager/DatabaseManager+Feeds.swift
@@ -52,12 +52,28 @@ nonisolated extension DatabaseManager {
         ))
     }
 
+    func updateFeedMuted(id: Int64, isMuted: Bool) throws {
+        let target = feeds.filter(feedID == id)
+        try database.run(target.update(feedIsMuted <- isMuted))
+    }
+
+    func updateFeedDetails(id: Int64, title: String, url: String,
+                           customIconURL: String?) throws {
+        let target = feeds.filter(feedID == id)
+        try database.run(target.update(
+            feedTitle <- title,
+            feedURL <- url,
+            feedCustomIconURL <- customIconURL
+        ))
+    }
+
     func feedExists(url: String) -> Bool {
         (try? database.pluck(feeds.filter(feedURL == url))) != nil
     }
 
     func deleteFeed(id: Int64) throws {
         try database.run(articles.filter(articleFeedID == id).delete())
+        try database.run(feedRules.filter(ruleFeedID == id).delete())
         try database.run(feeds.filter(feedID == id).delete())
     }
 
@@ -73,7 +89,9 @@ nonisolated extension DatabaseManager {
             faviconURL: row[feedFaviconURL],
             lastFetched: row[feedLastFetched].map { Date(timeIntervalSince1970: $0) },
             category: row[feedCategory],
-            isPodcast: (try? row.get(feedIsPodcast)) ?? false
+            isPodcast: (try? row.get(feedIsPodcast)) ?? false,
+            isMuted: (try? row.get(feedIsMuted)) ?? false,
+            customIconURL: try? row.get(feedCustomIconURL)
         )
     }
 }

--- a/Shared/DatabaseManager/DatabaseManager+Rules.swift
+++ b/Shared/DatabaseManager/DatabaseManager+Rules.swift
@@ -1,0 +1,47 @@
+import Foundation
+@preconcurrency import SQLite
+
+nonisolated extension DatabaseManager {
+
+    // MARK: - Feed Rules CRUD
+
+    func rules(forFeedID feedID: Int64, type: String) throws -> [String] {
+        try database.prepare(
+            feedRules
+                .filter(ruleFeedID == feedID && ruleType == type)
+                .order(ruleValue.asc)
+        ).map { $0[ruleValue] }
+    }
+
+    @discardableResult
+    func insertRule(feedID: Int64, type: String, value: String) throws -> Int64 {
+        try database.run(feedRules.insert(
+            ruleFeedID <- feedID,
+            ruleType <- type,
+            ruleValue <- value
+        ))
+    }
+
+    func deleteRule(feedID: Int64, type: String, value: String) throws {
+        let target = feedRules.filter(
+            ruleFeedID == feedID && ruleType == type && ruleValue == value
+        )
+        try database.run(target.delete())
+    }
+
+    func replaceRules(feedID: Int64, type: String, values: [String]) throws {
+        let existing = feedRules.filter(ruleFeedID == feedID && ruleType == type)
+        try database.run(existing.delete())
+        for value in values {
+            try database.run(feedRules.insert(
+                ruleFeedID <- feedID,
+                ruleType <- type,
+                ruleValue <- value
+            ))
+        }
+    }
+
+    func deleteAllRules(forFeedID feedID: Int64) throws {
+        try database.run(feedRules.filter(ruleFeedID == feedID).delete())
+    }
+}

--- a/Shared/DatabaseManager/DatabaseManager.swift
+++ b/Shared/DatabaseManager/DatabaseManager.swift
@@ -19,6 +19,8 @@ nonisolated final class DatabaseManager: @unchecked Sendable {
     let feedLastFetched = SQLite.Expression<Double?>("last_fetched")
     let feedCategory = SQLite.Expression<String?>("category")
     let feedIsPodcast = SQLite.Expression<Bool>("is_podcast")
+    let feedIsMuted = SQLite.Expression<Bool>("is_muted")
+    let feedCustomIconURL = SQLite.Expression<String?>("custom_icon_url")
 
     let imageCache = Table("image_cache")
     let imageCacheURL = SQLite.Expression<String>("url")
@@ -47,6 +49,12 @@ nonisolated final class DatabaseManager: @unchecked Sendable {
     let summaryCacheDate = SQLite.Expression<String>("date")
     let summaryCacheContent = SQLite.Expression<String>("content")
 
+    let feedRules = Table("feed_rules")
+    let ruleID = SQLite.Expression<Int64>("id")
+    let ruleFeedID = SQLite.Expression<Int64>("feed_id")
+    let ruleType = SQLite.Expression<String>("type")
+    let ruleValue = SQLite.Expression<String>("value")
+
     // MARK: - Init
 
     private init() {
@@ -73,6 +81,8 @@ nonisolated final class DatabaseManager: @unchecked Sendable {
             table.column(feedLastFetched)
             table.column(feedCategory)
             table.column(feedIsPodcast, defaultValue: false)
+            table.column(feedIsMuted, defaultValue: false)
+            table.column(feedCustomIconURL)
         })
 
         try database.run(articles.create(ifNotExists: true) { table in
@@ -107,6 +117,13 @@ nonisolated final class DatabaseManager: @unchecked Sendable {
             table.column(summaryCacheDate)
             table.column(summaryCacheContent)
             table.primaryKey(summaryCacheType, summaryCacheDate)
+        })
+
+        try database.run(feedRules.create(ifNotExists: true) { table in
+            table.column(ruleID, primaryKey: .autoincrement)
+            table.column(ruleFeedID, references: feeds, feedID)
+            table.column(ruleType)
+            table.column(ruleValue)
         })
     }
 }

--- a/Shared/Models.swift
+++ b/Shared/Models.swift
@@ -10,6 +10,8 @@ nonisolated struct Feed: Identifiable, Hashable, Sendable {
     var lastFetched: Date?
     var category: String?
     var isPodcast: Bool
+    var isMuted: Bool
+    var customIconURL: String?
 
     var domain: String {
         URL(string: siteURL)?.host ?? URL(string: url)?.host ?? ""
@@ -22,6 +24,12 @@ nonisolated struct Feed: Identifiable, Hashable, Sendable {
     var isFeedViewDomain: Bool {
         FeedViewDomains.shouldPreferFeedView(feedDomain: domain)
     }
+}
+
+nonisolated enum FeedOpenMode: String, CaseIterable, Sendable {
+    case inAppViewer
+    case inAppBrowser
+    case browser
 }
 
 nonisolated struct Article: Identifiable, Hashable, Sendable {


### PR DESCRIPTION
## Summary
This PR adds comprehensive feed management capabilities including content filtering rules, feed editing, custom icons, and configurable link opening behavior.

## Key Changes

### Feed Rules System
- Added `FeedRulesSheet` view for managing muted keywords and authors per feed
- Implemented database layer for storing and retrieving feed rules (`DatabaseManager+Rules.swift`)
- Rules are applied when fetching articles to filter out content matching keywords or authors
- Suggested authors are displayed based on existing articles in the feed

### Feed Editing
- Added `FeedEditSheet` view for editing feed name, URL, and icon settings
- Support for custom feed icons via URL or photo library selection
- Icons are cached using the existing `FaviconCache` system
- Added `updateFeedDetails()` method to `FeedManager` for persisting changes

### Feed Muting
- Added `toggleMuted()` method to mute/unmute entire feeds
- Muted feeds are excluded from article counts and feed lists
- Visual indicator (bell.slash icon) shows muted status in feed list

### Link Opening Modes
- Added `FeedOpenMode` enum with three options: inAppViewer, inAppBrowser, browser
- Per-feed configuration stored in UserDefaults
- `ArticleLink` component respects the configured open mode
- Supports opening links in Safari View Controller or external browser

### Context Menu
- Added context menu to feed rows with options to:
  - Mute/unmute feed
  - Configure feed rules
  - Edit feed details
  - Delete feed with confirmation dialog

### Database Schema Updates
- Added `is_muted` and `custom_icon_url` columns to feeds table
- Created new `feed_rules` table for storing keyword and author rules
- Updated feed deletion to cascade delete associated rules

### UI Enhancements
- `FeedRowView` now displays muted indicator
- Favicon loading respects custom icons and falls back to default favicon
- Improved article filtering to apply rules across all article lists

## Implementation Details
- Rules are applied at query time in `FeedManager` using case-insensitive substring matching
- Custom favicons are stored in the file system cache with memory caching layer
- Feed state changes trigger data revision updates to refresh dependent views
- All database operations are wrapped in try-catch with graceful fallbacks

https://claude.ai/code/session_01ASHgdCPeChfu9KggQpv243