### PR TITLE
Bump NLP priority and show Insights spinner while loading

### DIFF
--- a/SakuraRSS/Structs/NLPProcessingCoordinator.swift
+++ b/SakuraRSS/Structs/NLPProcessingCoordinator.swift
@@ -28,7 +28,7 @@ enum NLPProcessingCoordinator {
         logger.debug("processNewArticlesIfEnabled: starting (similar=\(similarContentEnabled), topics=\(topicsPeopleEnabled))")
         #endif
 
-        await Task.detached(priority: .utility) {
+        await Task.detached(priority: .userInitiated) {
             var idsToProcess = Set<Int64>()
             if similarContentEnabled {
                 if let ids = try? db.unprocessedSentimentArticleIDs(since: sevenDaysAgo, limit: 200) {
@@ -69,7 +69,7 @@ enum NLPProcessingCoordinator {
         let similarContentEnabled = defaults.bool(forKey: "Intelligence.SimilarContent.Enabled")
         let topicsPeopleEnabled = defaults.bool(forKey: "Intelligence.TopicsPeople.Enabled")
 
-        await Task.detached(priority: .utility) {
+        await Task.detached(priority: .userInitiated) {
             processArticleSync(article, similarContent: similarContentEnabled,
                                topicsPeople: topicsPeopleEnabled)
         }.value

--- a/SakuraRSS/Views/Shared/Article Detail/ArticleDetailView+SimilarContent.swift
+++ b/SakuraRSS/Views/Shared/Article Detail/ArticleDetailView+SimilarContent.swift
@@ -12,7 +12,7 @@ extension ArticleDetailView {
 
     @ViewBuilder
     var insightsSection: some View {
-        if hasAnyInsights {
+        if shouldShowInsightsSection {
             VStack(alignment: .leading, spacing: 20) {
                 Divider()
                     .padding(.horizontal)
@@ -22,31 +22,43 @@ extension ArticleDetailView {
                     .fontWeight(.bold)
                     .padding(.horizontal)
 
-                if similarContentEnabled && !similarArticles.isEmpty {
-                    similarContentSubsection
-                }
+                if isLoadingInsights {
+                    ProgressView()
+                        .frame(maxWidth: .infinity, alignment: .center)
+                        .padding(.vertical, 8)
+                        .transition(.blurReplace)
+                } else {
+                    if similarContentEnabled && !similarArticles.isEmpty {
+                        similarContentSubsection
+                    }
 
-                if topicsPeopleEnabled && !articleTopics.isEmpty {
-                    entityChipsSubsection(
-                        titleKey: "SimilarContent.Topics",
-                        systemImage: "number",
-                        types: ["organization", "place"],
-                        names: articleTopics
-                    )
-                }
+                    if topicsPeopleEnabled && !articleTopics.isEmpty {
+                        entityChipsSubsection(
+                            titleKey: "SimilarContent.Topics",
+                            systemImage: "number",
+                            types: ["organization", "place"],
+                            names: articleTopics
+                        )
+                    }
 
-                if topicsPeopleEnabled && !articlePeople.isEmpty {
-                    entityChipsSubsection(
-                        titleKey: "SimilarContent.People",
-                        systemImage: "person.2",
-                        types: ["person"],
-                        names: articlePeople
-                    )
+                    if topicsPeopleEnabled && !articlePeople.isEmpty {
+                        entityChipsSubsection(
+                            titleKey: "SimilarContent.People",
+                            systemImage: "person.2",
+                            types: ["person"],
+                            names: articlePeople
+                        )
+                    }
                 }
             }
             .padding(.top, 16)
             .padding(.bottom, 24)
         }
+    }
+
+    private var shouldShowInsightsSection: Bool {
+        guard similarContentEnabled || topicsPeopleEnabled else { return false }
+        return isLoadingInsights || hasAnyInsights
     }
 
     private var hasAnyInsights: Bool {
@@ -123,6 +135,7 @@ extension ArticleDetailView {
         let currentArticle = article
         let feedsLookup = feedManager.feedsByID
 
+        isLoadingInsights = true
         Task {
             let loadedSimilar: [SimilarArticleItem]
             if loadSimilar {
@@ -151,6 +164,7 @@ extension ArticleDetailView {
                 articleTopics = loadedEntities.topics
                 articlePeople = loadedEntities.people
             }
+            isLoadingInsights = false
         }
     }
 
@@ -162,7 +176,7 @@ extension ArticleDetailView {
         articleSummary: String
     ) async -> (topics: [String], people: [String]) {
         let db = DatabaseManager.shared
-        return await Task.detached(priority: .utility) {
+        return await Task.detached(priority: .userInitiated) {
             // Ensure entity extraction has been run for this article.
             if (try? db.isEntitiesProcessed(articleId: articleID)) != true {
                 let text = [articleTitle, articleSummary]
@@ -207,7 +221,7 @@ extension ArticleDetailView {
         currentArticle: Article,
         feedsLookup: [Int64: Feed]
     ) async -> [SimilarArticleItem] {
-        let rawMatches = await Task.detached(priority: .utility) {
+        let rawMatches = await Task.detached(priority: .userInitiated) {
             await computeRawMatches(
                 currentArticle: currentArticle, feedsLookup: feedsLookup
             )

--- a/SakuraRSS/Views/Shared/Article Detail/ArticleDetailView.swift
+++ b/SakuraRSS/Views/Shared/Article Detail/ArticleDetailView.swift
@@ -38,6 +38,7 @@ struct ArticleDetailView: View {
     @State var similarArticles: [SimilarArticleItem] = []
     @State var articleTopics: [String] = []
     @State var articlePeople: [String] = []
+    @State var isLoadingInsights: Bool = false
 
     var isAppleIntelligenceAvailable: Bool {
         SystemLanguageModel.default.availability == .available
@@ -179,6 +180,7 @@ struct ArticleDetailView: View {
                 .animation(.smooth.speed(2.0), value: similarArticles.count)
                 .animation(.smooth.speed(2.0), value: articleTopics.count)
                 .animation(.smooth.speed(2.0), value: articlePeople.count)
+                .animation(.smooth.speed(2.0), value: isLoadingInsights)
         }
         .refreshable {
             await refreshArticleContent()


### PR DESCRIPTION
Raise NLP background and on-demand task priority from .utility to
.userInitiated so insights surface faster after opening an article and
after refresh. Add an isLoadingInsights flag so the Insights section
appears immediately with a ProgressView whenever any insight feature is
enabled, then swaps to the populated content once loading completes.

https://claude.ai/code/session_01MsPCfYxpU8NM7xZk2K3Tun