### PR TITLE
Make toolbar title display mode configurable in ArticlesView

### DIFF
--- a/SakuraRSS/Views/Home/AllArticlesView.swift
+++ b/SakuraRSS/Views/Home/AllArticlesView.swift
@@ -35,6 +35,7 @@ struct AllArticlesView: View {
             articles: displayedArticles,
             title: String(localized: "Shared.AllArticles"),
             feedKey: "all",
+            titleDisplayMode: .inlineLarge,
             onLoadMore: showingOlderArticles ? nil : {
                 showingOlderArticles = true
             },

--- a/SakuraRSS/Views/Shared/Articles/ArticlesView.swift
+++ b/SakuraRSS/Views/Shared/Articles/ArticlesView.swift
@@ -11,6 +11,7 @@ struct ArticlesView: View {
     let isPodcastFeed: Bool
     let isFeedViewDomain: Bool
     let isTimelineViewDomain: Bool
+    let titleDisplayMode: ToolbarTitleDisplayMode
     var onLoadMore: (() -> Void)?
     var onRefresh: (() async -> Void)?
 
@@ -29,6 +30,7 @@ struct ArticlesView: View {
     init(articles: [Article], title: String, feedKey: String,
          isVideoFeed: Bool = false, isPodcastFeed: Bool = false,
          isFeedViewDomain: Bool = false, isTimelineViewDomain: Bool = false,
+         titleDisplayMode: ToolbarTitleDisplayMode = .inline,
          onLoadMore: (() -> Void)? = nil,
          onRefresh: (() async -> Void)? = nil) {
         self.articles = articles
@@ -38,6 +40,7 @@ struct ArticlesView: View {
         self.isPodcastFeed = isPodcastFeed
         self.isFeedViewDomain = isFeedViewDomain
         self.isTimelineViewDomain = isTimelineViewDomain
+        self.titleDisplayMode = titleDisplayMode
         self.onLoadMore = onLoadMore
         self.onRefresh = onRefresh
         let raw = UserDefaults.standard.string(forKey: "Display.Style.\(feedKey)")
@@ -96,7 +99,7 @@ struct ArticlesView: View {
         .scrollContentBackground(.hidden)
         .sakuraBackground()
         .navigationTitle(title)
-        .toolbarTitleDisplayMode(.inline)
+        .toolbarTitleDisplayMode(titleDisplayMode)
         .toolbar {
             ToolbarItemGroup(placement: .topBarTrailing) {
                 Menu {


### PR DESCRIPTION
## Summary
This PR makes the toolbar title display mode configurable in `ArticlesView` instead of being hardcoded to `.inline`, allowing different views to customize how the navigation title is displayed.

## Key Changes
- Added `titleDisplayMode` property to `ArticlesView` with a default value of `.inline` to maintain backward compatibility
- Updated `ArticlesView` initializer to accept `titleDisplayMode` parameter
- Changed the hardcoded `.toolbarTitleDisplayMode(.inline)` modifier to use the configurable `titleDisplayMode` property
- Updated `AllArticlesView` to use `.inlineLarge` display mode for its articles view

## Implementation Details
- The new parameter defaults to `.inline` to preserve existing behavior for all current callers
- `AllArticlesView` now explicitly sets `titleDisplayMode: .inlineLarge` to display a larger title in its articles list
- This change provides flexibility for different views to have different title display styles while keeping the default behavior unchanged

https://claude.ai/code/session_01K5wtCWHZRHyc3oSa64SsrT