### PR TITLE
Fix transcript scrolling and spacing

### DIFF
--- a/SakuraRSS/Views/Shared/Podcast Episode/PodcastEpisodeView.swift
+++ b/SakuraRSS/Views/Shared/Podcast Episode/PodcastEpisodeView.swift
@@ -246,9 +246,6 @@ struct PodcastEpisodeView: View {
             .padding(.vertical)
         }
         .onScrollPhaseChange { _, newPhase in
-            // When the user starts interacting with the scroll view while the
-            // transcript is showing, disable auto-follow so the transcript
-            // doesn't snap back to the active segment while they're reading.
             if showingTranscript,
                isTranscriptAutoScrolling,
                newPhase == .interacting || newPhase == .tracking {

--- a/SakuraRSS/Views/Shared/Podcast Episode/PodcastEpisodeView.swift
+++ b/SakuraRSS/Views/Shared/Podcast Episode/PodcastEpisodeView.swift
@@ -245,6 +245,16 @@ struct PodcastEpisodeView: View {
             }
             .padding(.vertical)
         }
+        .onScrollPhaseChange { _, newPhase in
+            // When the user starts interacting with the scroll view while the
+            // transcript is showing, disable auto-follow so the transcript
+            // doesn't snap back to the active segment while they're reading.
+            if showingTranscript,
+               isTranscriptAutoScrolling,
+               newPhase == .interacting || newPhase == .tracking {
+                isTranscriptAutoScrolling = false
+            }
+        }
         .overlay(alignment: .bottom) {
             followAlongOverlay(scrollProxy: scrollProxy)
         }

--- a/SakuraRSS/Views/Shared/Podcast Episode/TranscriptView.swift
+++ b/SakuraRSS/Views/Shared/Podcast Episode/TranscriptView.swift
@@ -32,23 +32,16 @@ struct TranscriptView: View {
     }
 
     var body: some View {
-        // Render segments as continuous prose — one flowing paragraph — rather
-        // than a list of timestamped blocks. Each segment is still tappable to
-        // seek, and the active segment is emphasized with weight + color.
-        LazyVStack(alignment: .leading, spacing: 0) {
+        // Render segments as a readable list of tappable lines. Each segment
+        // is tappable to seek, and the active segment is emphasized with
+        // weight + color.
+        LazyVStack(alignment: .leading, spacing: 10) {
             ForEach(segments) { segment in
                 segmentText(segment)
                     .id(segment.id)
             }
         }
         .padding(.vertical, 12)
-        .simultaneousGesture(
-            DragGesture(minimumDistance: 8).onChanged { _ in
-                if isAutoScrolling {
-                    isAutoScrolling = false
-                }
-            }
-        )
         .onChange(of: activeSegmentID) { _, newID in
             guard isAutoScrolling, let newID else { return }
             if newID != lastActiveID {
@@ -63,8 +56,9 @@ struct TranscriptView: View {
     @ViewBuilder
     private func segmentText(_ segment: TranscriptSegment) -> some View {
         let isActive = segment.id == activeSegmentID
-        Text(segment.text + " ")
+        Text(segment.text)
             .font(.body)
+            .lineSpacing(4)
             .fontWeight(isActive ? .semibold : .regular)
             .foregroundStyle(isActive ? Color.primary : Color.primary.opacity(0.55))
             .frame(maxWidth: .infinity, alignment: .leading)


### PR DESCRIPTION
The transcript view's auto-follow was snapping the scroll back to the
active segment every few seconds, making it feel like scrolling was
broken. Switch the user-scroll detection from an unreliable
simultaneousGesture(DragGesture) on the inner LazyVStack to
onScrollPhaseChange on the outer ScrollView, which fires reliably when
the user actually drags the scroll view.

Also add vertical spacing between segments and line spacing within
segments so the transcript is actually readable.

https://claude.ai/code/session_01R1YsvRRyu1MhKSVm4EZdT5