### PR TITLE
Add round-rect inset support for transparent favicons

### DIFF
--- a/SakuraRSS/Views/Shared/FaviconImage.swift
+++ b/SakuraRSS/Views/Shared/FaviconImage.swift
@@ -13,6 +13,9 @@ struct FaviconImage: View {
     var needsWhiteBackground: Bool { !skipInset && image.isDark }
     var isNearBlack: Bool { image.isNearBlack }
 
+    /// In round-rect mode, a transparent favicon should be inset with a tinted background.
+    var showRoundRectInset: Bool { !skipInset && !isCircle && image.isSquare && image.hasTransparentPixels }
+
     var iconSize: CGFloat {
         if isNearBlack {
             return size * 0.7
@@ -21,7 +24,7 @@ struct FaviconImage: View {
         } else if isNonSquare {
             let padding: CGFloat = isCircle ? 3 : 2
              return size - padding * 2
-        } else if showInset || needsWhiteBackground {
+        } else if showInset || needsWhiteBackground || showRoundRectInset {
             return size * 0.7
         } else {
             return size
@@ -37,6 +40,8 @@ struct FaviconImage: View {
             return .white
         } else if showInset {
             return Color(.secondarySystemBackground)
+        } else if showRoundRectInset {
+            return image.nearWhiteAverageColor
         } else {
             return .clear
         }
@@ -133,6 +138,104 @@ extension UIImage {
 extension UIImage {
     var isDark: Bool {
         averageLuminance < 0.3
+    }
+
+    /// Returns `true` when the image contains any transparent pixels.
+    var hasTransparentPixels: Bool {
+        !isFilledSquare
+    }
+
+    /// Computes the average colour of all opaque pixels as a SwiftUI `Color`.
+    var averageColor: Color {
+        guard let cgImage = cgImage else { return .gray }
+
+        let sampleSize = 16
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        var pixelData = [UInt8](repeating: 0, count: sampleSize * sampleSize * 4)
+
+        guard let context = CGContext(
+            data: &pixelData,
+            width: sampleSize,
+            height: sampleSize,
+            bitsPerComponent: 8,
+            bytesPerRow: sampleSize * 4,
+            space: colorSpace,
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else { return .gray }
+
+        context.draw(cgImage, in: CGRect(x: 0, y: 0, width: sampleSize, height: sampleSize))
+
+        var totalR: CGFloat = 0
+        var totalG: CGFloat = 0
+        var totalB: CGFloat = 0
+        var opaqueCount: CGFloat = 0
+
+        for index in 0..<(sampleSize * sampleSize) {
+            let offset = index * 4
+            let alpha = CGFloat(pixelData[offset + 3]) / 255.0
+            guard alpha > 0.1 else { continue }
+            totalR += CGFloat(pixelData[offset]) / 255.0
+            totalG += CGFloat(pixelData[offset + 1]) / 255.0
+            totalB += CGFloat(pixelData[offset + 2]) / 255.0
+            opaqueCount += 1
+        }
+
+        guard opaqueCount > 0 else { return .gray }
+        return Color(
+            red: totalR / opaqueCount,
+            green: totalG / opaqueCount,
+            blue: totalB / opaqueCount
+        )
+    }
+
+    /// A near-white tint derived from the average colour of the image,
+    /// suitable as a subtle background behind a transparent favicon.
+    var nearWhiteAverageColor: Color {
+        guard let cgImage = cgImage else { return Color(.secondarySystemBackground) }
+
+        let sampleSize = 16
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        var pixelData = [UInt8](repeating: 0, count: sampleSize * sampleSize * 4)
+
+        guard let context = CGContext(
+            data: &pixelData,
+            width: sampleSize,
+            height: sampleSize,
+            bitsPerComponent: 8,
+            bytesPerRow: sampleSize * 4,
+            space: colorSpace,
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else { return Color(.secondarySystemBackground) }
+
+        context.draw(cgImage, in: CGRect(x: 0, y: 0, width: sampleSize, height: sampleSize))
+
+        var totalR: CGFloat = 0
+        var totalG: CGFloat = 0
+        var totalB: CGFloat = 0
+        var opaqueCount: CGFloat = 0
+
+        for index in 0..<(sampleSize * sampleSize) {
+            let offset = index * 4
+            let alpha = CGFloat(pixelData[offset + 3]) / 255.0
+            guard alpha > 0.1 else { continue }
+            totalR += CGFloat(pixelData[offset]) / 255.0
+            totalG += CGFloat(pixelData[offset + 1]) / 255.0
+            totalB += CGFloat(pixelData[offset + 2]) / 255.0
+            opaqueCount += 1
+        }
+
+        guard opaqueCount > 0 else { return Color(.secondarySystemBackground) }
+        let avgR = totalR / opaqueCount
+        let avgG = totalG / opaqueCount
+        let avgB = totalB / opaqueCount
+
+        // Mix 85% white with 15% of the average colour
+        let whiteBlend: CGFloat = 0.85
+        return Color(
+            red: whiteBlend + (1 - whiteBlend) * avgR,
+            green: whiteBlend + (1 - whiteBlend) * avgG,
+            blue: whiteBlend + (1 - whiteBlend) * avgB
+        )
     }
 
     /// Returns `true` when virtually all opaque pixels are near-black,


### PR DESCRIPTION
## Summary
Enhanced favicon rendering to intelligently handle transparent favicons in round-rect mode by applying a subtle, color-derived background tint instead of leaving them transparent.

## Key Changes
- Added `showRoundRectInset` computed property to detect when a transparent favicon should receive a tinted background in round-rect mode (non-circle, square favicons with transparency)
- Updated `iconSize` calculation to treat round-rect inset favicons the same as other inset cases (70% of original size)
- Updated `backgroundColor` logic to apply a near-white tinted color for round-rect inset favicons
- Added `hasTransparentPixels` property that leverages existing `isFilledSquare` check
- Implemented `averageColor` computed property to calculate the average color of opaque pixels in an image
- Implemented `nearWhiteAverageColor` computed property that blends 85% white with 15% of the image's average color, providing a subtle background that complements the favicon's color palette

## Implementation Details
- Both color-averaging methods use a 16x16 sample size for performance
- Pixel sampling ignores pixels with alpha < 0.1 to focus on meaningfully opaque content
- The near-white blend ratio (85:15) ensures backgrounds remain subtle and readable while maintaining visual harmony with the favicon
- Graceful fallbacks to `.gray` or `.secondarySystemBackground` if image processing fails

https://claude.ai/code/session_015LRashEGgE6EY7TwXL4YPq