### PR TITLE
Fix image clipping in photos view for tall images

### DIFF
--- a/SakuraRSS/Views/Shared/CachedAsyncImage.swift
+++ b/SakuraRSS/Views/Shared/CachedAsyncImage.swift
@@ -29,6 +29,7 @@ struct CachedAsyncImage<Placeholder: View>: View {
                         .resizable()
                         .aspectRatio(contentMode: .fill)
                         .frame(width: geo.size.width, height: geo.size.height, alignment: alignment)
+                        .clipped()
                 }
             } else {
                 placeholder()

--- a/SakuraRSS/Views/Shared/Feed Views/PhotosStyleView.swift
+++ b/SakuraRSS/Views/Shared/Feed Views/PhotosStyleView.swift
@@ -120,17 +120,20 @@ struct PhotosArticleCard: View {
 
             // Edge-to-edge photo
             if let imageURL = article.imageURL, let url = URL(string: imageURL) {
-                CachedAsyncImage(url: url) {
-                    Rectangle()
-                        .fill(.secondary.opacity(0.1))
-                        .aspectRatio(1, contentMode: .fit)
-                }
-                .frame(maxWidth: .infinity)
-                .aspectRatio(contentMode: .fit)
-                .task {
-                    photoImage = await CachedAsyncImage<EmptyView>.loadImage(from: url)
-                }
-                .padding(.bottom, 10)
+                Color.clear
+                    .aspectRatio(4.0 / 5.0, contentMode: .fit)
+                    .frame(maxWidth: .infinity)
+                    .overlay {
+                        CachedAsyncImage(url: url) {
+                            Rectangle()
+                                .fill(.secondary.opacity(0.1))
+                        }
+                    }
+                    .clipped()
+                    .task {
+                        photoImage = await CachedAsyncImage<EmptyView>.loadImage(from: url)
+                    }
+                    .padding(.bottom, 10)
             }
 
             // Action buttons below photo


### PR DESCRIPTION
Add .clipped() to CachedAsyncImage's GeometryReader to prevent images
using .fill content mode from overflowing their bounds. In PhotosStyleView,
replace the unconstrained .fit aspect ratio with a 4:5 container that
crops tall images instead of letting them stretch the card height.

https://claude.ai/code/session_01HBLXaV3qj5hVosJyU3tvUG