### PR TITLE
Fix image viewer layout when zoom scale is not at default

### DIFF
--- a/SakuraRSS/Views/Shared/ImageViewerView.swift
+++ b/SakuraRSS/Views/Shared/ImageViewerView.swift
@@ -32,7 +32,8 @@ private class LayoutAwareScrollView: UIScrollView {
     override func layoutSubviews() {
         super.layoutSubviews()
         guard let imageView = viewWithTag(1) as? UIImageView,
-              bounds.size != .zero else { return }
+              bounds.size != .zero,
+              zoomScale == 1.0 else { return }
         if imageView.frame.size != bounds.size {
             imageView.frame = bounds
             contentSize = bounds.size
@@ -70,7 +71,7 @@ private struct ZoomableScrollView: UIViewRepresentable {
     func updateUIView(_ scrollView: UIScrollView, context: Context) {
         guard let imageView = scrollView.viewWithTag(1) as? UIImageView else { return }
         imageView.image = image
-        if scrollView.bounds.size != .zero {
+        if scrollView.zoomScale == 1.0 && scrollView.bounds.size != .zero {
             imageView.frame = scrollView.bounds
             scrollView.contentSize = scrollView.bounds.size
         }


### PR DESCRIPTION
## Summary
Fixed a layout issue in the image viewer where the image frame and content size were being incorrectly reset when the scroll view was zoomed in or out.

## Key Changes
- Added `zoomScale == 1.0` guard condition in `LayoutAwareScrollView.layoutSubviews()` to prevent layout adjustments when the user has zoomed the image
- Added the same `zoomScale == 1.0` check in `ZoomableScrollView.updateUIView()` to prevent overriding the image frame during zoom operations

## Implementation Details
The changes ensure that the image frame and content size are only reset to match the scroll view bounds when the zoom scale is at its default value (1.0). This prevents the layout system from fighting against user zoom interactions and maintains the correct zoom state when the view hierarchy updates.

https://claude.ai/code/session_019oYVt3RHC8qt3K5BmZaRFH