### PR TITLE
Filter out placeholder summaries from feed articles

### DIFF
--- a/SakuraRSS/Views/Shared/Feed Views/FeedStyleView.swift
+++ b/SakuraRSS/Views/Shared/Feed Views/FeedStyleView.swift
@@ -90,7 +90,7 @@ struct FeedArticleRow: View {
                 }
 
                 Group {
-                    if !preferTitle, let summary = article.summary {
+                    if !preferTitle, article.hasMeaningfulSummary, let summary = article.summary {
                         Text(summary)
                     } else {
                         Text(article.title)

--- a/SakuraRSS/Views/Shared/Feed Views/InboxStyleView.swift
+++ b/SakuraRSS/Views/Shared/Feed Views/InboxStyleView.swift
@@ -57,7 +57,7 @@ struct InboxArticleRow: View {
                     .lineLimit(1)
                     .foregroundStyle(article.isRead ? .secondary : .primary)
 
-                if let summary = article.summary {
+                if article.hasMeaningfulSummary, let summary = article.summary {
                     Text(summary)
                         .font(.subheadline)
                         .foregroundStyle(.secondary)

--- a/Shared/Models.swift
+++ b/Shared/Models.swift
@@ -66,6 +66,13 @@ nonisolated struct Article: Identifiable, Hashable, Sendable {
     var isPodcastEpisode: Bool {
         audioURL != nil
     }
+
+    /// Whether the summary has enough meaningful content to display.
+    /// Filters out placeholder text like "Comments" from Hacker News feeds.
+    var hasMeaningfulSummary: Bool {
+        guard let summary else { return false }
+        return summary.count >= 20
+    }
 }
 
 nonisolated enum FeedDisplayStyle: String, CaseIterable, Sendable {


### PR DESCRIPTION
## Summary
Add validation to prevent displaying placeholder or minimal text as article summaries in feed views. This improves the user experience by filtering out unhelpful summary text like "Comments" that commonly appears in Hacker News feeds.

## Changes
- Added `hasMeaningfulSummary` computed property to the `Article` model that validates summaries have at least 20 characters of content
- Updated `FeedArticleRow` to only display summaries when they meet the meaningful content threshold
- Updated `InboxArticleRow` to only display summaries when they meet the meaningful content threshold

## Implementation Details
The new `hasMeaningfulSummary` property:
- Returns `false` if the summary is `nil`
- Returns `true` only if the summary contains 20 or more characters
- Provides a single source of truth for summary validation across all feed views

https://claude.ai/code/session_01AAkXN1Gt4NTznaES4QrenN