### PR TITLE
Add timeline display style for RSS feeds

### DIFF
--- a/SakuraRSS/Views/Bookmarks/BookmarksView.swift
+++ b/SakuraRSS/Views/Bookmarks/BookmarksView.swift
@@ -44,6 +44,8 @@ struct BookmarksView: View {
                         PhotosStyleView(articles: bookmarkedArticles)
                     case .podcast:
                         PodcastStyleView(articles: bookmarkedArticles)
+                    case .timeline:
+                        TimelineStyleView(articles: bookmarkedArticles)
                     }
                 }
             }
@@ -72,6 +74,8 @@ struct BookmarksView: View {
                                     Label(String(localized: "Articles.Style.Photos"), systemImage: "photo.stack")
                                         .tag(FeedDisplayStyle.photos)
                                 }
+                                Label(String(localized: "Articles.Style.Timeline"), systemImage: "clock")
+                                    .tag(FeedDisplayStyle.timeline)
                             }
                         } label: {
                             Image(systemName: "line.3.horizontal.decrease")

--- a/SakuraRSS/Views/Onboarding/OnboardingView+DisplayStyle.swift
+++ b/SakuraRSS/Views/Onboarding/OnboardingView+DisplayStyle.swift
@@ -88,7 +88,7 @@ private struct StylePreviewView: View {
     var body: some View {
         Group {
             switch style {
-            case .inbox, .video, .podcast:
+            case .inbox, .video, .podcast, .timeline:
                 inboxPreview
             case .feed:
                 feedPreview

--- a/SakuraRSS/Views/Search/SearchView.swift
+++ b/SakuraRSS/Views/Search/SearchView.swift
@@ -58,6 +58,8 @@ struct SearchView: View {
                         PhotosStyleView(articles: searchResults)
                     case .podcast:
                         PodcastStyleView(articles: searchResults)
+                    case .timeline:
+                        TimelineStyleView(articles: searchResults)
                     }
                 }
             }

--- a/SakuraRSS/Views/Shared/ArticleListView.swift
+++ b/SakuraRSS/Views/Shared/ArticleListView.swift
@@ -34,7 +34,7 @@ struct ArticleListView: View {
         let defaultRaw = UserDefaults.standard.string(forKey: "Display.DefaultStyle") ?? FeedDisplayStyle.inbox.rawValue
         let fallback: FeedDisplayStyle = isPodcastFeed ? .podcast
             : isVideoFeed ? .video
-            : isFeedViewDomain ? .feed
+            : isFeedViewDomain ? .timeline
             : (FeedDisplayStyle(rawValue: defaultRaw) ?? .inbox)
         self._displayStyle = State(initialValue: raw.flatMap(FeedDisplayStyle.init(rawValue:)) ?? fallback)
     }
@@ -57,6 +57,8 @@ struct ArticleListView: View {
                 PhotosStyleView(articles: articles, onLoadMore: onLoadMore)
             case .podcast:
                 PodcastStyleView(articles: articles, onLoadMore: onLoadMore)
+            case .timeline:
+                TimelineStyleView(articles: articles, onLoadMore: onLoadMore)
             }
         }
         .scrollContentBackground(.hidden)
@@ -88,6 +90,10 @@ struct ArticleListView: View {
                             Label(String(localized: "Articles.Style.Podcast"), systemImage: "headphones")
                                 .tag(FeedDisplayStyle.podcast)
                         }
+                        if feedKey != "all" {
+                            Label(String(localized: "Articles.Style.Timeline"), systemImage: "clock")
+                                .tag(FeedDisplayStyle.timeline)
+                        }
                     }
                 } label: {
                     Image(systemName: "line.3.horizontal.decrease")
@@ -117,6 +123,9 @@ struct ArticleListView: View {
             return .inbox
         }
         if displayStyle == .podcast && !isPodcastFeed {
+            return .inbox
+        }
+        if displayStyle == .timeline && feedKey == "all" {
             return .inbox
         }
         return displayStyle

--- a/SakuraRSS/Views/Shared/Feed Views/TimelineStyleView.swift
+++ b/SakuraRSS/Views/Shared/Feed Views/TimelineStyleView.swift
@@ -1,0 +1,117 @@
+import SwiftUI
+
+struct TimelineStyleView: View {
+
+    @Environment(FeedManager.self) var feedManager
+    let articles: [Article]
+    var onLoadMore: (() -> Void)?
+
+    var body: some View {
+        List {
+            if let latest = articles.first {
+                ArticleLink(article: latest) {
+                    VStack(alignment: .leading, spacing: 6) {
+                        if let date = latest.publishedDate {
+                            RelativeTimeText(date: date)
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                        }
+                        Text(latest.title)
+                            .font(.title2)
+                            .fontWeight(.bold)
+                            .foregroundStyle(latest.isRead ? .secondary : .primary)
+                    }
+                    .padding(.vertical, 8)
+                }
+                .listRowBackground(Color.clear)
+                .listRowSeparator(.hidden)
+            }
+
+            let timelineArticles = Array(articles.dropFirst())
+            ForEach(Array(timelineArticles.enumerated()), id: \.element.id) { index, article in
+                ArticleLink(article: article) {
+                    timelineRow(
+                        article: article,
+                        isFirst: index == 0,
+                        isLast: index == timelineArticles.count - 1
+                    )
+                }
+                .listRowBackground(Color.clear)
+                .listRowInsets(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))
+                .listRowSeparator(.hidden)
+                .listRowSpacing(0)
+            }
+
+            if let onLoadMore {
+                LoadPreviousArticlesButton(action: onLoadMore)
+                    .listRowBackground(Color.clear)
+                    .listRowSeparator(.hidden)
+            }
+        }
+        .listStyle(.plain)
+    }
+
+    private func timelineRow(article: Article, isFirst: Bool, isLast: Bool) -> some View {
+        HStack(alignment: .top, spacing: 0) {
+            Group {
+                if let date = article.publishedDate {
+                    RelativeTimeText(date: date)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } else {
+                    Text("")
+                        .font(.caption)
+                }
+            }
+            .frame(width: 64, alignment: .trailing)
+            .padding(.top, 12)
+
+            TimelineConnector(isFirst: isFirst, isLast: isLast, isRead: article.isRead)
+                .frame(width: 28)
+
+            Text(article.title)
+                .font(.subheadline)
+                .fontWeight(article.isRead ? .regular : .medium)
+                .foregroundStyle(article.isRead ? .secondary : .primary)
+                .lineLimit(2)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.vertical, 12)
+        }
+    }
+}
+
+private struct TimelineConnector: View {
+
+    let isFirst: Bool
+    let isLast: Bool
+    let isRead: Bool
+
+    var body: some View {
+        GeometryReader { geometry in
+            let midX = geometry.size.width / 2
+            let dotSize: CGFloat = 10
+            let dotY: CGFloat = 19
+
+            if !isFirst {
+                Path { path in
+                    path.move(to: CGPoint(x: midX, y: 0))
+                    path.addLine(to: CGPoint(x: midX, y: dotY - dotSize / 2))
+                }
+                .stroke(Color.secondary.opacity(0.3), lineWidth: 2)
+            }
+
+            if !isLast {
+                Path { path in
+                    path.move(to: CGPoint(x: midX, y: dotY + dotSize / 2))
+                    path.addLine(to: CGPoint(x: midX, y: geometry.size.height))
+                }
+                .stroke(Color.secondary.opacity(0.3), lineWidth: 2)
+            }
+
+            Circle()
+                .fill(isRead ? Color.secondary.opacity(0.4) : Color.accentColor)
+                .frame(width: dotSize, height: dotSize)
+                .position(x: midX, y: dotY)
+        }
+    }
+}

