### PR TITLE
Fix feed refresh and favicon updates for newly added feeds

### DIFF
--- a/SakuraRSS/Classes/Feed Manager/FeedManager.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager.swift
@@ -56,6 +56,11 @@ final class FeedManager {
         }
     }
 
+    /// Notify the UI that favicons may have changed so views re-fetch them.
+    func notifyFaviconChange() {
+        faviconRevision += 1
+    }
+
     // MARK: - Feed CRUD
 
     func addFeed(url: String, title: String, siteURL: String,
@@ -187,6 +192,35 @@ final class FeedManager {
             }
         }
         await loadFromDatabaseInBackground()
+    }
+
+    /// Refreshes feeds that have never been fetched (e.g. added by the share
+    /// extension while the main app was in the background).  Also generates
+    /// acronym icons and fetches favicons for those feeds.
+    func refreshUnfetchedFeeds() async {
+        let unfetched = feeds.filter { $0.lastFetched == nil }
+        guard !unfetched.isEmpty else { return }
+
+        // Generate acronym icons the share extension doesn't create.
+        for feed in unfetched {
+            generateAcronymIcon(feedID: feed.id, title: feed.title)
+        }
+
+        // Fetch articles for the new feeds.
+        await withTaskGroup(of: Void.self) { group in
+            for feed in unfetched {
+                group.addTask {
+                    try? await self.refreshFeed(feed, reloadData: false)
+                }
+            }
+        }
+        await loadFromDatabaseInBackground()
+
+        // Clear any stale favicon failures and notify the UI so
+        // FeedRowViews re-fetch their icons.
+        let entries = unfetched.map { ($0.domain, $0.siteURL as String?) }
+        await FaviconCache.shared.clearFailedLookups(for: entries)
+        faviconRevision += 1
     }
 
     func refreshAllFeedsAndFavicons() async {

--- a/SakuraRSS/Views/App.swift
+++ b/SakuraRSS/Views/App.swift
@@ -40,6 +40,9 @@ struct SakuraRSSApp: App {
                     feedManager.loadFromDatabase()
                     feedManager.updateBadgeCount()
                     WidgetCenter.shared.reloadAllTimelines()
+                    Task {
+                        await feedManager.refreshUnfetchedFeeds()
+                    }
                 }
                 .onChange(of: backgroundRefreshEnabled) {
                     scheduleAppRefresh()

--- a/SakuraRSS/Views/Feeds/FeedsListPage.swift
+++ b/SakuraRSS/Views/Feeds/FeedsListPage.swift
@@ -94,6 +94,9 @@ struct FeedsListPage: View {
                 onNavigateToFeed?(feed)
                 Task {
                     try? await feedManager.refreshFeed(feed)
+                    // Pre-warm the favicon cache so the feed row picks it up.
+                    _ = await FaviconCache.shared.favicon(for: feed)
+                    feedManager.notifyFaviconChange()
                 }
             }
         } content: {

--- a/Shared/Favicon Cache/FaviconCache.swift
+++ b/Shared/Favicon Cache/FaviconCache.swift
@@ -71,6 +71,15 @@ actor FaviconCache {
         try? FileManager.default.createDirectory(at: cacheDirectory, withIntermediateDirectories: true)
     }
 
+    /// Removes specific entries from the failed-lookups set so they will be
+    /// retried on the next request.
+    func clearFailedLookups(for entries: [(domain: String, siteURL: String?)]) {
+        for entry in entries {
+            let cacheKey = Self.cacheKey(domain: entry.domain, siteURL: entry.siteURL)
+            failedLookups.remove(cacheKey)
+        }
+    }
+
     nonisolated static func cacheKey(domain: String, siteURL: String?) -> String {
         guard isProfileBased(domain: domain, siteURL: siteURL),
               let siteURL = siteURL, let url = URL(string: siteURL) else {


### PR DESCRIPTION
## Summary

- Feeds added via the share extension are now automatically refreshed (articles fetched, acronym icons generated, favicons loaded) when returning to the main app
- Favicons for freshly added feeds (especially YouTube channels and other profile-based feeds) now reliably appear in the UI by pre-warming the cache and bumping `faviconRevision`
- Added `FaviconCache.clearFailedLookups(for:)` to allow targeted retry of favicon fetches that previously failed

## Details

**Share extension feed refresh:** The `willEnterForeground` handler called `loadFromDatabase()` which picked up new feed rows from the shared database, but never fetched their articles, generated acronym icons, or fetched favicons. The new `refreshUnfetchedFeeds()` method detects feeds with no `lastFetched` date and handles all of this automatically.

**Favicon updates:** `FeedRowView` loads favicons via `.task` (runs once on appear) and `.onChange(of: faviconRevision)`. However, `faviconRevision` was only bumped during the manual "Refresh All Feeds and Favicons" action — never during normal feed addition. For profile-based feeds like YouTube channels (which require scraping the channel page for `og:image`), if the initial fetch was slow or failed, the favicon would stay nil with no retry mechanism. Now `faviconRevision` is bumped after adding a feed in-app and after refreshing share-extension feeds on foreground return.

## Test plan

- [ ] Add a feed via the share sheet, return to the main app, and verify articles are fetched and the favicon appears
- [ ] Add a YouTube channel feed in-app and verify the channel avatar appears (not just the acronym icon)
- [ ] Add a regular RSS feed in-app and verify the favicon loads correctly
- [ ] Verify existing feeds are not affected by the foreground handler changes (no unnecessary re-fetches for feeds that already have `lastFetched` set)

https://claude.ai/code/session_01S8d7YAN16MTYXTkeBqhgGo