### PR TITLE
Center images in scroll view when smaller than bounds

### DIFF
--- a/SakuraRSS/Views/Shared/ImageViewerView.swift
+++ b/SakuraRSS/Views/Shared/ImageViewerView.swift
@@ -41,6 +41,10 @@ private class LayoutAwareScrollView: UIScrollView {
             imageView.frame = CGRect(origin: .zero, size: fitSize)
             contentSize = fitSize
         }
+        // Center the image within the scroll view bounds
+        let offsetX = max((bounds.width - contentSize.width) / 2, 0)
+        let offsetY = max((bounds.height - contentSize.height) / 2, 0)
+        imageView.frame.origin = CGPoint(x: offsetX, y: offsetY)
     }
 
     static func aspectFitSize(for imageSize: CGSize, in boundsSize: CGSize) -> CGSize {


### PR DESCRIPTION
## Summary
Fixed image positioning in the ImageViewerView to center images within the scroll view when they are smaller than the available bounds.

## Key Changes
- Added logic to calculate horizontal and vertical offsets that center the image within the scroll view bounds
- The offsets use `max()` to ensure they never go negative, maintaining proper positioning when the image is larger than the bounds
- Image frame origin is now set based on these calculated offsets after the content size is determined

## Implementation Details
The centering calculation computes offsets by taking half the difference between the scroll view bounds and content size:
- `offsetX = max((bounds.width - contentSize.width) / 2, 0)`
- `offsetY = max((bounds.height - contentSize.height) / 2, 0)`

This ensures images are visually centered when they fit entirely within the scroll view, while maintaining correct positioning for larger images.

https://claude.ai/code/session_01AynGJ3TvArTPKy8yPYc4nK