### PR TITLE
Move summaries toggle to top bar trailing with spacer before view style selector

### DIFF
--- a/SakuraRSS/Views/Home/AllArticlesView.swift
+++ b/SakuraRSS/Views/Home/AllArticlesView.swift
@@ -36,6 +36,13 @@ struct AllArticlesView: View {
             title: String(localized: "Shared.AllArticles"),
             feedKey: "all",
             titleDisplayMode: .inlineLarge,
+            anySummaryHidden: anySummaryHidden,
+            onRestoreSummaries: {
+                withAnimation(.smooth.speed(2.0)) {
+                    whileYouSleptDismissedDate = ""
+                    todaysSummaryDismissedDate = ""
+                }
+            },
             onLoadMore: showingOlderArticles ? nil : {
                 showingOlderArticles = true
             },
@@ -55,20 +62,6 @@ struct AllArticlesView: View {
             .animation(.smooth.speed(2.0), value: whileYouSleptDismissedDate)
             .animation(.smooth.speed(2.0), value: todaysSummaryDismissedDate)
             .padding(.bottom, 8)
-        }
-        .toolbar {
-            if anySummaryHidden {
-                ToolbarItem(placement: .topBarLeading) {
-                    Button {
-                        withAnimation(.smooth.speed(2.0)) {
-                            whileYouSleptDismissedDate = ""
-                            todaysSummaryDismissedDate = ""
-                        }
-                    } label: {
-                        Image(systemName: "apple.intelligence")
-                    }
-                }
-            }
         }
         .refreshable {
             await feedManager.refreshAllFeeds()

--- a/SakuraRSS/Views/Shared/Articles/ArticlesView.swift
+++ b/SakuraRSS/Views/Shared/Articles/ArticlesView.swift
@@ -12,6 +12,8 @@ struct ArticlesView: View {
     let isFeedViewDomain: Bool
     let isTimelineViewDomain: Bool
     let titleDisplayMode: ToolbarTitleDisplayMode
+    var anySummaryHidden: Bool
+    var onRestoreSummaries: (() -> Void)?
     var onLoadMore: (() -> Void)?
     var onRefresh: (() async -> Void)?
 
@@ -31,6 +33,8 @@ struct ArticlesView: View {
          isVideoFeed: Bool = false, isPodcastFeed: Bool = false,
          isFeedViewDomain: Bool = false, isTimelineViewDomain: Bool = false,
          titleDisplayMode: ToolbarTitleDisplayMode = .inline,
+         anySummaryHidden: Bool = false,
+         onRestoreSummaries: (() -> Void)? = nil,
          onLoadMore: (() -> Void)? = nil,
          onRefresh: (() async -> Void)? = nil) {
         self.articles = articles
@@ -41,6 +45,8 @@ struct ArticlesView: View {
         self.isFeedViewDomain = isFeedViewDomain
         self.isTimelineViewDomain = isTimelineViewDomain
         self.titleDisplayMode = titleDisplayMode
+        self.anySummaryHidden = anySummaryHidden
+        self.onRestoreSummaries = onRestoreSummaries
         self.onLoadMore = onLoadMore
         self.onRefresh = onRefresh
         let raw = UserDefaults.standard.string(forKey: "Display.Style.\(feedKey)")
@@ -101,6 +107,16 @@ struct ArticlesView: View {
         .navigationTitle(title)
         .toolbarTitleDisplayMode(titleDisplayMode)
         .toolbar {
+            if anySummaryHidden {
+                ToolbarItemGroup(placement: .topBarTrailing) {
+                    Button {
+                        onRestoreSummaries?()
+                    } label: {
+                        Image(systemName: "apple.intelligence")
+                    }
+                }
+            }
+            ToolbarSpacer(.fixed, placement: .topBarTrailing)
             ToolbarItemGroup(placement: .topBarTrailing) {
                 Menu {
                     Picker(String(localized: "Articles.DisplayStyle"), selection: $displayStyle) {


### PR DESCRIPTION
The summaries restore button (apple.intelligence icon) now appears in the
top bar trailing toolbar of the Following feed, separated from the view
style selector by a ToolbarSpacer. The view style menu remains the last
item in the trailing area.

https://claude.ai/code/session_01Ty5EjbWJXjDxgMtBMxZ1B7