### PR TITLE
Fix image viewer not displaying images

### DIFF
--- a/SakuraRSS/Views/Shared/ImageViewerView.swift
+++ b/SakuraRSS/Views/Shared/ImageViewerView.swift
@@ -28,6 +28,18 @@ struct ImageViewerView: View {
     }
 }
 
+private class LayoutAwareScrollView: UIScrollView {
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        guard let imageView = viewWithTag(1) as? UIImageView,
+              bounds.size != .zero else { return }
+        if imageView.frame.size != bounds.size {
+            imageView.frame = bounds
+            contentSize = bounds.size
+        }
+    }
+}
+
 private struct ZoomableScrollView: UIViewRepresentable {
 
     let image: UIImage
@@ -37,7 +49,7 @@ private struct ZoomableScrollView: UIViewRepresentable {
     }
 
     func makeUIView(context: Context) -> UIScrollView {
-        let scrollView = UIScrollView()
+        let scrollView = LayoutAwareScrollView()
         scrollView.delegate = context.coordinator
         scrollView.minimumZoomScale = 1.0
         scrollView.maximumZoomScale = 5.0
@@ -58,7 +70,10 @@ private struct ZoomableScrollView: UIViewRepresentable {
     func updateUIView(_ scrollView: UIScrollView, context: Context) {
         guard let imageView = scrollView.viewWithTag(1) as? UIImageView else { return }
         imageView.image = image
-        imageView.frame = scrollView.bounds
+        if scrollView.bounds.size != .zero {
+            imageView.frame = scrollView.bounds
+            scrollView.contentSize = scrollView.bounds.size
+        }
         context.coordinator.centerImageView(in: scrollView)
     }
 


### PR DESCRIPTION
The ZoomableScrollView never set scrollView.contentSize, causing UIScrollView
to treat its content area as zero-sized. Additionally, imageView.frame was set
from scrollView.bounds in updateUIView, which could be .zero before layout.

Fix by:
- Setting scrollView.contentSize alongside imageView.frame in updateUIView
- Using a LayoutAwareScrollView subclass that updates the image frame and
  content size in layoutSubviews, ensuring correct sizing after layout passes

https://claude.ai/code/session_01EehCZpYkZZsuDW417KVPX6