### PR TITLE
Add Spotlight indexing for articles to make them searchable system-wide

### DIFF
--- a/SakuraRSS/Classes/Feed Manager/FeedManager+InstagramProfile.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+InstagramProfile.swift
@@ -59,6 +59,8 @@ extension FeedManager {
         try await Task.detached {
             try database.insertArticles(feedID: feed.id, articles: postTuples)
             try database.updateFeedLastFetched(id: feed.id, date: Date())
+            let articlesToIndex = try database.articles(forFeedID: feed.id, limit: postTuples.count)
+            SpotlightIndexer.indexArticles(articlesToIndex, feedTitle: feedTitle)
         }.value
 
         // Cache favicon and update feed details

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+XProfile.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+XProfile.swift
@@ -59,6 +59,8 @@ extension FeedManager {
         try await Task.detached {
             try database.insertArticles(feedID: feed.id, articles: tweetTuples)
             try database.updateFeedLastFetched(id: feed.id, date: Date())
+            let articlesToIndex = try database.articles(forFeedID: feed.id, limit: tweetTuples.count)
+            SpotlightIndexer.indexArticles(articlesToIndex, feedTitle: feedTitle)
         }.value
 
         // Cache favicon and update feed details

--- a/SakuraRSS/Classes/Feed Manager/FeedManager.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager.swift
@@ -1,3 +1,4 @@
+import CoreSpotlight
 import Foundation
 import SwiftUI
 @preconcurrency import UserNotifications
@@ -74,7 +75,9 @@ final class FeedManager {
     }
 
     func deleteFeed(_ feed: Feed) throws {
+        let articleIDs = (try? database.articles(forFeedID: feed.id)).map { $0.map(\.id) } ?? []
         try database.deleteFeed(id: feed.id)
+        SpotlightIndexer.removeArticles(feedID: feed.id, articleIDs: articleIDs)
         loadFromDatabase()
     }
 
@@ -135,6 +138,10 @@ final class FeedManager {
 
             try database.insertArticles(feedID: feed.id, articles: articleTuples)
 
+            let feedTitleForIndex = parsed.title.isEmpty ? feed.title : parsed.title
+            let articlesToIndex = try database.articles(forFeedID: feed.id, limit: articleTuples.count)
+            SpotlightIndexer.indexArticles(articlesToIndex, feedTitle: feedTitleForIndex)
+
             if parsed.isPodcast && !feed.isPodcast {
                 try database.updateFeedIsPodcast(id: feed.id, isPodcast: true)
             } else if !parsed.isPodcast && feed.isPodcast {
@@ -153,6 +160,7 @@ final class FeedManager {
     func deleteAllArticlesAndRefresh() async {
         let database = database
         _ = try? await Task.detached { try database.deleteAllArticles() }.value
+        SpotlightIndexer.removeAllArticles()
         await loadFromDatabaseInBackground()
         await refreshAllFeeds()
     }
@@ -171,6 +179,7 @@ final class FeedManager {
             }
             try database.vacuum()
         }.value
+        SpotlightIndexer.removeAllArticles()
         await loadFromDatabaseInBackground()
     }
 

--- a/SakuraRSS/Views/App.swift
+++ b/SakuraRSS/Views/App.swift
@@ -1,3 +1,4 @@
+import CoreSpotlight
 import SwiftUI
 import BackgroundTasks
 import StoreKit
@@ -49,6 +50,11 @@ struct SakuraRSSApp: App {
                 }
                 .onOpenURL { url in
                     handleOpenURL(url)
+                }
+                .onContinueUserActivity(CSSearchableItemActionType) { activity in
+                    if let articleID = SpotlightIndexer.articleID(from: activity) {
+                        pendingArticleID = articleID
+                    }
                 }
         }
     }

--- a/Shared/SpotlightIndexer.swift
+++ b/Shared/SpotlightIndexer.swift
@@ -10,33 +10,43 @@ enum SpotlightIndexer {
     static func indexArticles(_ articles: [Article], feedTitle: String?) {
         guard !articles.isEmpty else { return }
 
-        let items = articles.compactMap { article -> CSSearchableItem? in
-            let attributes = CSSearchableItemAttributeSet(contentType: .text)
-            attributes.title = article.title
-            attributes.contentDescription = article.summary ?? article.content.flatMap { stripHTML($0) }
-            if let author = article.author {
-                attributes.authorNames = [author]
-            }
-            if let date = article.publishedDate {
-                attributes.contentCreationDate = date
-            }
-            if let urlString = URL(string: article.url) {
-                attributes.url = urlString
-            }
-            if let imageURLString = article.imageURL, let imageURL = URL(string: imageURLString) {
-                attributes.thumbnailURL = imageURL
-            }
-            if let feedTitle {
-                attributes.containerTitle = feedTitle
-            }
-            return CSSearchableItem(
-                uniqueIdentifier: uniqueIdentifier(for: article.id),
-                domainIdentifier: domainIdentifier,
-                attributeSet: attributes
+        let entries = articles.map { article in
+            IndexEntry(
+                identifier: uniqueIdentifier(for: article.id),
+                title: article.title,
+                contentDescription: article.summary ?? article.content.flatMap { stripHTML($0) },
+                author: article.author,
+                publishedDate: article.publishedDate,
+                url: URL(string: article.url),
+                thumbnailURL: article.imageURL.flatMap { URL(string: $0) },
+                feedTitle: feedTitle
             )
         }
 
-        CSSearchableIndex.default().indexSearchableItems(items)
+        Task { @MainActor in
+            let items = entries.map { entry -> CSSearchableItem in
+                let attributes = CSSearchableItemAttributeSet(contentType: .text)
+                attributes.title = entry.title
+                attributes.contentDescription = entry.contentDescription
+                if let author = entry.author {
+                    attributes.authorNames = [author]
+                }
+                if let date = entry.publishedDate {
+                    attributes.contentCreationDate = date
+                }
+                attributes.url = entry.url
+                attributes.thumbnailURL = entry.thumbnailURL
+                if let feedTitle = entry.feedTitle {
+                    attributes.containerTitle = feedTitle
+                }
+                return CSSearchableItem(
+                    uniqueIdentifier: entry.identifier,
+                    domainIdentifier: domainIdentifier,
+                    attributeSet: attributes
+                )
+            }
+            CSSearchableIndex.default().indexSearchableItems(items)
+        }
     }
 
     // MARK: - Removal
@@ -97,4 +107,15 @@ enum SpotlightIndexer {
         ).trimmingCharacters(in: .whitespacesAndNewlines)
         return text.isEmpty ? nil : String(text.prefix(300))
     }
+}
+
+private struct IndexEntry: Sendable {
+    let identifier: String
+    let title: String
+    let contentDescription: String?
+    let author: String?
+    let publishedDate: Date?
+    let url: URL?
+    let thumbnailURL: URL?
+    let feedTitle: String?
 }

--- a/Shared/SpotlightIndexer.swift
+++ b/Shared/SpotlightIndexer.swift
@@ -1,0 +1,100 @@
+import CoreSpotlight
+import Foundation
+
+enum SpotlightIndexer {
+
+    static let domainIdentifier = "com.tsubuzaki.SakuraRSS.article"
+
+    // MARK: - Indexing
+
+    static func indexArticles(_ articles: [Article], feedTitle: String?) {
+        guard !articles.isEmpty else { return }
+
+        let items = articles.compactMap { article -> CSSearchableItem? in
+            let attributes = CSSearchableItemAttributeSet(contentType: .text)
+            attributes.title = article.title
+            attributes.contentDescription = article.summary ?? article.content.flatMap { stripHTML($0) }
+            if let author = article.author {
+                attributes.authorNames = [author]
+            }
+            if let date = article.publishedDate {
+                attributes.contentCreationDate = date
+            }
+            if let urlString = URL(string: article.url) {
+                attributes.url = urlString
+            }
+            if let imageURLString = article.imageURL, let imageURL = URL(string: imageURLString) {
+                attributes.thumbnailURL = imageURL
+            }
+            if let feedTitle {
+                attributes.containerTitle = feedTitle
+            }
+            return CSSearchableItem(
+                uniqueIdentifier: uniqueIdentifier(for: article.id),
+                domainIdentifier: domainIdentifier,
+                attributeSet: attributes
+            )
+        }
+
+        CSSearchableIndex.default().indexSearchableItems(items)
+    }
+
+    // MARK: - Removal
+
+    static func removeArticle(id: Int64) {
+        CSSearchableIndex.default().deleteSearchableItems(
+            withIdentifiers: [uniqueIdentifier(for: id)]
+        )
+    }
+
+    static func removeArticles(feedID: Int64, articleIDs: [Int64]) {
+        guard !articleIDs.isEmpty else { return }
+        let identifiers = articleIDs.map { uniqueIdentifier(for: $0) }
+        CSSearchableIndex.default().deleteSearchableItems(withIdentifiers: identifiers)
+    }
+
+    static func removeAllArticles() {
+        CSSearchableIndex.default().deleteSearchableItems(
+            withDomainIdentifiers: [domainIdentifier]
+        )
+    }
+
+    // MARK: - Deep Link Parsing
+
+    static func articleID(from userActivity: NSUserActivity) -> Int64? {
+        guard let identifier = userActivity.userInfo?[CSSearchableItemActivityIdentifier] as? String
+        else { return nil }
+        return parseArticleID(from: identifier)
+    }
+
+    // MARK: - Helpers
+
+    static func uniqueIdentifier(for articleID: Int64) -> String {
+        "article.\(articleID)"
+    }
+
+    private static func parseArticleID(from identifier: String) -> Int64? {
+        guard identifier.hasPrefix("article.") else { return nil }
+        return Int64(identifier.dropFirst("article.".count))
+    }
+
+    private static func stripHTML(_ html: String) -> String? {
+        var text = html.replacingOccurrences(
+            of: "<[^>]+>",
+            with: " ",
+            options: .regularExpression
+        )
+        text = text.replacingOccurrences(of: "&amp;", with: "&")
+        text = text.replacingOccurrences(of: "&lt;", with: "<")
+        text = text.replacingOccurrences(of: "&gt;", with: ">")
+        text = text.replacingOccurrences(of: "&quot;", with: "\"")
+        text = text.replacingOccurrences(of: "&#39;", with: "'")
+        text = text.replacingOccurrences(of: "&nbsp;", with: " ")
+        text = text.replacingOccurrences(
+            of: "\\s+",
+            with: " ",
+            options: .regularExpression
+        ).trimmingCharacters(in: .whitespacesAndNewlines)
+        return text.isEmpty ? nil : String(text.prefix(300))
+    }
+}

--- a/Shared/SpotlightIndexer.swift
+++ b/Shared/SpotlightIndexer.swift
@@ -1,7 +1,7 @@
 import CoreSpotlight
 import Foundation
 
-enum SpotlightIndexer {
+nonisolated enum SpotlightIndexer {
 
     static let domainIdentifier = "com.tsubuzaki.SakuraRSS.article"
 
@@ -52,21 +52,26 @@ enum SpotlightIndexer {
     // MARK: - Removal
 
     static func removeArticle(id: Int64) {
-        CSSearchableIndex.default().deleteSearchableItems(
-            withIdentifiers: [uniqueIdentifier(for: id)]
-        )
+        let identifiers = [uniqueIdentifier(for: id)]
+        Task { @MainActor in
+            CSSearchableIndex.default().deleteSearchableItems(withIdentifiers: identifiers)
+        }
     }
 
     static func removeArticles(feedID: Int64, articleIDs: [Int64]) {
         guard !articleIDs.isEmpty else { return }
         let identifiers = articleIDs.map { uniqueIdentifier(for: $0) }
-        CSSearchableIndex.default().deleteSearchableItems(withIdentifiers: identifiers)
+        Task { @MainActor in
+            CSSearchableIndex.default().deleteSearchableItems(withIdentifiers: identifiers)
+        }
     }
 
     static func removeAllArticles() {
-        CSSearchableIndex.default().deleteSearchableItems(
-            withDomainIdentifiers: [domainIdentifier]
-        )
+        Task { @MainActor in
+            CSSearchableIndex.default().deleteSearchableItems(
+                withDomainIdentifiers: [domainIdentifier]
+            )
+        }
     }
 
     // MARK: - Deep Link Parsing


### PR DESCRIPTION
Indexes article title, summary, author, date, and thumbnail via
CoreSpotlight after each feed refresh. Tapping a Spotlight result
deep-links into the article. Articles are removed from the index
when feeds are deleted or articles are purged.

https://claude.ai/code/session_018xrS2Zc6u298s44grxn6zn