### PR TITLE
Add smooth animation to read/unread toggle in inbox

### DIFF
--- a/SakuraRSS/Views/Shared/Feed Views/InboxStyleView.swift
+++ b/SakuraRSS/Views/Shared/Feed Views/InboxStyleView.swift
@@ -97,7 +97,9 @@ struct InboxArticleRow: View {
         }
         .swipeActions(edge: .leading) {
             Button {
-                feedManager.toggleRead(article)
+                withAnimation(.smooth.speed(2.0)) {
+                    feedManager.toggleRead(article)
+                }
             } label: {
                 Image(systemName: article.isRead ? "envelope" : "envelope.open")
             }


### PR DESCRIPTION
## Summary
Added a smooth animation effect to the read/unread toggle action in the inbox article row view.

## Key Changes
- Wrapped the `feedManager.toggleRead(article)` call with `withAnimation(.smooth.speed(2.0))` to provide visual feedback when toggling the read status of an article

## Implementation Details
The animation uses SwiftUI's `.smooth` animation curve with a speed multiplier of 2.0, which creates a faster, more responsive feel when users tap the read/unread button in the leading swipe actions menu. This improves the user experience by making the state change feel more polished and intentional.

https://claude.ai/code/session_011FG2QkgAsqH24VFkEa8Suq