### PR TITLE
Unify Content Insights settings and implement hybrid similarity ranking

### DIFF
--- a/SakuraRSS/Structs/NLPProcessingCoordinator.swift
+++ b/SakuraRSS/Structs/NLPProcessingCoordinator.swift
@@ -7,15 +7,14 @@ enum NLPProcessingCoordinator {
     nonisolated static let logger = Logger(subsystem: "com.tsubuzaki.SakuraRSS", category: "NLPCoordinator")
     #endif
 
-    /// Processes unprocessed articles if any NLP feature is enabled.
+    /// Processes unprocessed articles if Content Insights is enabled.
     /// Called after feed refresh completes.
     static func processNewArticlesIfEnabled() async {
         let defaults = UserDefaults.standard
-        let similarContentEnabled = defaults.bool(forKey: "Intelligence.SimilarContent.Enabled")
-        let topicsPeopleEnabled = defaults.bool(forKey: "Intelligence.TopicsPeople.Enabled")
-        guard similarContentEnabled || topicsPeopleEnabled else {
+        let contentInsightsEnabled = defaults.bool(forKey: "Intelligence.ContentInsights.Enabled")
+        guard contentInsightsEnabled else {
             #if DEBUG
-            logger.debug("processNewArticlesIfEnabled: both features disabled, skipping")
+            logger.debug("processNewArticlesIfEnabled: content insights disabled, skipping")
             #endif
             return
         }
@@ -25,20 +24,16 @@ enum NLPProcessingCoordinator {
 
         #if DEBUG
         let startTime = Date()
-        logger.debug("processNewArticlesIfEnabled: starting (similar=\(similarContentEnabled), topics=\(topicsPeopleEnabled))")
+        logger.debug("processNewArticlesIfEnabled: starting")
         #endif
 
         await Task.detached(priority: .userInitiated) {
             var idsToProcess = Set<Int64>()
-            if similarContentEnabled {
-                if let ids = try? db.unprocessedSentimentArticleIDs(since: sevenDaysAgo, limit: 200) {
-                    idsToProcess.formUnion(ids)
-                }
+            if let ids = try? db.unprocessedSentimentArticleIDs(since: sevenDaysAgo, limit: 200) {
+                idsToProcess.formUnion(ids)
             }
-            if topicsPeopleEnabled {
-                if let ids = try? db.unprocessedEntitiesArticleIDs(since: sevenDaysAgo, limit: 200) {
-                    idsToProcess.formUnion(ids)
-                }
+            if let ids = try? db.unprocessedEntitiesArticleIDs(since: sevenDaysAgo, limit: 200) {
+                idsToProcess.formUnion(ids)
             }
 
             #if DEBUG
@@ -48,8 +43,7 @@ enum NLPProcessingCoordinator {
             let orderedIDs = Array(idsToProcess)
             for (index, id) in orderedIDs.enumerated() {
                 guard let article = try? db.article(byID: id) else { continue }
-                processArticleSync(article, similarContent: similarContentEnabled,
-                                   topicsPeople: topicsPeopleEnabled)
+                processArticleSync(article)
 
                 if index > 0 && index % 50 == 0 {
                     await Task.yield()
@@ -66,20 +60,17 @@ enum NLPProcessingCoordinator {
     /// Processes a single article on-demand (e.g., from ArticleDetailView).
     static func processArticle(_ article: Article) async {
         let defaults = UserDefaults.standard
-        let similarContentEnabled = defaults.bool(forKey: "Intelligence.SimilarContent.Enabled")
-        let topicsPeopleEnabled = defaults.bool(forKey: "Intelligence.TopicsPeople.Enabled")
+        guard defaults.bool(forKey: "Intelligence.ContentInsights.Enabled") else { return }
 
         await Task.detached(priority: .userInitiated) {
-            processArticleSync(article, similarContent: similarContentEnabled,
-                               topicsPeople: topicsPeopleEnabled)
+            processArticleSync(article)
         }.value
     }
 
-    private nonisolated static func processArticleSync(
-        _ article: Article,
-        similarContent: Bool,
-        topicsPeople: Bool
-    ) {
+    /// Extracts sentiment and entities for an article. Called only when
+    /// Content Insights is enabled — the hybrid similarity ranker relies on
+    /// entities being present, so both passes always run together.
+    private nonisolated static func processArticleSync(_ article: Article) {
         let db = DatabaseManager.shared
         let text = [article.title, article.summary ?? ""]
             .filter { !$0.isEmpty }
@@ -89,22 +80,18 @@ enum NLPProcessingCoordinator {
         logger.debug("processArticleSync: article=\(article.id) title=\"\(article.title.prefix(60))\"")
         #endif
 
-        if similarContent {
-            if let score = NLPProcessor.sentimentScore(for: text) {
-                try? db.updateSentimentScore(score, for: article.id)
-            }
-            try? db.markSentimentProcessed(articleId: article.id)
+        if let score = NLPProcessor.sentimentScore(for: text) {
+            try? db.updateSentimentScore(score, for: article.id)
         }
+        try? db.markSentimentProcessed(articleId: article.id)
 
-        if topicsPeople {
-            let entities = NLPProcessor.extractEntities(from: text)
-            if !entities.isEmpty {
-                try? db.insertEntities(
-                    entities.map { (name: $0.name, type: $0.type) },
-                    for: article.id
-                )
-            }
-            try? db.markEntitiesProcessed(articleId: article.id)
+        let entities = NLPProcessor.extractEntities(from: text)
+        if !entities.isEmpty {
+            try? db.insertEntities(
+                entities.map { (name: $0.name, type: $0.type) },
+                for: article.id
+            )
         }
+        try? db.markEntitiesProcessed(articleId: article.id)
     }
 }

--- a/SakuraRSS/Views/More/OnDeviceIntelligenceSettingsView.swift
+++ b/SakuraRSS/Views/More/OnDeviceIntelligenceSettingsView.swift
@@ -5,8 +5,7 @@ struct OnDeviceIntelligenceSettingsView: View {
 
     @AppStorage("TodaysSummary.Enabled") private var todaysSummaryEnabled: Bool = false
     @AppStorage("WhileYouSlept.Enabled") private var whileYouSleptEnabled: Bool = false
-    @AppStorage("Intelligence.SimilarContent.Enabled") private var similarContentEnabled: Bool = false
-    @AppStorage("Intelligence.TopicsPeople.Enabled") private var topicsPeopleEnabled: Bool = false
+    @AppStorage("Intelligence.ContentInsights.Enabled") private var contentInsightsEnabled: Bool = false
 
     private var isAppleIntelligenceAvailable: Bool {
         SystemLanguageModel.default.availability == .available
@@ -26,15 +25,9 @@ struct OnDeviceIntelligenceSettingsView: View {
             }
 
             Section {
-                Toggle("Settings.SimilarContent", isOn: $similarContentEnabled)
+                Toggle("Settings.ContentInsights", isOn: $contentInsightsEnabled)
             } footer: {
-                Text("Settings.SimilarContent.Footer")
-            }
-
-            Section {
-                Toggle("Settings.TopicsPeople", isOn: $topicsPeopleEnabled)
-            } footer: {
-                Text("Settings.TopicsPeople.Footer")
+                Text("Settings.ContentInsights.Footer")
             }
         }
         .navigationTitle("Settings.Section.InsightsAndIntelligence")

--- a/SakuraRSS/Views/Search/SearchView.swift
+++ b/SakuraRSS/Views/Search/SearchView.swift
@@ -8,7 +8,7 @@ struct SearchView: View {
 
     @Environment(FeedManager.self) var feedManager
     @AppStorage("Search.DisplayStyle") private var searchDisplayStyle: FeedDisplayStyle = .inbox
-    @AppStorage("Intelligence.TopicsPeople.Enabled") private var topicsPeopleEnabled: Bool = false
+    @AppStorage("Intelligence.ContentInsights.Enabled") private var contentInsightsEnabled: Bool = false
     @State private var searchText = ""
     @State private var searchResults: [Article] = []
     @State private var selectedTab: SearchTab = .search
@@ -32,7 +32,7 @@ struct SearchView: View {
     var body: some View {
         NavigationStack(path: $path) {
             VStack(spacing: 0) {
-                if topicsPeopleEnabled {
+                if contentInsightsEnabled {
                     Picker("", selection: $selectedTab) {
                         Text("Search.Tab.Search").tag(SearchTab.search)
                         Text("Search.Tab.Topics").tag(SearchTab.topics)
@@ -109,7 +109,7 @@ struct SearchView: View {
                     searchResults = results
                 }
             }
-            .onChange(of: topicsPeopleEnabled) { _, newValue in
+            .onChange(of: contentInsightsEnabled) { _, newValue in
                 if !newValue && selectedTab != .search {
                     selectedTab = .search
                 }

--- a/SakuraRSS/Views/Shared/Article Detail/ArticleDetailView+SimilarContent.swift
+++ b/SakuraRSS/Views/Shared/Article Detail/ArticleDetailView+SimilarContent.swift
@@ -28,11 +28,11 @@ extension ArticleDetailView {
                         .padding(.vertical, 8)
                         .transition(.blurReplace)
                 } else {
-                    if similarContentEnabled && !similarArticles.isEmpty {
+                    if !similarArticles.isEmpty {
                         similarContentSubsection
                     }
 
-                    if topicsPeopleEnabled && !articleTopics.isEmpty {
+                    if !articleTopics.isEmpty {
                         entityChipsSubsection(
                             titleKey: "SimilarContent.Topics",
                             systemImage: "number",
@@ -41,7 +41,7 @@ extension ArticleDetailView {
                         )
                     }
 
-                    if topicsPeopleEnabled && !articlePeople.isEmpty {
+                    if !articlePeople.isEmpty {
                         entityChipsSubsection(
                             titleKey: "SimilarContent.People",
                             systemImage: "person.2",
@@ -57,13 +57,12 @@ extension ArticleDetailView {
     }
 
     private var shouldShowInsightsSection: Bool {
-        guard similarContentEnabled || topicsPeopleEnabled else { return false }
+        guard contentInsightsEnabled else { return false }
         return isLoadingInsights || hasAnyInsights
     }
 
     private var hasAnyInsights: Bool {
-        (similarContentEnabled && !similarArticles.isEmpty)
-            || (topicsPeopleEnabled && (!articleTopics.isEmpty || !articlePeople.isEmpty))
+        !similarArticles.isEmpty || !articleTopics.isEmpty || !articlePeople.isEmpty
     }
 
     @ViewBuilder
@@ -129,41 +128,26 @@ extension ArticleDetailView {
     /// that run on the generic executor (off MainActor); only the
     /// final @State writes land back on MainActor after the awaits.
     func loadInsightsInBackground() {
-        guard similarContentEnabled || topicsPeopleEnabled else { return }
-        let loadSimilar = similarContentEnabled
-        let loadEntities = topicsPeopleEnabled
+        guard contentInsightsEnabled else { return }
         let currentArticle = article
         let feedsLookup = feedManager.feedsByID
 
         isLoadingInsights = true
         Task {
-            let loadedSimilar: [SimilarArticleItem]
-            if loadSimilar {
-                loadedSimilar = await Self.computeSimilarArticles(
-                    currentArticle: currentArticle, feedsLookup: feedsLookup
-                )
-            } else {
-                loadedSimilar = []
-            }
+            async let similarTask = Self.computeSimilarArticles(
+                currentArticle: currentArticle, feedsLookup: feedsLookup
+            )
+            async let entitiesTask = Self.computeArticleEntities(
+                articleID: currentArticle.id,
+                articleTitle: currentArticle.title,
+                articleSummary: currentArticle.summary ?? ""
+            )
+            let loadedSimilar = await similarTask
+            let loadedEntities = await entitiesTask
 
-            let loadedEntities: (topics: [String], people: [String])
-            if loadEntities {
-                loadedEntities = await Self.computeArticleEntities(
-                    articleID: currentArticle.id,
-                    articleTitle: currentArticle.title,
-                    articleSummary: currentArticle.summary ?? ""
-                )
-            } else {
-                loadedEntities = (topics: [], people: [])
-            }
-
-            if loadSimilar {
-                similarArticles = loadedSimilar
-            }
-            if loadEntities {
-                articleTopics = loadedEntities.topics
-                articlePeople = loadedEntities.people
-            }
+            similarArticles = loadedSimilar
+            articleTopics = loadedEntities.topics
+            articlePeople = loadedEntities.people
             isLoadingInsights = false
         }
     }
@@ -255,18 +239,17 @@ extension ArticleDetailView {
         }
     }
 
-    /// Returns match metadata ordered by similarity rank. Uses the SQLite
-    /// cache when available; otherwise runs NLP, persists the result, and
-    /// marks the source article as computed. Must be called from a
-    /// detached task — it is synchronous aside from the NLP await, so
-    /// its DB work would otherwise block whichever actor invokes it.
+    /// Returns match metadata ordered by hybrid similarity score. Uses the
+    /// SQLite cache when available; otherwise runs the retrieve-then-rerank
+    /// pipeline, persists the result, and marks the source article as
+    /// computed. Must be called from a detached task.
     fileprivate nonisolated static func computeRawMatches(
         currentArticle: Article,
         feedsLookup: [Int64: Feed]
     ) async -> [SimilarMatchData] {
         let db = DatabaseManager.shared
 
-        // 1. Cache hit path — instant return, no NLP, no 48h window scan.
+        // 1. Cache hit path — instant return, no NLP, no window scan.
         if (try? db.isSimilarComputed(articleId: currentArticle.id)) == true {
             if let cached = try? db.cachedSimilarArticleIDs(forSourceID: currentArticle.id),
                !cached.isEmpty {
@@ -289,25 +272,57 @@ extension ArticleDetailView {
             return []
         }
 
-        // 2. Cache miss — run NLP and persist. The embedding comparison is
-        // parallelized inside NLPProcessor.findSimilarArticles.
+        // 2. Cache miss — run the hybrid ranker.
+        //
+        // Retrieval: widen the candidate window to ±7 days / up to 300
+        // articles so the reranker gets real recall instead of a narrow
+        // 48h slice.
         guard let candidates = try? db.articlesInWindow(
-            around: currentArticle, hours: 48, limit: 60
-        ) else {
+            around: currentArticle, hours: 168, limit: 300
+        ), !candidates.isEmpty else {
             try? db.cacheSimilarArticles([], forSourceID: currentArticle.id)
             return []
         }
 
-        let similar = await NLPProcessor.findSimilarArticles(
+        // Ensure the source article has entities extracted. The background
+        // coordinator normally handles this during feed refresh, but a
+        // freshly opened brand-new article may not have been processed yet.
+        // Same pattern as `computeArticleEntities` above.
+        if (try? db.isEntitiesProcessed(articleId: currentArticle.id)) != true {
+            let sourceText = [currentArticle.title, currentArticle.summary ?? ""]
+                .filter { !$0.isEmpty }
+                .joined(separator: " ")
+            let extracted = NLPProcessor.extractEntities(from: sourceText)
+            if !extracted.isEmpty {
+                try? db.insertEntities(
+                    extracted.map { (name: $0.name, type: $0.type) },
+                    for: currentArticle.id
+                )
+            }
+            try? db.markEntitiesProcessed(articleId: currentArticle.id)
+        }
+
+        // Batch-load source + candidate entities in a single query.
+        let sourceEntities: Set<String> = (try? db.entities(forArticleID: currentArticle.id))
+            .map { Set($0.map { $0.name.lowercased() }) } ?? []
+        let candidateIDs = candidates.map { $0.id }
+        let entityMap = (try? db.entities(forArticleIDs: candidateIDs)) ?? [:]
+        let pairs: [(article: Article, entities: Set<String>)] = candidates.map { candidate in
+            (article: candidate, entities: entityMap[candidate.id] ?? [])
+        }
+
+        let similar = await NLPProcessor.findSimilarArticlesHybrid(
             to: currentArticle,
-            candidates: candidates,
+            sourceEntities: sourceEntities,
+            candidates: pairs,
             maxResults: 8,
-            maximumDistance: 1.5
+            minimumScore: 0.35
         )
 
-        // Persist even if empty so we don't recompute on the next open.
+        // Persist `1 - score` as the distance column so lower-is-better and
+        // rank-ordering stay consistent with the existing cache reader.
         try? db.cacheSimilarArticles(
-            similar.map { (id: $0.articleID, distance: $0.distance) },
+            similar.map { (id: $0.articleID, distance: 1.0 - $0.score) },
             forSourceID: currentArticle.id
         )
 

--- a/SakuraRSS/Views/Shared/Article Detail/ArticleDetailView.swift
+++ b/SakuraRSS/Views/Shared/Article Detail/ArticleDetailView.swift
@@ -33,8 +33,7 @@ struct ArticleDetailView: View {
     @State var heroImageAspectRatio: CGFloat?
     @Namespace private var imageViewerNamespace
     @AppStorage("YouTube.OpenMode") var youTubeOpenMode: YouTubeOpenMode = .inAppPlayer
-    @AppStorage("Intelligence.SimilarContent.Enabled") var similarContentEnabled: Bool = false
-    @AppStorage("Intelligence.TopicsPeople.Enabled") var topicsPeopleEnabled: Bool = false
+    @AppStorage("Intelligence.ContentInsights.Enabled") var contentInsightsEnabled: Bool = false
     @State var similarArticles: [SimilarArticleItem] = []
     @State var articleTopics: [String] = []
     @State var articlePeople: [String] = []

--- a/SakuraRSS/Views/iPadSidebarView.swift
+++ b/SakuraRSS/Views/iPadSidebarView.swift
@@ -31,7 +31,7 @@ struct IPadSidebarView: View {
     @State private var pendingYouTubeSafariURL: URL?
     @State private var searchText = ""
     @AppStorage("Onboarding.Completed") private var onboardingCompleted: Bool = false
-    @AppStorage("Intelligence.TopicsPeople.Enabled") private var topicsPeopleEnabled: Bool = false
+    @AppStorage("Intelligence.ContentInsights.Enabled") private var contentInsightsEnabled: Bool = false
 
     @Namespace private var cardZoom
 
@@ -236,7 +236,7 @@ struct IPadSidebarView: View {
                     .tag(SidebarDestination.bookmarks)
             }
 
-            if topicsPeopleEnabled {
+            if contentInsightsEnabled {
                 Section {
                     Label("Topics.Title", systemImage: "number")
                         .tag(SidebarDestination.topics)

--- a/Shared/Database Manager/DatabaseManager+NLP.swift
+++ b/Shared/Database Manager/DatabaseManager+NLP.swift
@@ -66,6 +66,28 @@ nonisolated extension DatabaseManager {
         }
     }
 
+    /// Batch-fetches entities for many article IDs in a single query, returning
+    /// a map of article ID → lowercased entity-name set. Used by the hybrid
+    /// similarity ranker so we don't fire N single-row queries.
+    func entities(forArticleIDs ids: [Int64]) throws -> [Int64: Set<String>] {
+        guard !ids.isEmpty else { return [:] }
+        let placeholders = ids.map { _ in "?" }.joined(separator: ", ")
+        let sql = """
+            SELECT article_id, LOWER(name)
+            FROM nlp_entities
+            WHERE article_id IN (\(placeholders))
+            """
+        let bindings: [Binding?] = ids.map { $0 as Binding? }
+        var result: [Int64: Set<String>] = [:]
+        for row in try database.prepare(sql, bindings) {
+            guard let articleId = row[0] as? Int64,
+                  let name = row[1] as? String,
+                  !name.isEmpty else { continue }
+            result[articleId, default: []].insert(name)
+        }
+        return result
+    }
+
     // MARK: - Entity Queries (Topics & People)
 
     func topEntities(type: String, since date: Date, limit: Int) throws -> [(name: String, count: Int)] {
@@ -230,6 +252,16 @@ nonisolated extension DatabaseManager {
                 articles.filter(articleID == sourceID)
                     .update(articleSimilarComputed <- true)
             )
+        }
+    }
+
+    /// Wipes every cached similar-article match and resets the per-article
+    /// `similar_computed` flag. Used on algorithm-version bumps so the next
+    /// article open recomputes under the new scoring.
+    func invalidateSimilarContentCache() throws {
+        try database.transaction {
+            try database.run(similarArticles.delete())
+            try database.run(articles.update(articleSimilarComputed <- false))
         }
     }
 

--- a/Shared/Database Manager/DatabaseManager.swift
+++ b/Shared/Database Manager/DatabaseManager.swift
@@ -106,6 +106,8 @@ nonisolated final class DatabaseManager: @unchecked Sendable {
             try createTables()
             fixupIfVersionChanged()
             invalidateStaleParserCache()
+            migrateContentInsightsToggle()
+            invalidateStaleSimilarContentCache()
         } catch {
             fatalError("Database initialization failed: \(error)")
         }
@@ -117,6 +119,37 @@ nonisolated final class DatabaseManager: @unchecked Sendable {
         if stored < ParserVersion.articleExtractor {
             try? invalidateAllCachedArticleContent()
             UserDefaults.standard.set(ParserVersion.articleExtractor, forKey: key)
+        }
+    }
+
+    /// Collapses the legacy `Intelligence.SimilarContent.Enabled` /
+    /// `Intelligence.TopicsPeople.Enabled` toggles into a single
+    /// `Intelligence.ContentInsights.Enabled` key. Runs exactly once per
+    /// install, tracked by `Intelligence.ContentInsights.Migrated`.
+    private func migrateContentInsightsToggle() {
+        let defaults = UserDefaults.standard
+        let migratedKey = "Intelligence.ContentInsights.Migrated"
+        guard !defaults.bool(forKey: migratedKey) else { return }
+        let legacySimilar = defaults.bool(forKey: "Intelligence.SimilarContent.Enabled")
+        let legacyTopics = defaults.bool(forKey: "Intelligence.TopicsPeople.Enabled")
+        if legacySimilar || legacyTopics {
+            defaults.set(true, forKey: "Intelligence.ContentInsights.Enabled")
+        }
+        defaults.removeObject(forKey: "Intelligence.SimilarContent.Enabled")
+        defaults.removeObject(forKey: "Intelligence.TopicsPeople.Enabled")
+        defaults.set(true, forKey: migratedKey)
+    }
+
+    /// Bumps the similar-content algorithm version and wipes the cache the
+    /// first time the app launches under a newer ranker. Mirrors the
+    /// `invalidateStaleParserCache()` pattern above.
+    private func invalidateStaleSimilarContentCache() {
+        let key = "Intelligence.SimilarContent.AlgorithmVersion"
+        let current = 2   // v1: embedding-only; v2: hybrid embedding + entity Jaccard
+        let stored = UserDefaults.standard.integer(forKey: key)
+        if stored < current {
+            try? invalidateSimilarContentCache()
+            UserDefaults.standard.set(current, forKey: key)
         }
     }
 

--- a/Shared/Localizable.xcstrings
+++ b/Shared/Localizable.xcstrings
@@ -16443,60 +16443,32 @@
         "zh-Hant": { "stringUnit": { "state": "translated", "value": "洞察與智慧" } }
       }
     },
-    "Settings.SimilarContent": {
+    "Settings.ContentInsights": {
       "extractionState": "manual",
       "localizations": {
-        "de": { "stringUnit": { "state": "translated", "value": "Ähnliche Inhalte" } },
-        "en": { "stringUnit": { "state": "translated", "value": "Similar Content" } },
-        "fr": { "stringUnit": { "state": "translated", "value": "Contenu similaire" } },
-        "it": { "stringUnit": { "state": "translated", "value": "Contenuti simili" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "類似コンテンツ" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "유사한 콘텐츠" } },
-        "vi": { "stringUnit": { "state": "translated", "value": "Nội dung tương tự" } },
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "相似内容" } },
-        "zh-Hant": { "stringUnit": { "state": "translated", "value": "相似內容" } }
+        "de": { "stringUnit": { "state": "translated", "value": "Inhalts-Insights" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Content Insights" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Analyse de contenu" } },
+        "it": { "stringUnit": { "state": "translated", "value": "Approfondimenti contenuto" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "コンテンツインサイト" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "콘텐츠 인사이트" } },
+        "vi": { "stringUnit": { "state": "translated", "value": "Phân tích nội dung" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "内容洞察" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "內容洞察" } }
       }
     },
-    "Settings.SimilarContent.Footer": {
+    "Settings.ContentInsights.Footer": {
       "extractionState": "manual",
       "localizations": {
-        "de": { "stringUnit": { "state": "translated", "value": "Zeigt semantisch ähnliche Artikel aus anderen Feeds beim Lesen eines Artikels an." } },
-        "en": { "stringUnit": { "state": "translated", "value": "Show semantically similar articles from other feeds when reading an article." } },
-        "fr": { "stringUnit": { "state": "translated", "value": "Afficher des articles similaires d’autres flux lors de la lecture d’un article." } },
-        "it": { "stringUnit": { "state": "translated", "value": "Mostra articoli semanticamente simili da altri feed durante la lettura di un articolo." } },
-        "ja": { "stringUnit": { "state": "translated", "value": "記事を読んでいるときに、他のフィードから意味的に類似した記事を表示します。" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "기사를 읽을 때 다른 피드에서 의미적으로 유사한 기사를 표시합니다." } },
-        "vi": { "stringUnit": { "state": "translated", "value": "Hiển thị các bài viết tương tự về mặt ngữ nghĩa từ các nguồn cấp khác khi đọc bài." } },
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "阅读文章时，显示来自其他订阅源的语义相似文章。" } },
-        "zh-Hant": { "stringUnit": { "state": "translated", "value": "閱讀文章時，顯示來自其他訂閱源的語意相似文章。" } }
-      }
-    },
-    "Settings.TopicsPeople": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": { "stringUnit": { "state": "translated", "value": "Themen & Personen" } },
-        "en": { "stringUnit": { "state": "translated", "value": "Topics & People" } },
-        "fr": { "stringUnit": { "state": "translated", "value": "Sujets et personnes" } },
-        "it": { "stringUnit": { "state": "translated", "value": "Argomenti e persone" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "トピックと人物" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "주제 및 인물" } },
-        "vi": { "stringUnit": { "state": "translated", "value": "Chủ đề và Nhân vật" } },
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "话题与人物" } },
-        "zh-Hant": { "stringUnit": { "state": "translated", "value": "話題與人物" } }
-      }
-    },
-    "Settings.TopicsPeople.Footer": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": { "stringUnit": { "state": "translated", "value": "Themen, Organisationen und Personen aus Artikeln extrahieren. Im Suchtab durchsuchen." } },
-        "en": { "stringUnit": { "state": "translated", "value": "Extract topics, organizations, and people from articles. Browse them in the Search tab." } },
-        "fr": { "stringUnit": { "state": "translated", "value": "Extraire des sujets, organisations et personnes des articles. Parcourez-les dans l’onglet Recherche." } },
-        "it": { "stringUnit": { "state": "translated", "value": "Estrai argomenti, organizzazioni e persone dagli articoli. Esplorali nella scheda Cerca." } },
-        "ja": { "stringUnit": { "state": "translated", "value": "記事からトピック、組織、人物を抽出します。検索タブで閲覧できます。" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "기사에서 주제, 조직, 인물을 추출합니다. 검색 탭에서 찾아보세요." } },
-        "vi": { "stringUnit": { "state": "translated", "value": "Trích xuất chủ đề, tổ chức và nhân vật từ bài viết. Duyệt chúng trong tab Tìm kiếm." } },
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "从文章中提取话题、组织和人物。在搜索标签页中浏览。" } },
-        "zh-Hant": { "stringUnit": { "state": "translated", "value": "從文章中擷取話題、組織和人物。在搜尋標籤中瀏覽。" } }
+        "de": { "stringUnit": { "state": "translated", "value": "Ähnliche Artikel anzeigen, Themen, Organisationen und Personen aus Artikeln extrahieren. Im Suchtab durchsuchen." } },
+        "en": { "stringUnit": { "state": "translated", "value": "Show similar articles, extract topics, organizations, and people from articles. Browse them in the Search tab." } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Afficher des articles similaires, extraire des sujets, organisations et personnes des articles. Parcourez-les dans l’onglet Recherche." } },
+        "it": { "stringUnit": { "state": "translated", "value": "Mostra articoli simili, estrai argomenti, organizzazioni e persone dagli articoli. Esplorali nella scheda Cerca." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "類似記事を表示し、記事からトピック、組織、人物を抽出します。検索タブで閲覧できます。" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "유사한 기사를 표시하고, 기사에서 주제, 조직, 인물을 추출합니다. 검색 탭에서 찾아보세요." } },
+        "vi": { "stringUnit": { "state": "translated", "value": "Hiển thị bài viết tương tự, trích xuất chủ đề, tổ chức và nhân vật từ bài viết. Duyệt chúng trong tab Tìm kiếm." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "显示相似文章，从文章中提取话题、组织和人物。在搜索标签页中浏览。" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "顯示相似文章，從文章中擷取話題、組織和人物。在搜尋標籤中瀏覽。" } }
       }
     },
     "Settings.Section.ReadingAnalytics": {

--- a/Shared/NLP/NLPProcessor.swift
+++ b/Shared/NLP/NLPProcessor.swift
@@ -8,6 +8,18 @@ nonisolated enum NLPProcessor {
     static let logger = Logger(subsystem: "com.tsubuzaki.SakuraRSS", category: "NLP")
     #endif
 
+    // MARK: - Hybrid Scoring Tunables
+
+    /// Weight applied to the normalized embedding similarity term in the
+    /// hybrid ranker. The two weights should sum to 1.0.
+    static let hybridEmbeddingWeight: Double = 0.65
+    /// Weight applied to the entity Jaccard overlap term in the hybrid
+    /// ranker. Ignored when the source article has no entities.
+    static let hybridEntityWeight: Double = 0.35
+    /// Cosine-distance ceiling returned by `NLEmbedding.distance`. Used to
+    /// normalize distances to a [0, 1] similarity in the hybrid formula.
+    static let maxEmbeddingDistance: Double = 2.0
+
     struct EntityResult {
         let name: String
         let type: String
@@ -86,14 +98,28 @@ nonisolated enum NLPProcessor {
         return average
     }
 
-    // MARK: - Similarity via NLEmbedding
+    // MARK: - Similarity via NLEmbedding + Entity Overlap
 
-    static func findSimilarArticles(
+    /// Ranks `candidates` by a hybrid score that blends normalized
+    /// `NLEmbedding` sentence-embedding similarity with entity Jaccard
+    /// overlap. See `hybridEmbeddingWeight` / `hybridEntityWeight`.
+    ///
+    /// - Parameters:
+    ///   - article: Source article being viewed.
+    ///   - sourceEntities: Lowercased entity names for the source article.
+    ///     Pass an empty set to fall back to embedding-only scoring.
+    ///   - candidates: Candidate articles paired with their lowercased
+    ///     entity sets. Caller is expected to batch-load entities so this
+    ///     function stays allocation-light.
+    ///   - maxResults: Maximum number of ranked matches to return.
+    ///   - minimumScore: Matches below this blended score are dropped.
+    static func findSimilarArticlesHybrid(
         to article: Article,
-        candidates: [Article],
+        sourceEntities: Set<String>,
+        candidates: [(article: Article, entities: Set<String>)],
         maxResults: Int = 10,
-        maximumDistance: Double = 1.0
-    ) async -> [(articleID: Int64, distance: Double)] {
+        minimumScore: Double = 0.35
+    ) async -> [(articleID: Int64, score: Double)] {
         let sourceText = articleText(article)
         guard !sourceText.isEmpty else { return [] }
 
@@ -104,42 +130,63 @@ nonisolated enum NLPProcessor {
             ?? NLEmbedding.sentenceEmbedding(for: .english)
         guard let embedding else {
             #if DEBUG
-            logger.debug("findSimilarArticles: no embedding available for language \(language.rawValue)")
+            logger.debug("findSimilarArticlesHybrid: no embedding available for language \(language.rawValue)")
             #endif
             return []
         }
 
+        let hasSourceEntities = !sourceEntities.isEmpty
+        let embeddingWeight = hasSourceEntities ? hybridEmbeddingWeight : 1.0
+        let entityWeight = hasSourceEntities ? hybridEntityWeight : 0.0
+
         #if DEBUG
-        logger.debug("findSimilarArticles: comparing article \(article.id) against \(candidates.count) candidates (lang=\(language.rawValue))")
+        logger.debug("findSimilarArticlesHybrid: comparing article \(article.id) against \(candidates.count) candidates (lang=\(language.rawValue), sourceEntities=\(sourceEntities.count))")
         #endif
 
         // NLEmbedding is not thread-safe — process serially.
-        var scored: [(articleID: Int64, distance: Double)] = []
+        var scored: [(articleID: Int64, score: Double)] = []
         scored.reserveCapacity(candidates.count)
         for candidate in candidates {
-            let candidateText = articleText(candidate)
+            let candidateText = articleText(candidate.article)
             guard !candidateText.isEmpty else { continue }
+
             let distance = embedding.distance(between: sourceText, and: candidateText)
-            if distance <= maximumDistance {
-                scored.append((articleID: candidate.id, distance: distance))
+            let normalized = min(max(distance / maxEmbeddingDistance, 0.0), 1.0)
+            let embeddingSim = 1.0 - normalized
+
+            let entityJaccard: Double
+            if hasSourceEntities && !candidate.entities.isEmpty {
+                let intersectionCount = sourceEntities.intersection(candidate.entities).count
+                let unionCount = sourceEntities.union(candidate.entities).count
+                entityJaccard = unionCount == 0 ? 0.0 : Double(intersectionCount) / Double(unionCount)
+            } else {
+                entityJaccard = 0.0
+            }
+
+            let score = embeddingWeight * embeddingSim + entityWeight * entityJaccard
+            if score >= minimumScore {
+                scored.append((articleID: candidate.article.id, score: score))
             }
         }
 
-        let sorted = scored.sorted { $0.distance < $1.distance }
+        let sorted = scored.sorted { $0.score > $1.score }
         let results = Array(sorted.prefix(maxResults))
         #if DEBUG
-        logger.debug("findSimilarArticles: returning \(results.count) matches (best distance: \(String(format: "%.3f", results.first?.distance ?? -1)))")
+        logger.debug("findSimilarArticlesHybrid: returning \(results.count) matches (best score: \(String(format: "%.3f", results.first?.score ?? -1)))")
         #endif
         return results
     }
 
+    /// Combined text fed into the sentence embedding. Title is repeated so
+    /// it dominates summary content in the resulting vector — short, cheap,
+    /// and noticeably helpful for headline-driven feeds.
     private static func articleText(_ article: Article) -> String {
         let title = article.title
         let summary = article.summary ?? ""
         if summary.isEmpty {
             return title
         }
-        return title + " " + summary
+        return title + " " + title + " " + summary
     }
 }
 


### PR DESCRIPTION
## Summary
This PR consolidates the separate "Similar Content" and "Topics & People" NLP feature toggles into a single "Content Insights" setting, and upgrades the article similarity algorithm from embedding-only to a hybrid approach that blends sentence embeddings with entity Jaccard overlap.

## Key Changes

### Settings Unification
- Merged `Intelligence.SimilarContent.Enabled` and `Intelligence.TopicsPeople.Enabled` into a single `Intelligence.ContentInsights.Enabled` toggle
- Updated all UI references in `OnDeviceIntelligenceSettingsView`, `SearchView`, and `iPadSidebarView`
- Added migration logic in `DatabaseManager` to preserve user preferences when upgrading
- Updated localization strings across 9 languages to reflect the unified setting

### Hybrid Similarity Ranking
- Replaced `findSimilarArticles()` with `findSimilarArticlesHybrid()` in `NLPProcessor`
- New algorithm combines:
  - **Embedding similarity** (65% weight): Normalized cosine distance via `NLEmbedding`
  - **Entity overlap** (35% weight): Jaccard similarity of extracted named entities
- Expanded retrieval window from ±48 hours / 60 articles to ±7 days / 300 articles to give the reranker better recall
- Changed scoring from distance-based (lower-is-better) to score-based (higher-is-better) with configurable `minimumScore` threshold
- Added batch entity loading to avoid N+1 queries during ranking

### Processing Pipeline Simplification
- Unified `NLPProcessingCoordinator.processArticleSync()` to always extract both sentiment and entities when Content Insights is enabled
- Removed conditional branching for individual features since they now run together
- Ensured source article entities are extracted on-demand in `computeRawMatches()` if not already processed

### Database & Caching
- Added `entities(forArticleIDs:)` batch query method for efficient entity lookup
- Implemented `invalidateSimilarContentCache()` to clear stale results on algorithm version bumps
- Bumped similarity cache algorithm version from 1 to 2 to trigger automatic invalidation on first launch

### Documentation Updates
- Updated docstrings to reflect the hybrid ranking approach and new retrieval strategy
- Clarified that title is repeated in the embedding text to emphasize headlines
- Removed references to the old 48-hour window and embedding-only methodology

## Implementation Details
- The hybrid score formula: `embeddingWeight × embeddingSim + entityWeight × entityJaccard`
- Entity names are lowercased for case-insensitive matching
- Embedding distance is normalized to [0, 1] using a ceiling of 2.0
- Results are sorted by score descending and limited to `maxResults` (default 8)
- Backward compatibility maintained through UserDefaults migration on first launch

https://claude.ai/code/session_011YVw4AAi6AZUPpqBECGyxb