### PR TITLE
Refactor login view close buttons to use icon style

### DIFF
--- a/SakuraRSS/Views/Shared/XLoginView.swift
+++ b/SakuraRSS/Views/Shared/XLoginView.swift
@@ -17,16 +17,13 @@ struct XLoginView: View {
                 .navigationTitle(String(localized: "XLogin.Title"))
                 .navigationBarTitleDisplayMode(.inline)
                 .toolbar {
-                    ToolbarItem(placement: .cancellationAction) {
-                        Button(role: .cancel) {
+                    ToolbarItem(placement: .topBarTrailing) {
+                        Button {
                             dismiss()
-                        }
-                    }
-                    ToolbarItem(placement: .confirmationAction) {
-                        if isLoggedIn {
-                            Button(role: .confirm) {
-                                dismiss()
-                            }
+                        } label: {
+                            Image(systemName: "xmark.circle.fill")
+                                .symbolRenderingMode(.hierarchical)
+                                .foregroundStyle(.secondary)
                         }
                     }
                 }

--- a/SakuraRSS/Views/Shared/YouTubeLoginView.swift
+++ b/SakuraRSS/Views/Shared/YouTubeLoginView.swift
@@ -16,16 +16,13 @@ struct YouTubeLoginView: View {
                 .navigationTitle(String(localized: "YouTubeLogin.Title"))
                 .navigationBarTitleDisplayMode(.inline)
                 .toolbar {
-                    ToolbarItem(placement: .cancellationAction) {
-                        Button(role: .cancel) {
+                    ToolbarItem(placement: .topBarTrailing) {
+                        Button {
                             dismiss()
-                        }
-                    }
-                    ToolbarItem(placement: .confirmationAction) {
-                        if isLoggedIn {
-                            Button(role: .confirm) {
-                                dismiss()
-                            }
+                        } label: {
+                            Image(systemName: "xmark.circle.fill")
+                                .symbolRenderingMode(.hierarchical)
+                                .foregroundStyle(.secondary)
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
Updated the close button UI in XLoginView and YouTubeLoginView to use a consistent icon-based design instead of text-based buttons with semantic roles.

## Key Changes
- Changed toolbar button placement from `.cancellationAction` to `.topBarTrailing` for both login views
- Replaced text-based cancel/confirm buttons with a visual close button using `xmark.circle.fill` SF Symbol
- Applied hierarchical symbol rendering mode and secondary foreground color for visual consistency
- Removed conditional rendering of confirmation button (previously only shown when `isLoggedIn`)
- Simplified button implementation by removing semantic roles (`.cancel` and `.confirm`)

## Implementation Details
- Both views now use a single, unified close button in the trailing position
- The icon button provides a more modern, intuitive UI pattern for dismissing modal views
- The hierarchical rendering mode ensures the icon displays with appropriate visual depth
- Secondary foreground color keeps the close button visually subtle while remaining accessible

https://claude.ai/code/session_01UkE9Z3XWwhZ4Cz3CUM8URA