### PR TITLE
Improve UX: relocate paste button and add onboarding shortcut

### DIFF
--- a/SakuraRSS/Views/Home/AddFeedView.swift
+++ b/SakuraRSS/Views/Home/AddFeedView.swift
@@ -29,6 +29,17 @@ struct AddFeedView: View {
                         .autocorrectionDisabled()
                         .textInputAutocapitalization(.never)
                         .onSubmit { searchFeeds() }
+                        .overlay(alignment: .trailing) {
+                            if urlInput.isEmpty {
+                                PasteButton(payloadType: URL.self) { urls in
+                                    if let url = urls.first {
+                                        urlInput = url.absoluteString
+                                    }
+                                }
+                                .buttonBorderShape(.capsule)
+                                .controlSize(.mini)
+                            }
+                        }
 
                     Button {
                         searchFeeds()
@@ -43,20 +54,7 @@ struct AddFeedView: View {
                     }
                     .disabled(urlInput.isEmpty || isSearching)
                 } header: {
-                    HStack {
-                        Text("AddFeed.Section.Search")
-                        Spacer()
-                        if urlInput.isEmpty {
-                            PasteButton(payloadType: URL.self) { urls in
-                                if let url = urls.first {
-                                    urlInput = url.absoluteString
-                                }
-                            }
-                            .buttonStyle(.plain)
-                            .buttonBorderShape(.capsule)
-                            .controlSize(.mini)
-                        }
-                    }
+                    Text("AddFeed.Section.Search")
                 } footer: {
                     Text("AddFeed.Section.SearchFooter.\(appName)")
                 }

--- a/SakuraRSS/Views/Search/SearchView.swift
+++ b/SakuraRSS/Views/Search/SearchView.swift
@@ -5,6 +5,7 @@ struct SearchView: View {
     @Environment(FeedManager.self) var feedManager
     @AppStorage("Search.DisplayStyle") private var searchDisplayStyle: FeedDisplayStyle = .inbox
     @State private var searchText = ""
+    @State private var showingOnboarding = false
 
     private var searchResults: [Article] {
         guard !searchText.isEmpty else { return [] }
@@ -73,6 +74,18 @@ struct SearchView: View {
                 }
             }
             .searchable(text: $searchText, prompt: String(localized: "Search.Prompt"))
+            .onChange(of: searchText) {
+                if searchText == "/reonboard" {
+                    searchText = ""
+                    showingOnboarding = true
+                }
+            }
+            .sheet(isPresented: $showingOnboarding) {
+                OnboardingView {
+                    showingOnboarding = false
+                }
+                .environment(feedManager)
+            }
         }
     }
 }

--- a/SakuraRSS/Views/Shared/ArticleListView.swift
+++ b/SakuraRSS/Views/Shared/ArticleListView.swift
@@ -67,7 +67,7 @@ struct ArticleListView: View {
         .scrollContentBackground(.hidden)
         .sakuraBackground()
         .navigationTitle(title)
-        .toolbarTitleDisplayMode(.inlineLarge)
+        .toolbarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItemGroup(placement: .topBarTrailing) {
                 Menu {


### PR DESCRIPTION
## Summary
This PR enhances the user experience by repositioning the paste button in the feed URL input field and adding a hidden onboarding shortcut in the search view.

## Key Changes
- **AddFeedView**: Moved the PasteButton from the section header into an overlay on the trailing edge of the URL input field, providing better visual integration and reducing header clutter
- **SearchView**: Added a hidden onboarding trigger by typing "/reonboard" in the search field, allowing users to re-access the onboarding flow
- **ArticleListView**: Changed toolbar title display mode from `.inlineLarge` to `.inline` for a more compact header appearance

## Implementation Details
- The paste button now appears as a `.mini` capsule-shaped control directly in the input field when the URL field is empty
- The onboarding shortcut clears the search text and presents the OnboardingView in a sheet with proper environment setup
- These changes maintain existing functionality while improving the overall interface layout and accessibility

https://claude.ai/code/session_01BYVDSkNxHA2yYTZftmsnHt