--- a/Shared/Domain Options/FeedViewDomains.swift
+++ b/Shared/Domain Options/FeedViewDomains.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Domains that should use the feed display style by default.
+/// Domains that should use the timeline display style by default.
 nonisolated enum FeedViewDomains {
 
     static let allowlistedDomains: Set<String> = [

--- a/Shared/Models.swift
+++ b/Shared/Models.swift
@@ -57,4 +57,5 @@ nonisolated enum FeedDisplayStyle: String, CaseIterable, Sendable {
     case video
     case photos
     case podcast
+    case timeline
 }


### PR DESCRIPTION
## Summary
This PR introduces a new timeline display style for viewing RSS feed articles. The timeline style presents articles in a chronological, visually connected format with relative timestamps and read/unread indicators.

## Key Changes
- **New TimelineStyleView component**: A custom SwiftUI view that displays articles in a timeline format with:
  - Featured latest article at the top with large title
  - Subsequent articles shown with connecting timeline lines
  - Visual indicators for read/unread status
  - Relative time display for each article
  
- **TimelineConnector component**: A private helper view that renders the visual timeline connector (vertical lines and circular dots) between articles, with styling based on read status

- **FeedDisplayStyle enum**: Added `.timeline` case to support the new display style

- **Integration across views**:
  - ArticleListView: Added timeline style option (available for non-"all" feeds, defaults to timeline for FeedViewDomains)
  - BookmarksView: Added timeline style option to bookmarks display
  - SearchView: Added timeline style option to search results
  - OnboardingView: Updated style preview to handle timeline style

- **FeedViewDomains**: Updated documentation to reflect that certain domains now use timeline style by default instead of feed style

## Notable Implementation Details
- Timeline style is only available for individual feeds (not the "all" feed view)
- The latest article is displayed prominently at the top with different styling than subsequent articles
- Timeline connectors intelligently hide top/bottom lines for first/last items
- Read articles show muted styling (secondary color) while unread articles use primary color and medium font weight
- The implementation maintains consistency with existing display styles (inbox, feed, photos, podcast, video)

https://claude.ai/code/session_01V1qdn1jv3FxHtTnq4ixEkZ