### PR TITLE
Fix X feed icons not filling circle when detected as near-black

### DIFF
--- a/SakuraRSS/Views/Shared/FaviconImage.swift
+++ b/SakuraRSS/Views/Shared/FaviconImage.swift
@@ -17,10 +17,10 @@ struct FaviconImage: View {
     var showRoundRectInset: Bool { !skipInset && !isCircle && image.isSquare && image.hasTransparentPixels }
 
     var iconSize: CGFloat {
-        if isNearBlack {
-            return size * 0.7
-        } else if skipInset {
+        if skipInset {
             return size
+        } else if isNearBlack {
+            return size * 0.7
         } else if isNonSquare {
             let padding: CGFloat = isCircle ? 3 : 2
              return size - padding * 2
@@ -32,10 +32,10 @@ struct FaviconImage: View {
     }
 
     var bgColor: Color {
-        if isNearBlack {
-            return .white
-        } else if skipInset {
+        if skipInset {
             return .clear
+        } else if isNearBlack {
+            return .white
         } else if isNonSquare || needsWhiteBackground {
             return .white
         } else if showInset {


### PR DESCRIPTION
The isNearBlack check had higher priority than skipInset in both
iconSize and bgColor, causing X feed icons to be shrunk to 70% with a
white background even when skipInset was explicitly set to true.

https://claude.ai/code/session_01PmxnEo8NWaTzHKn9XQScjr