### PR TITLE
Migrate cookie storage to Keychain-backed storage

### DIFF
--- a/SakuraRSS.xcodeproj/project.pbxproj
+++ b/SakuraRSS.xcodeproj/project.pbxproj
@@ -618,7 +618,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4;
+				MARKETING_VERSION = 1.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.SakuraRSS;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -661,7 +661,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4;
+				MARKETING_VERSION = 1.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.SakuraRSS;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -696,7 +696,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.4;
+				MARKETING_VERSION = 1.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.tsubuzaki.SakuraRSS.Add-Feed";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -732,7 +732,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.4;
+				MARKETING_VERSION = 1.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.tsubuzaki.SakuraRSS.Add-Feed";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -769,7 +769,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.4;
+				MARKETING_VERSION = 1.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.SakuraRSS.Widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -806,7 +806,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.4;
+				MARKETING_VERSION = 1.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.SakuraRSS.Widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+InstagramProfile.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+InstagramProfile.swift
@@ -9,12 +9,24 @@ extension FeedManager {
     /// Also used by `FaviconProgressBadge` to size the cooldown pie.
     static let instagramRefreshInterval: TimeInterval = 30 * 60
 
+    /// Returns a jittered effective refresh interval.  A hard 30-minute
+    /// cadence is a strong automation signal on its own — real users do
+    /// not open the same profile on the tick.  We keep 30 min as the
+    /// floor and add up to ~10 min of upward jitter so consecutive
+    /// refreshes never fall on a fixed schedule.
+    private static func jitteredRefreshInterval() -> TimeInterval {
+        instagramRefreshInterval + TimeInterval.random(in: 0...(10 * 60))
+    }
+
     func refreshInstagramFeed(_ feed: Feed, reloadData: Bool = true) async throws {
-        // Skip if this feed was fetched less than 30 minutes ago to avoid rate limits
+        // Skip if this feed was fetched too recently to avoid rate limits.
+        // The cutoff is randomised on each check to avoid a perfectly
+        // periodic fetch cadence.
+        let effectiveInterval = Self.jitteredRefreshInterval()
         if let lastFetched = feed.lastFetched,
-           Date().timeIntervalSince(lastFetched) < Self.instagramRefreshInterval {
+           Date().timeIntervalSince(lastFetched) < effectiveInterval {
             #if DEBUG
-            let remaining = Self.instagramRefreshInterval - Date().timeIntervalSince(lastFetched)
+            let remaining = effectiveInterval - Date().timeIntervalSince(lastFetched)
             print("[InstagramProfile] Skipping refresh for @\(feed.title) — "
                   + "\(Int(remaining))s until next allowed fetch")
             #endif

--- a/SakuraRSS/Classes/Feed Manager/FeedManager.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager.swift
@@ -217,11 +217,14 @@ final class FeedManager {
     ///
     /// - Parameter skipAuthenticatedScrapers: When `true`, X and Instagram
     ///   profile feeds are skipped entirely.  Pass this from background
-    ///   refresh tasks: those scrapers rely on WKWebView-backed cookie
-    ///   warming and GraphQL query-ID fetching, neither of which is
-    ///   reliable in a headless `BGAppRefreshTask`.  Hitting the APIs
-    ///   from a locked device at a fixed cadence is also itself a strong
-    ///   bot-like signal, so we reserve those scrapes for foreground use.
+    ///   refresh tasks.  Instagram's cookies now live in Keychain and so
+    ///   are technically available in the background, but hitting the
+    ///   Instagram/X APIs from a locked device at a fixed scheduler
+    ///   cadence is itself a strong bot-like signal — a stronger signal
+    ///   than anything else in the request fingerprint — so those
+    ///   scrapes are reserved for foreground use.  X additionally still
+    ///   depends on WKWebView-backed cookie warming and a JS-bundle
+    ///   query-ID fetch that is unreliable in a `BGAppRefreshTask`.
     func refreshAllFeeds(skipAuthenticatedScrapers: Bool = false) async {
         await MainActor.run { isLoading = true }
         defer { Task { @MainActor in self.isLoading = false } }

--- a/SakuraRSS/Classes/Feed Manager/FeedManager.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager.swift
@@ -213,13 +213,25 @@ final class FeedManager {
         await loadFromDatabaseInBackground()
     }
 
-    func refreshAllFeeds() async {
+    /// Refreshes every feed.
+    ///
+    /// - Parameter skipAuthenticatedScrapers: When `true`, X and Instagram
+    ///   profile feeds are skipped entirely.  Pass this from background
+    ///   refresh tasks: those scrapers rely on WKWebView-backed cookie
+    ///   warming and GraphQL query-ID fetching, neither of which is
+    ///   reliable in a headless `BGAppRefreshTask`.  Hitting the APIs
+    ///   from a locked device at a fixed cadence is also itself a strong
+    ///   bot-like signal, so we reserve those scrapes for foreground use.
+    func refreshAllFeeds(skipAuthenticatedScrapers: Bool = false) async {
         await MainActor.run { isLoading = true }
         defer { Task { @MainActor in self.isLoading = false } }
 
         let currentFeeds = feeds
         await withTaskGroup(of: Void.self) { group in
             for feed in currentFeeds {
+                if skipAuthenticatedScrapers, feed.isXFeed || feed.isInstagramFeed {
+                    continue
+                }
                 group.addTask {
                     try? await self.refreshFeed(feed, reloadData: false)
                 }

--- a/SakuraRSS/Classes/Feed Manager/FeedManager.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager.swift
@@ -133,7 +133,7 @@ final class FeedManager {
             guard let url = URL(string: feed.url) else { return }
             let fetchURL = RedirectDomains.redirectedURL(url)
 
-            let (data, _) = try await URLSession.shared.data(from: fetchURL)
+            let (data, _) = try await URLSession.shared.data(for: .sakura(url: fetchURL))
             let parser = RSSParser()
             guard let parsed = parser.parse(data: data) else { return }
 

--- a/SakuraRSS/Classes/Feed Manager/FeedManager.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager.swift
@@ -217,14 +217,14 @@ final class FeedManager {
     ///
     /// - Parameter skipAuthenticatedScrapers: When `true`, X and Instagram
     ///   profile feeds are skipped entirely.  Pass this from background
-    ///   refresh tasks.  Instagram's cookies now live in Keychain and so
-    ///   are technically available in the background, but hitting the
+    ///   refresh tasks.  Both scrapers' cookies now live in Keychain and
+    ///   so are technically available in the background, but hitting the
     ///   Instagram/X APIs from a locked device at a fixed scheduler
     ///   cadence is itself a strong bot-like signal — a stronger signal
     ///   than anything else in the request fingerprint — so those
     ///   scrapes are reserved for foreground use.  X additionally still
-    ///   depends on WKWebView-backed cookie warming and a JS-bundle
-    ///   query-ID fetch that is unreliable in a `BGAppRefreshTask`.
+    ///   depends on a JS-bundle query-ID fetch that is unreliable in a
+    ///   `BGAppRefreshTask`.
     func refreshAllFeeds(skipAuthenticatedScrapers: Bool = false) async {
         await MainActor.run { isLoading = true }
         defer { Task { @MainActor in self.isLoading = false } }

--- a/SakuraRSS/Views/App.swift
+++ b/SakuraRSS/Views/App.swift
@@ -267,7 +267,14 @@ struct SakuraRSSApp: App {
 
         let refreshTask = Task {
             let manager = FeedManager()
-            await manager.refreshAllFeeds()
+            // Skip X and Instagram profile feeds in background refresh.
+            // Both scrapers depend on WKWebView-backed cookie warming
+            // (and X additionally on a JS-bundle query-ID fetch) that
+            // isn't reliable in a headless BGAppRefreshTask, and firing
+            // authenticated API calls from a locked device at a fixed
+            // cadence is itself a bot-like signal.  Those feeds refresh
+            // when the user actually opens the app instead.
+            await manager.refreshAllFeeds(skipAuthenticatedScrapers: true)
             await NLPProcessingCoordinator.processNewArticlesIfEnabled()
             manager.updateBadgeCount()
         }

--- a/SakuraRSS/Views/App.swift
+++ b/SakuraRSS/Views/App.swift
@@ -25,16 +25,22 @@ struct SakuraRSSApp: App {
                 .environment(feedManager)
                 .modifier(KeepScreenOnDuringPodcastWork())
                 .task {
-                    // Pre-warm the X and Instagram WKWebsiteDataStore
-                    // cookie stores so that the first feed refresh sees
-                    // valid session cookies.  On cold launch the cookie
-                    // store is otherwise empty until a WKWebView has
-                    // loaded a page from the domain.
+                    // Pre-warm the X WKWebsiteDataStore cookie store so
+                    // that the first feed refresh sees valid session
+                    // cookies.  On cold launch the cookie store is
+                    // otherwise empty until a WKWebView has loaded a
+                    // page from the domain.
+                    //
+                    // Instagram has migrated to Keychain-backed cookie
+                    // storage, so its cookies are always available
+                    // without any WebKit warming — we just run a
+                    // one-time migration for users upgrading from a
+                    // version that only stored cookies in WebKit.
                     if UserDefaults.standard.bool(forKey: "Labs.XProfileFeeds") {
                         await XProfileScraper.warmCookieStore()
                     }
                     if UserDefaults.standard.bool(forKey: "Labs.InstagramProfileFeeds") {
-                        await InstagramProfileScraper.warmCookieStore()
+                        await InstagramProfileScraper.migrateWebKitCookiesIfNeeded()
                     }
                     await feedManager.refreshAllFeeds()
                     UserDefaults.standard.set(false, forKey: "App.StartupInProgress")
@@ -115,9 +121,8 @@ struct SakuraRSSApp: App {
                     if UserDefaults.standard.bool(forKey: "Labs.XProfileFeeds") {
                         await XProfileScraper.fetchQueryIDsIfNeeded()
                     }
-                    if UserDefaults.standard.bool(forKey: "Labs.InstagramProfileFeeds") {
-                        await InstagramProfileScraper.warmCookieStore()
-                    }
+                    // Instagram cookies live in Keychain, which survives
+                    // the filesystem wipe above — no re-warming needed.
                     let entries = feedManager.feeds.map { ($0.domain, $0.siteURL as String?) }
                     await FaviconCache.shared.refreshFavicons(for: entries)
                 }

--- a/SakuraRSS/Views/App.swift
+++ b/SakuraRSS/Views/App.swift
@@ -268,15 +268,6 @@ struct SakuraRSSApp: App {
 
         let refreshTask = Task {
             let manager = FeedManager()
-            // Skip X and Instagram profile feeds in background refresh.
-            // Both scrapers' cookies now live in Keychain so they would
-            // technically be reachable from a BGAppRefreshTask, but
-            // firing authenticated API calls from a locked device at a
-            // fixed cadence is itself a bot-like signal — stronger than
-            // anything else in the request fingerprint.  X additionally
-            // depends on a JS-bundle query-ID fetch that isn't reliable
-            // in a headless BGAppRefreshTask.  Those feeds refresh when
-            // the user actually opens the app instead.
             await manager.refreshAllFeeds(skipAuthenticatedScrapers: true)
             await NLPProcessingCoordinator.processNewArticlesIfEnabled()
             manager.updateBadgeCount()

--- a/SakuraRSS/Views/App.swift
+++ b/SakuraRSS/Views/App.swift
@@ -25,19 +25,13 @@ struct SakuraRSSApp: App {
                 .environment(feedManager)
                 .modifier(KeepScreenOnDuringPodcastWork())
                 .task {
-                    // Pre-warm the X WKWebsiteDataStore cookie store so
-                    // that the first feed refresh sees valid session
-                    // cookies.  On cold launch the cookie store is
-                    // otherwise empty until a WKWebView has loaded a
-                    // page from the domain.
-                    //
-                    // Instagram has migrated to Keychain-backed cookie
-                    // storage, so its cookies are always available
-                    // without any WebKit warming — we just run a
-                    // one-time migration for users upgrading from a
-                    // version that only stored cookies in WebKit.
+                    // Both X and Instagram now use Keychain-backed cookie
+                    // storage, so their cookies are available without any
+                    // WebKit warming on cold launch.  We run a one-time
+                    // migration for users upgrading from versions that
+                    // only stored cookies in WebKit.
                     if UserDefaults.standard.bool(forKey: "Labs.XProfileFeeds") {
-                        await XProfileScraper.warmCookieStore()
+                        await XProfileScraper.migrateWebKitCookiesIfNeeded()
                     }
                     if UserDefaults.standard.bool(forKey: "Labs.InstagramProfileFeeds") {
                         await InstagramProfileScraper.migrateWebKitCookiesIfNeeded()
@@ -118,11 +112,13 @@ struct SakuraRSSApp: App {
             case "putonpipboy":
                 wipeAllCachesAndData()
                 Task {
+                    // X and Instagram cookies live in Keychain, which
+                    // survives the filesystem wipe above — no cookie
+                    // re-warming needed.  X still has to re-extract its
+                    // in-memory GraphQL query IDs from the JS bundle.
                     if UserDefaults.standard.bool(forKey: "Labs.XProfileFeeds") {
                         await XProfileScraper.fetchQueryIDsIfNeeded()
                     }
-                    // Instagram cookies live in Keychain, which survives
-                    // the filesystem wipe above — no re-warming needed.
                     let entries = feedManager.feeds.map { ($0.domain, $0.siteURL as String?) }
                     await FaviconCache.shared.refreshFavicons(for: entries)
                 }
@@ -273,12 +269,14 @@ struct SakuraRSSApp: App {
         let refreshTask = Task {
             let manager = FeedManager()
             // Skip X and Instagram profile feeds in background refresh.
-            // Both scrapers depend on WKWebView-backed cookie warming
-            // (and X additionally on a JS-bundle query-ID fetch) that
-            // isn't reliable in a headless BGAppRefreshTask, and firing
-            // authenticated API calls from a locked device at a fixed
-            // cadence is itself a bot-like signal.  Those feeds refresh
-            // when the user actually opens the app instead.
+            // Both scrapers' cookies now live in Keychain so they would
+            // technically be reachable from a BGAppRefreshTask, but
+            // firing authenticated API calls from a locked device at a
+            // fixed cadence is itself a bot-like signal — stronger than
+            // anything else in the request fingerprint.  X additionally
+            // depends on a JS-bundle query-ID fetch that isn't reliable
+            // in a headless BGAppRefreshTask.  Those feeds refresh when
+            // the user actually opens the app instead.
             await manager.refreshAllFeeds(skipAuthenticatedScrapers: true)
             await NLPProcessingCoordinator.processNewArticlesIfEnabled()
             manager.updateBadgeCount()

--- a/SakuraRSS/Views/Feeds/FeedEditSheet+Icons.swift
+++ b/SakuraRSS/Views/Feeds/FeedEditSheet+Icons.swift
@@ -16,7 +16,7 @@ extension FeedEditSheet {
             }
             // Download, cache locally, then return
             if let url = URL(string: customURL),
-               let (data, _) = try? await URLSession.shared.data(from: url),
+               let (data, _) = try? await URLSession.shared.data(for: .sakura(url: url)),
                let image = UIImage(data: data) {
                 await FaviconCache.shared.setCustomFavicon(image, feedID: feed.id)
                 return image
@@ -42,7 +42,7 @@ extension FeedEditSheet {
             if let userInfo = await scraper.fetchUserInfo(screenName: handle, cookies: cookies),
                let imageURLString = userInfo.profileImageURL,
                let imageURL = URL(string: imageURLString),
-               let (data, _) = try? await URLSession.shared.data(from: imageURL),
+               let (data, _) = try? await URLSession.shared.data(for: .sakura(url: imageURL)),
                let image = UIImage(data: data) {
                 await FaviconCache.shared.setCustomFavicon(image, feedID: feed.id, skipTrimming: true)
                 customIconImage = nil
@@ -62,7 +62,7 @@ extension FeedEditSheet {
             let result = await scraper.scrapeProfile(profileURL: profileURL)
             if let imageURLString = result.profileImageURL,
                let imageURL = URL(string: imageURLString),
-               let (data, _) = try? await URLSession.shared.data(from: imageURL),
+               let (data, _) = try? await URLSession.shared.data(for: .sakura(url: imageURL)),
                let image = UIImage(data: data) {
                 await FaviconCache.shared.setCustomFavicon(image, feedID: feed.id, skipTrimming: true)
                 customIconImage = nil
@@ -94,7 +94,7 @@ extension FeedEditSheet {
         isFetchingIcon = true
         defer { isFetchingIcon = false }
         do {
-            let (data, _) = try await URLSession.shared.data(from: url)
+            let (data, _) = try await URLSession.shared.data(for: .sakura(url: url))
             if let image = UIImage(data: data) {
                 customIconImage = image.trimmed()
                 selectedPhoto = nil

--- a/SakuraRSS/Views/Home/AddFeedView.swift
+++ b/SakuraRSS/Views/Home/AddFeedView.swift
@@ -268,7 +268,7 @@ struct AddFeedView: View {
         let fetchURL = RedirectDomains.redirectedURL(url)
 
         do {
-            let (data, response) = try await URLSession.shared.data(from: fetchURL)
+            let (data, response) = try await URLSession.shared.data(for: .sakura(url: fetchURL))
             guard let httpResponse = response as? HTTPURLResponse,
                   httpResponse.statusCode == 200 else { return nil }
 

--- a/SakuraRSS/Views/Onboarding/OnboardingView+AddFeed.swift
+++ b/SakuraRSS/Views/Onboarding/OnboardingView+AddFeed.swift
@@ -190,7 +190,7 @@ extension OnboardingView {
         let fetchURL = RedirectDomains.redirectedURL(url)
 
         do {
-            let (data, response) = try await URLSession.shared.data(from: fetchURL)
+            let (data, response) = try await URLSession.shared.data(for: .sakura(url: fetchURL))
             guard let httpResponse = response as? HTTPURLResponse,
                   httpResponse.statusCode == 200 else { return nil }
 

--- a/SakuraRSS/Views/Shared/CachedAsyncImage.swift
+++ b/SakuraRSS/Views/Shared/CachedAsyncImage.swift
@@ -108,7 +108,7 @@ struct CachedAsyncImage<Placeholder: View>: View {
 
         // 3. Network download
         do {
-            let (data, response) = try await URLSession.shared.data(from: url)
+            let (data, response) = try await URLSession.shared.data(for: .sakura(url: url))
             let statusCode = (response as? HTTPURLResponse)?.statusCode
             #if DEBUG
             debugPrint("[Image] Downloaded \(urlString): \(data.count) bytes, HTTP \(statusCode ?? 0)")

--- a/SakuraRSS/Views/Shared/InstagramLoginView.swift
+++ b/SakuraRSS/Views/Shared/InstagramLoginView.swift
@@ -70,6 +70,11 @@ private struct InstagramLoginWebView: UIViewRepresentable {
                 try? await Task.sleep(for: .seconds(1))
                 guard !Task.isCancelled else { return }
 
+                // Copy any cookies Instagram just set in the WKWebView
+                // over to Keychain so `hasInstagramSession()`, which
+                // reads from Keychain, can detect the successful login.
+                await InstagramProfileScraper.syncCookiesFromWebKit()
+
                 let loggedIn = await InstagramProfileScraper.hasInstagramSession()
                 if loggedIn {
                     self.isLoggedIn = true

--- a/SakuraRSS/Views/Shared/XLoginView.swift
+++ b/SakuraRSS/Views/Shared/XLoginView.swift
@@ -71,6 +71,11 @@ private struct XLoginWebView: UIViewRepresentable {
                 try? await Task.sleep(for: .seconds(1))
                 guard !Task.isCancelled else { return }
 
+                // Copy any cookies X just set in the WKWebView over to
+                // Keychain so `hasXSession()`, which reads from Keychain,
+                // can detect the successful login.
+                await XProfileScraper.syncCookiesFromWebKit()
+
                 let loggedIn = await XProfileScraper.hasXSession()
                 if loggedIn {
                     self.isLoggedIn = true

--- a/Shared/Audio Player/AudioPlayer+NowPlaying.swift
+++ b/Shared/Audio Player/AudioPlayer+NowPlaying.swift
@@ -33,7 +33,7 @@ extension AudioPlayer {
 
     func loadArtwork(from urlString: String?) {
         guard let urlString, let url = URL(string: urlString) else { return }
-        URLSession.shared.dataTask(with: url) { [weak self] data, _, _ in
+        URLSession.shared.dataTask(with: URLRequest.sakura(url: url)) { [weak self] data, _, _ in
             guard let data, let image = UIImage(data: data), let cgImage = image.cgImage else { return }
             let safeImage = UIImage(cgImage: cgImage)
             let size = safeImage.size

--- a/Shared/Favicon Cache/FaviconCache.swift
+++ b/Shared/Favicon Cache/FaviconCache.swift
@@ -8,12 +8,16 @@ actor FaviconCache {
     /// Dedicated URLSession used for every favicon-related network fetch.
     /// Favicons are cosmetic and must not fail just because an image takes
     /// a long time to download, so this session effectively bypasses the
-    /// normal request / resource timeouts.
+    /// normal request / resource timeouts.  `httpAdditionalHeaders` sets
+    /// a Safari-parity User-Agent on every request so the default
+    /// `CFNetwork` UA (which leaks the app bundle ID and iOS version) is
+    /// never sent.
     nonisolated static let urlSession: URLSession = {
         let config = URLSessionConfiguration.default
         config.timeoutIntervalForRequest = 600
         config.timeoutIntervalForResource = 600
         config.waitsForConnectivity = true
+        config.httpAdditionalHeaders = ["User-Agent": sakuraUserAgent]
         return URLSession(configuration: config)
     }()
 

--- a/Shared/FeedDiscovery.swift
+++ b/Shared/FeedDiscovery.swift
@@ -81,7 +81,7 @@ actor FeedDiscovery {
     private func discoverFromHTML(url: URL) async -> [DiscoveredFeed] {
 
         do {
-            let (data, _) = try await URLSession.shared.data(from: url)
+            let (data, _) = try await URLSession.shared.data(for: .sakura(url: url))
             guard let html = String(data: data, encoding: .utf8) else { return [] }
             return extractFeedLinks(from: html, baseURL: url)
         } catch {
@@ -213,9 +213,8 @@ actor FeedDiscovery {
         guard let url = URL(string: "https://\(domain)\(path)") else { return nil }
 
         do {
-            var request = URLRequest(url: url)
+            var request = URLRequest.sakura(url: url, timeoutInterval: 10)
             request.httpMethod = "GET"
-            request.timeoutInterval = 10
 
             let (data, response) = try await URLSession.shared.data(for: request)
             guard let httpResponse = response as? HTTPURLResponse,

--- a/Shared/Instagram Integration/InstagramProfileScraper+Fetching.swift
+++ b/Shared/Instagram Integration/InstagramProfileScraper+Fetching.swift
@@ -24,6 +24,13 @@ extension InstagramProfileScraper {
         print("[InstagramProfileScraper] Fetching profile for handle: \(handle)")
         #endif
 
+        // Enforce a human-like gap since the previous scrape.  When several
+        // feeds refresh at once they serialise through `activeScrape`, so
+        // without this wait they would fire back-to-back in a tight burst
+        // — a strong automation signal.  Spacing them out imitates a user
+        // navigating between profiles.
+        await Self.awaitHumanPacing()
+
         guard let cookies = await Self.getInstagramCookies() else {
             #if DEBUG
             print("[InstagramProfileScraper] No Instagram session cookies found")
@@ -51,7 +58,65 @@ extension InstagramProfileScraper {
               + "name: \(profileData.displayName ?? "nil")")
         #endif
 
+        // Record completion time so the next serialised scrape can space
+        // itself out relative to when this one finished.
+        Self.markRequestCompleted()
+
         return profileData
+    }
+
+    // MARK: - Human-Like Pacing
+
+    /// Timestamp of the most recently completed Instagram network request.
+    /// Used to enforce a minimum inter-scrape gap so a burst of feed
+    /// refreshes does not fire back-to-back.
+    nonisolated(unsafe) private static var lastRequestCompletedAt: Date?
+    nonisolated(unsafe) private static let pacingLock = NSLock()
+
+    static func markRequestCompleted() {
+        pacingLock.lock()
+        defer { pacingLock.unlock() }
+        lastRequestCompletedAt = Date()
+    }
+
+    /// Sleeps for a randomised interval so consecutive Instagram requests
+    /// look like a human navigating, not a script.  The delay combines a
+    /// baseline jitter (always applied) with an additional cool-down that
+    /// only kicks in when we have just finished a previous request.
+    static func awaitHumanPacing() async {
+        pacingLock.lock()
+        let lastCompleted = lastRequestCompletedAt
+        pacingLock.unlock()
+
+        // Minimum gap between any two serialised scrapes — picked from a
+        // fairly wide range so the cadence is not predictable.
+        let minCooldown: TimeInterval = 3.5
+        let maxCooldown: TimeInterval = 9.0
+
+        var delay = TimeInterval.random(in: 0.4...1.8)
+        if let lastCompleted {
+            let elapsed = Date().timeIntervalSince(lastCompleted)
+            let targetCooldown = TimeInterval.random(in: minCooldown...maxCooldown)
+            if elapsed < targetCooldown {
+                delay = max(delay, targetCooldown - elapsed)
+            }
+        }
+
+        #if DEBUG
+        print("[InstagramProfileScraper] Human-pacing delay: \(String(format: "%.2f", delay))s")
+        #endif
+        try? await Task.sleep(for: .seconds(delay))
+    }
+
+    /// Short randomised pause used between back-to-back API calls inside
+    /// a single scrape (e.g. `web_profile_info` → `feed/user`).  Mimics a
+    /// user briefly looking at the profile before scrolling the feed.
+    static func awaitIntraScrapePause() async {
+        let delay = TimeInterval.random(in: 0.9...2.6)
+        #if DEBUG
+        print("[InstagramProfileScraper] Intra-scrape pause: \(String(format: "%.2f", delay))s")
+        #endif
+        try? await Task.sleep(for: .seconds(delay))
     }
 
     // MARK: - Cookie Warming
@@ -125,17 +190,43 @@ extension InstagramProfileScraper {
 
     // MARK: - Request Building
 
-    func buildRequest(url: URL, cookies: InstagramCookies) -> URLRequest {
-        var request = URLRequest(url: url, timeoutInterval: requestTimeoutInterval)
+    func buildRequest(url: URL, cookies: InstagramCookies,
+                      referer: String = "https://www.instagram.com/") -> URLRequest {
+        // Jitter the timeout slightly so the fingerprint isn't a flat 15s.
+        let jitteredTimeout = requestTimeoutInterval + TimeInterval.random(in: -1.5...2.5)
+        var request = URLRequest(url: url, timeoutInterval: max(5, jitteredTimeout))
         request.setValue(sakuraUserAgent, forHTTPHeaderField: "User-Agent")
         request.setValue(cookies.csrfToken, forHTTPHeaderField: "x-csrftoken")
         request.setValue("XMLHttpRequest", forHTTPHeaderField: "x-requested-with")
-        request.setValue("https://www.instagram.com/", forHTTPHeaderField: "referer")
+        request.setValue(referer, forHTTPHeaderField: "referer")
         request.setValue("https://www.instagram.com", forHTTPHeaderField: "origin")
         request.setValue("same-origin", forHTTPHeaderField: "sec-fetch-site")
         request.setValue("cors", forHTTPHeaderField: "sec-fetch-mode")
         request.setValue("empty", forHTTPHeaderField: "sec-fetch-dest")
         request.setValue(Self.webAppID, forHTTPHeaderField: "x-ig-app-id")
+
+        // Browser-parity headers.  Mobile Safari sends all of these on
+        // every XHR; omitting them makes the request fingerprint stick
+        // out against genuine web traffic.
+        request.setValue("*/*", forHTTPHeaderField: "Accept")
+        request.setValue("en-US,en;q=0.9", forHTTPHeaderField: "Accept-Language")
+        // NOTE: Do not set Accept-Encoding manually — URLSession sets its
+        // own supported value and transparently decodes the body.  Setting
+        // it here would disable that auto-decoding and break JSON parsing.
+        request.setValue("no-cache", forHTTPHeaderField: "Cache-Control")
+        request.setValue("no-cache", forHTTPHeaderField: "Pragma")
+        request.setValue("keep-alive", forHTTPHeaderField: "Connection")
+        // NOTE: sec-ch-ua* (User-Agent Client Hints) are a Chromium feature
+        // — Safari does NOT send them.  Including them alongside a Safari
+        // UA would itself be a detectable mismatch, so they are omitted.
+
+        // A few optional Instagram-internal headers the web client sends.
+        // They aren't strictly required, but their absence is one of the
+        // cheapest tells used to flag scrapers.  The values mirror what
+        // the desktop/mobile web client emits for unauthenticated-style
+        // public reads.
+        request.setValue("129477", forHTTPHeaderField: "x-asbd-id")
+        request.setValue("0", forHTTPHeaderField: "x-ig-www-claim")
 
         // Build the full cookie header from all Instagram cookies
         let cookieHeader = HTTPCookie.requestHeaderFields(with: cookies.allCookies)
@@ -199,6 +290,9 @@ extension InstagramProfileScraper {
             print("[InstagramProfileScraper] Profile had 0 posts, "
                   + "fetching feed for user ID: \(userId)")
             #endif
+            // Mimic a user briefly looking at the profile before the web
+            // client fires the follow-up feed XHR.
+            await Self.awaitIntraScrapePause()
             let feedPosts = await fetchUserFeed(
                 userId: userId, username: username,
                 displayName: result.displayName,
@@ -230,7 +324,11 @@ extension InstagramProfileScraper {
             return []
         }
 
-        let request = buildRequest(url: url, cookies: cookies)
+        // Use the profile page as the referer — that is what a real
+        // browser sends when the follow-up feed XHR fires from the
+        // profile page context.
+        let profileReferer = "https://www.instagram.com/\(username)/"
+        let request = buildRequest(url: url, cookies: cookies, referer: profileReferer)
 
         #if DEBUG
         print("[InstagramProfileScraper] Feed request: \(url)")

--- a/Shared/Instagram Integration/InstagramProfileScraper+Fetching.swift
+++ b/Shared/Instagram Integration/InstagramProfileScraper+Fetching.swift
@@ -144,6 +144,21 @@ extension InstagramProfileScraper {
         try? await Task.sleep(for: .seconds(delay))
     }
 
+    // MARK: - Accept-Language
+
+    /// Accept-Language header value derived from the user's preferred
+    /// locales, in the format Safari sends (primary locale at q=1.0,
+    /// additional locales at decreasing q values).
+    static var acceptLanguageHeader: String {
+        let preferred = Locale.preferredLanguages.prefix(5)
+        guard !preferred.isEmpty else { return "en-US,en;q=0.9" }
+        return preferred.enumerated().map { index, lang in
+            if index == 0 { return lang }
+            let quality = max(0.1, 1.0 - Double(index) * 0.1)
+            return "\(lang);q=\(String(format: "%.1f", quality))"
+        }.joined(separator: ",")
+    }
+
     // MARK: - Cookie Warming
 
     @MainActor
@@ -232,24 +247,13 @@ extension InstagramProfileScraper {
         // every XHR; omitting them makes the request fingerprint stick
         // out against genuine web traffic.
         request.setValue("*/*", forHTTPHeaderField: "Accept")
-        request.setValue("en-US,en;q=0.9", forHTTPHeaderField: "Accept-Language")
+        request.setValue(Self.acceptLanguageHeader, forHTTPHeaderField: "Accept-Language")
         // NOTE: Do not set Accept-Encoding manually — URLSession sets its
         // own supported value and transparently decodes the body.  Setting
         // it here would disable that auto-decoding and break JSON parsing.
         request.setValue("no-cache", forHTTPHeaderField: "Cache-Control")
         request.setValue("no-cache", forHTTPHeaderField: "Pragma")
         request.setValue("keep-alive", forHTTPHeaderField: "Connection")
-        // NOTE: sec-ch-ua* (User-Agent Client Hints) are a Chromium feature
-        // — Safari does NOT send them.  Including them alongside a Safari
-        // UA would itself be a detectable mismatch, so they are omitted.
-
-        // A few optional Instagram-internal headers the web client sends.
-        // They aren't strictly required, but their absence is one of the
-        // cheapest tells used to flag scrapers.  The values mirror what
-        // the desktop/mobile web client emits for unauthenticated-style
-        // public reads.
-        request.setValue("129477", forHTTPHeaderField: "x-asbd-id")
-        request.setValue("0", forHTTPHeaderField: "x-ig-www-claim")
 
         // Build the full cookie header from all Instagram cookies
         let cookieHeader = HTTPCookie.requestHeaderFields(with: cookies.allCookies)

--- a/Shared/Instagram Integration/InstagramProfileScraper+Fetching.swift
+++ b/Shared/Instagram Integration/InstagramProfileScraper+Fetching.swift
@@ -32,7 +32,7 @@ extension InstagramProfileScraper {
         // navigating between profiles.
         await Self.awaitHumanPacing()
 
-        guard let cookies = await Self.getInstagramCookies() else {
+        guard let cookies = Self.getInstagramCookies() else {
             #if DEBUG
             print("[InstagramProfileScraper] No Instagram session cookies found")
             #endif
@@ -44,10 +44,27 @@ extension InstagramProfileScraper {
               + "total cookies: \(cookies.allCookies.count)")
         #endif
 
+        // Session is created once and shared between the profile-info
+        // and feed/user requests so cookie rotations from Set-Cookie
+        // headers accumulate in a single jar that we can persist at
+        // the end of the scrape.
+        let session = makeSession(cookies: cookies)
+
         // Fetch profile info and recent posts
-        guard let profileData = await fetchProfileInfo(
-            username: handle, cookies: cookies
-        ) else {
+        let profileData = await fetchProfileInfo(
+            username: handle, cookies: cookies, session: session
+        )
+
+        // Persist any cookies Instagram rotated during the scrape,
+        // even if parsing failed — otherwise Keychain drifts stale
+        // and the user eventually gets silently signed out.
+        Self.persistRotatedCookies(from: session)
+
+        // Record completion time so the next serialised scrape can space
+        // itself out relative to when this one finished.
+        Self.markRequestCompleted()
+
+        guard let profileData else {
             #if DEBUG
             print("[InstagramProfileScraper] Failed to fetch profile info for \(handle)")
             #endif
@@ -59,11 +76,19 @@ extension InstagramProfileScraper {
               + "name: \(profileData.displayName ?? "nil")")
         #endif
 
-        // Record completion time so the next serialised scrape can space
-        // itself out relative to when this one finished.
-        Self.markRequestCompleted()
-
         return profileData
+    }
+
+    /// Writes rotated cookies from the URLSession jar back to Keychain
+    /// so subsequent scrapes pick up refreshed `sessionid` / `csrftoken`
+    /// / `mid` values that Instagram issued via `Set-Cookie`.
+    private static func persistRotatedCookies(from session: URLSession) {
+        guard let storage = session.configuration.httpCookieStorage else { return }
+        let updated = (storage.cookies ?? []).filter {
+            $0.domain.lowercased().contains("instagram.com")
+        }
+        guard !updated.isEmpty else { return }
+        InstagramProfileScraper.cookieStore.save(updated)
     }
 
     // MARK: - Human-Like Pacing
@@ -124,9 +149,12 @@ extension InstagramProfileScraper {
     @MainActor
     private static var cookieStoreWarmed = false
 
-    /// Loads a WKWebView with instagram.com to force WKWebsiteDataStore
-    /// to restore persisted cookies from disk. Without this, cookies may
-    /// not be available on cold app launch.
+    /// Loads a WKWebView with instagram.com to force `WKWebsiteDataStore`
+    /// to restore its persisted cookie jar from disk.
+    ///
+    /// This is now only used during the one-time Keychain migration in
+    /// `migrateWebKitCookiesIfNeeded()` — normal scrapes read directly
+    /// from the Keychain store and do not touch WebKit.
     @MainActor
     static func warmCookieStore() async {
         guard !cookieStoreWarmed else { return }
@@ -144,28 +172,23 @@ extension InstagramProfileScraper {
 
     // MARK: - Cookies
 
-    @MainActor
-    static func getInstagramCookies() async -> InstagramCookies? {
-        await warmCookieStore()
-
-        let store = WKWebsiteDataStore.default()
-        let allWebKitCookies = await store.httpCookieStore.allCookies()
+    /// Reads the current Instagram session from the Keychain-backed
+    /// cookie jar.  Synchronous and thread-safe — no WebKit hop.
+    static func getInstagramCookies() -> InstagramCookies? {
+        guard let cookies = InstagramProfileScraper.cookieStore.load() else {
+            return nil
+        }
 
         var csrfToken: String?
         var sessionID: String?
-        var instagramCookies: [HTTPCookie] = []
-
-        for cookie in allWebKitCookies {
-            let domain = cookie.domain.lowercased()
-            guard domain.contains("instagram.com") else { continue }
-            instagramCookies.append(cookie)
+        for cookie in cookies {
             if cookie.name == "csrftoken" { csrfToken = cookie.value }
             if cookie.name == "sessionid" { sessionID = cookie.value }
         }
 
         guard let csrf = csrfToken, let session = sessionID else { return nil }
         return InstagramCookies(csrfToken: csrf, sessionID: session,
-                                allCookies: instagramCookies)
+                                allCookies: cookies)
     }
 
     // MARK: - Session Building
@@ -240,7 +263,7 @@ extension InstagramProfileScraper {
     // MARK: - Profile Info + Posts
 
     func fetchProfileInfo(
-        username: String, cookies: InstagramCookies
+        username: String, cookies: InstagramCookies, session: URLSession
     ) async -> InstagramProfileScrapeResult? {
         guard let url = URL(
             string: "https://www.instagram.com/api/v1/users/web_profile_info/?username=\(username)"
@@ -248,7 +271,6 @@ extension InstagramProfileScraper {
             return nil
         }
 
-        let session = makeSession(cookies: cookies)
         let request = buildRequest(url: url, cookies: cookies)
 
         #if DEBUG

--- a/Shared/Instagram Integration/InstagramProfileScraper+Fetching.swift
+++ b/Shared/Instagram Integration/InstagramProfileScraper+Fetching.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 import WebKit
 
 // MARK: - API Fetching
@@ -69,14 +70,15 @@ extension InstagramProfileScraper {
 
     /// Timestamp of the most recently completed Instagram network request.
     /// Used to enforce a minimum inter-scrape gap so a burst of feed
-    /// refreshes does not fire back-to-back.
-    nonisolated(unsafe) private static var lastRequestCompletedAt: Date?
-    nonisolated(unsafe) private static let pacingLock = NSLock()
+    /// refreshes does not fire back-to-back.  Wrapped in an
+    /// `OSAllocatedUnfairLock` because `NSLock.lock()`/`unlock()` are
+    /// unavailable from async contexts under Swift 6 strict concurrency.
+    private static let lastRequestCompletedAt = OSAllocatedUnfairLock<Date?>(
+        initialState: nil
+    )
 
     static func markRequestCompleted() {
-        pacingLock.lock()
-        defer { pacingLock.unlock() }
-        lastRequestCompletedAt = Date()
+        lastRequestCompletedAt.withLock { $0 = Date() }
     }
 
     /// Sleeps for a randomised interval so consecutive Instagram requests
@@ -84,9 +86,7 @@ extension InstagramProfileScraper {
     /// baseline jitter (always applied) with an additional cool-down that
     /// only kicks in when we have just finished a previous request.
     static func awaitHumanPacing() async {
-        pacingLock.lock()
-        let lastCompleted = lastRequestCompletedAt
-        pacingLock.unlock()
+        let lastCompleted = lastRequestCompletedAt.withLock { $0 }
 
         // Minimum gap between any two serialised scrapes — picked from a
         // fairly wide range so the cadence is not predictable.

--- a/Shared/Instagram Integration/InstagramProfileScraper.swift
+++ b/Shared/Instagram Integration/InstagramProfileScraper.swift
@@ -23,8 +23,10 @@ struct InstagramProfileScrapeResult: Sendable {
 }
 
 /// Fetches posts from an Instagram profile using the web API.
-/// Requires the user to be logged in via the default WKWebsiteDataStore
-/// so that session cookies are available.
+///
+/// Session cookies are kept in a Keychain-backed store (`cookieStore`)
+/// populated from the login WebView on success and, for users upgrading
+/// from older builds, by a one-time migration from `WKWebsiteDataStore`.
 final class InstagramProfileScraper {
 
     /// Per-request timeout used for every URLRequest this scraper builds.
@@ -45,6 +47,18 @@ final class InstagramProfileScraper {
 
     /// Serialises access so only one fetch runs at a time.
     private static var activeScrape: Task<InstagramProfileScrapeResult, Never>?
+
+    /// Keychain-backed persistent cookie jar.  Using Keychain (instead of
+    /// `WKWebsiteDataStore.default()` as the source of truth) removes the
+    /// MainActor WKWebView warming step from every scrape, makes
+    /// `hasInstagramSession()` a cheap synchronous read, and lets cold-
+    /// launch and background scrapes work without waiting for WebKit to
+    /// restore cookies from disk.  WebKit is still the target of the
+    /// login UI — we export cookies from it to Keychain on login success
+    /// and on a one-time migration.
+    static let cookieStore = KeychainCookieStore(
+        service: "com.tsubuzaki.SakuraRSS.InstagramCookies"
+    )
 
     // MARK: - Public
 
@@ -130,69 +144,66 @@ final class InstagramProfileScraper {
         return String(url.dropFirst("instagram-profile://".count))
     }
 
-    /// UserDefaults key used to cache the Instagram session state.
-    private static let sessionCacheKey = "InstagramProfileScraper.hasSession"
-
     /// Checks if the user has Instagram cookies (i.e. is logged in).
-    @MainActor
+    ///
+    /// Kept `async` for API stability with the old WebKit-backed
+    /// implementation; the body is a synchronous Keychain read.
     static func hasInstagramSession() async -> Bool {
-        // Ensure the WKWebsiteDataStore has restored persisted cookies from
-        // disk before we inspect them. On cold launch, allCookies() returns
-        // an empty array until a WKWebView has loaded a page from the
-        // domain, which makes the user look logged-out even when they aren't.
-        await warmCookieStore()
-
-        let store = WKWebsiteDataStore.default()
-        let cookies = await store.httpCookieStore.allCookies()
-        let found = cookies.contains { cookie in
-            let domain = cookie.domain.lowercased()
-            return domain.contains("instagram.com")
-                && (cookie.name == "sessionid" || cookie.name == "ds_user_id")
-        }
-
-        if found {
-            UserDefaults.standard.set(true, forKey: sessionCacheKey)
-            return true
-        }
-
-        // Cookie store may still not have finished loading — retry if we were
-        // previously logged in.
-        if UserDefaults.standard.bool(forKey: sessionCacheKey) {
-            try? await Task.sleep(for: .milliseconds(500))
-            let retryResult = await retryHasInstagramSession()
-            if retryResult {
-                return true
-            }
-            // Don't clear the cache here — a transient cookie-store miss
-            // shouldn't silently sign the user out. clearInstagramSession()
-            // is the only path that should flip this to false.
-            return false
-        }
-
-        UserDefaults.standard.set(false, forKey: sessionCacheKey)
-        return false
-    }
-
-    /// One retry of the cookie check.
-    @MainActor
-    private static func retryHasInstagramSession() async -> Bool {
-        let store = WKWebsiteDataStore.default()
-        let cookies = await store.httpCookieStore.allCookies()
+        guard let cookies = cookieStore.load() else { return false }
         return cookies.contains { cookie in
-            let domain = cookie.domain.lowercased()
-            return domain.contains("instagram.com")
-                && (cookie.name == "sessionid" || cookie.name == "ds_user_id")
+            cookie.name == "sessionid" || cookie.name == "ds_user_id"
         }
     }
 
-    /// Clears Instagram session cookies.
+    /// Clears Instagram session cookies from both Keychain and the
+    /// WebKit data store (so the login WebView starts fresh).
     @MainActor
     static func clearInstagramSession() async {
+        cookieStore.clear()
+
         let store = WKWebsiteDataStore.default()
         let cookies = await store.httpCookieStore.allCookies()
         for cookie in cookies where cookie.domain.lowercased().contains("instagram.com") {
             await store.httpCookieStore.deleteCookie(cookie)
         }
-        UserDefaults.standard.set(false, forKey: sessionCacheKey)
+    }
+
+    /// Exports any Instagram cookies present in the default
+    /// `WKWebsiteDataStore` into Keychain.  Called after the user
+    /// completes the login flow in `InstagramLoginView` so that the
+    /// scraper's Keychain-backed session check can find them.
+    @MainActor
+    static func syncCookiesFromWebKit() async {
+        let store = WKWebsiteDataStore.default()
+        let allCookies = await store.httpCookieStore.allCookies()
+        let instagramCookies = allCookies.filter {
+            $0.domain.lowercased().contains("instagram.com")
+        }
+        guard !instagramCookies.isEmpty else { return }
+        cookieStore.save(instagramCookies)
+
+        #if DEBUG
+        print("[InstagramProfileScraper] Synced \(instagramCookies.count) "
+              + "cookies from WebKit → Keychain")
+        #endif
+    }
+
+    /// One-time migration for users upgrading from the WebKit-only
+    /// storage model.  If Keychain is empty but the WebKit data store
+    /// holds Instagram cookies from a prior install, copy them over so
+    /// the user stays signed in without having to log in again.
+    ///
+    /// Safe to call repeatedly — the Keychain-empty check makes it a
+    /// no-op after the first successful migration.
+    @MainActor
+    static func migrateWebKitCookiesIfNeeded() async {
+        // Fast path: already migrated.
+        if cookieStore.load() != nil { return }
+
+        // Force WebKit to restore its on-disk cookie store before we
+        // inspect it — on a cold launch `allCookies()` returns an empty
+        // array until a WKWebView has loaded a page from the domain.
+        await warmCookieStore()
+        await syncCookiesFromWebKit()
     }
 }

--- a/Shared/Instagram Integration/InstagramProfileScraper.swift
+++ b/Shared/Instagram Integration/InstagramProfileScraper.swift
@@ -48,14 +48,6 @@ final class InstagramProfileScraper {
     /// Serialises access so only one fetch runs at a time.
     private static var activeScrape: Task<InstagramProfileScrapeResult, Never>?
 
-    /// Keychain-backed persistent cookie jar.  Using Keychain (instead of
-    /// `WKWebsiteDataStore.default()` as the source of truth) removes the
-    /// MainActor WKWebView warming step from every scrape, makes
-    /// `hasInstagramSession()` a cheap synchronous read, and lets cold-
-    /// launch and background scrapes work without waiting for WebKit to
-    /// restore cookies from disk.  WebKit is still the target of the
-    /// login UI — we export cookies from it to Keychain on login success
-    /// and on a one-time migration.
     static let cookieStore = KeychainCookieStore(
         service: "com.tsubuzaki.SakuraRSS.InstagramCookies"
     )

--- a/Shared/Network/KeychainCookieStore.swift
+++ b/Shared/Network/KeychainCookieStore.swift
@@ -1,0 +1,110 @@
+import Foundation
+
+/// A minimal Keychain-backed persistence layer for `HTTPCookie` arrays.
+///
+/// Cookies are archived with secure coding and stored as a single
+/// `kSecClassGenericPassword` item per `service`.  Items are accessible
+/// `kSecAttrAccessibleAfterFirstUnlock`, which means they survive
+/// process relaunches and are readable from `BGAppRefreshTask`s on a
+/// device that has been unlocked at least once since boot.
+///
+/// This exists because relying on `WKWebsiteDataStore.default()` as a
+/// cookie persistence layer requires a MainActor WKWebView round-trip
+/// to restore cookies from disk — unreliable from background tasks and
+/// adds multi-second warming latency to cold-launch scrapes.
+struct KeychainCookieStore {
+
+    /// Keychain service identifier — unique per cookie jar.
+    let service: String
+
+    /// Single-account constant; each service stores exactly one item.
+    private let account = "cookies"
+
+    /// Persists the given cookies, replacing any previously stored value.
+    func save(_ cookies: [HTTPCookie]) {
+        let data: Data
+        do {
+            data = try NSKeyedArchiver.archivedData(
+                withRootObject: cookies,
+                requiringSecureCoding: true
+            )
+        } catch {
+            #if DEBUG
+            print("[KeychainCookieStore:\(service)] archive failed: \(error)")
+            #endif
+            return
+        }
+
+        let matchQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account
+        ]
+
+        let updateAttributes: [String: Any] = [
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock
+        ]
+
+        // Try update first, fall back to add on first save.
+        let updateStatus = SecItemUpdate(
+            matchQuery as CFDictionary,
+            updateAttributes as CFDictionary
+        )
+        if updateStatus == errSecItemNotFound {
+            var addQuery = matchQuery
+            for (key, value) in updateAttributes { addQuery[key] = value }
+            let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+            #if DEBUG
+            if addStatus != errSecSuccess {
+                print("[KeychainCookieStore:\(service)] add failed: \(addStatus)")
+            }
+            #endif
+        } else if updateStatus != errSecSuccess {
+            #if DEBUG
+            print("[KeychainCookieStore:\(service)] update failed: \(updateStatus)")
+            #endif
+        }
+    }
+
+    /// Loads the persisted cookies, or returns `nil` if no item is stored
+    /// or if the archived data cannot be decoded.
+    func load() -> [HTTPCookie]? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess, let data = result as? Data else {
+            return nil
+        }
+
+        do {
+            let unarchived = try NSKeyedUnarchiver.unarchivedObject(
+                ofClasses: [NSArray.self, HTTPCookie.self],
+                from: data
+            )
+            return unarchived as? [HTTPCookie]
+        } catch {
+            #if DEBUG
+            print("[KeychainCookieStore:\(service)] unarchive failed: \(error)")
+            #endif
+            return nil
+        }
+    }
+
+    /// Deletes the stored cookies, if any.
+    func clear() {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account
+        ]
+        SecItemDelete(query as CFDictionary)
+    }
+}

--- a/Shared/Podcast Downloads/PodcastDownloadManager.swift
+++ b/Shared/Podcast Downloads/PodcastDownloadManager.swift
@@ -47,6 +47,10 @@ final class PodcastDownloadManager: NSObject, URLSessionDownloadDelegate {
         config.waitsForConnectivity = true
         config.timeoutIntervalForRequest = 60
         config.timeoutIntervalForResource = 3600
+        // Use a Safari-parity User-Agent on every podcast download so we
+        // never send the default `CFNetwork` UA — some podcast CDNs serve
+        // a different file (or a 403) when they see an app-bundle UA.
+        config.httpAdditionalHeaders = ["User-Agent": sakuraUserAgent]
         self.urlSession = URLSession(
             configuration: config,
             delegate: self,

--- a/Shared/Podcast Downloads/PodcastDownloadManager.swift
+++ b/Shared/Podcast Downloads/PodcastDownloadManager.swift
@@ -47,9 +47,6 @@ final class PodcastDownloadManager: NSObject, URLSessionDownloadDelegate {
         config.waitsForConnectivity = true
         config.timeoutIntervalForRequest = 60
         config.timeoutIntervalForResource = 3600
-        // Use a Safari-parity User-Agent on every podcast download so we
-        // never send the default `CFNetwork` UA — some podcast CDNs serve
-        // a different file (or a 403) when they see an app-bundle UA.
         config.httpAdditionalHeaders = ["User-Agent": sakuraUserAgent]
         self.urlSession = URLSession(
             configuration: config,

--- a/Shared/SponsorBlock/SponsorBlockClient.swift
+++ b/Shared/SponsorBlock/SponsorBlockClient.swift
@@ -83,8 +83,7 @@ enum SponsorBlockClient {
             return []
         }
 
-        var request = URLRequest(url: url)
-        request.timeoutInterval = 5
+        let request = URLRequest.sakura(url: url, timeoutInterval: 5)
 
         do {
             let (data, response) = try await URLSession.shared.data(for: request)

--- a/Shared/UserAgent.swift
+++ b/Shared/UserAgent.swift
@@ -1,26 +1,10 @@
 import Foundation
 
 // swiftlint:disable line_length
-/// Safari-parity User-Agent string sent on every outbound request.
-///
-/// Marked `nonisolated` because targets in this project build with
-/// `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`, which would otherwise
-/// make this top-level `let` MainActor-only and unreachable from the
-/// background-thread scrapers that need to stamp it onto requests.
 nonisolated let sakuraUserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 Mobile/15E148 Safari/604.1"
 // swiftlint:enable line_length
 
 extension URLRequest {
-    /// Builds a URLRequest preconfigured with the Sakura User-Agent.  Use
-    /// this in place of `URLSession.shared.data(from: url)` so outbound
-    /// traffic doesn't leak the default `CFNetwork` UA, which advertises
-    /// both the app bundle and iOS version and gets flagged by bot
-    /// heuristics on a number of CDNs.
-    ///
-    /// Marked `nonisolated` because targets in this project build with
-    /// `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`, which would otherwise
-    /// make this extension method MainActor-only and unreachable from
-    /// background-thread scrapers.
     nonisolated static func sakura(
         url: URL,
         timeoutInterval: TimeInterval = 60

--- a/Shared/UserAgent.swift
+++ b/Shared/UserAgent.swift
@@ -10,7 +10,12 @@ extension URLRequest {
     /// traffic doesn't leak the default `CFNetwork` UA, which advertises
     /// both the app bundle and iOS version and gets flagged by bot
     /// heuristics on a number of CDNs.
-    static func sakura(
+    ///
+    /// Marked `nonisolated` because targets in this project build with
+    /// `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`, which would otherwise
+    /// make this extension method MainActor-only and unreachable from
+    /// background-thread scrapers.
+    nonisolated static func sakura(
         url: URL,
         timeoutInterval: TimeInterval = 60
     ) -> URLRequest {

--- a/Shared/UserAgent.swift
+++ b/Shared/UserAgent.swift
@@ -1,7 +1,13 @@
 import Foundation
 
 // swiftlint:disable line_length
-let sakuraUserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 Mobile/15E148 Safari/604.1"
+/// Safari-parity User-Agent string sent on every outbound request.
+///
+/// Marked `nonisolated` because targets in this project build with
+/// `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`, which would otherwise
+/// make this top-level `let` MainActor-only and unreachable from the
+/// background-thread scrapers that need to stamp it onto requests.
+nonisolated let sakuraUserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 Mobile/15E148 Safari/604.1"
 // swiftlint:enable line_length
 
 extension URLRequest {

--- a/Shared/UserAgent.swift
+++ b/Shared/UserAgent.swift
@@ -3,3 +3,19 @@ import Foundation
 // swiftlint:disable line_length
 let sakuraUserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 Mobile/15E148 Safari/604.1"
 // swiftlint:enable line_length
+
+extension URLRequest {
+    /// Builds a URLRequest preconfigured with the Sakura User-Agent.  Use
+    /// this in place of `URLSession.shared.data(from: url)` so outbound
+    /// traffic doesn't leak the default `CFNetwork` UA, which advertises
+    /// both the app bundle and iOS version and gets flagged by bot
+    /// heuristics on a number of CDNs.
+    static func sakura(
+        url: URL,
+        timeoutInterval: TimeInterval = 60
+    ) -> URLRequest {
+        var request = URLRequest(url: url, timeoutInterval: timeoutInterval)
+        request.setValue(sakuraUserAgent, forHTTPHeaderField: "User-Agent")
+        return request
+    }
+}

--- a/Shared/X Integration/XProfileScraper+Fetching.swift
+++ b/Shared/X Integration/XProfileScraper+Fetching.swift
@@ -1,5 +1,4 @@
 import Foundation
-import WebKit
 
 // MARK: - API Fetching
 
@@ -64,6 +63,10 @@ extension XProfileScraper {
         print("[XProfileScraper] Fetched \(tweets.count) tweets total")
         #endif
 
+        // Persist any cookies X rotated during the scrape so Keychain
+        // tracks refreshed `ct0` / `auth_token` values.
+        Self.persistRotatedCookies()
+
         return XProfileScrapeResult(
             tweets: tweets,
             profileImageURL: userInfo.profileImageURL,
@@ -73,25 +76,49 @@ extension XProfileScraper {
 
     // MARK: - Cookies
 
+    /// Reads the current X session from the Keychain-backed cookie jar.
+    ///
+    /// Also ensures GraphQL query IDs are loaded, because every caller of
+    /// this method is about to make an API request that depends on them.
+    /// The query ID fetch still needs a MainActor hop (WKWebView-backed
+    /// bundle extraction), so this method remains `@MainActor async`, but
+    /// the cookie read itself is a cheap synchronous Keychain lookup.
     @MainActor
     static func getXCookies() async -> XCookies? {
         await fetchQueryIDsIfNeeded()
+        return readXCookiesFromKeychain()
+    }
 
-        let store = WKWebsiteDataStore.default()
-        let cookies = await store.httpCookieStore.allCookies()
+    /// Synchronous Keychain-only read, for paths that already have query
+    /// IDs loaded (e.g. between back-to-back API calls inside a scrape).
+    static func readXCookiesFromKeychain() -> XCookies? {
+        guard let cookies = cookieStore.load() else { return nil }
 
         var csrfToken: String?
         var authToken: String?
 
         for cookie in cookies {
-            let domain = cookie.domain.lowercased()
-            guard domain.contains("x.com") || domain.contains("twitter.com") else { continue }
             if cookie.name == "ct0" { csrfToken = cookie.value }
             if cookie.name == "auth_token" { authToken = cookie.value }
         }
 
         guard let csrf = csrfToken, let auth = authToken else { return nil }
         return XCookies(csrfToken: csrf, authToken: auth)
+    }
+
+    /// Writes any rotated X cookies from `HTTPCookieStorage.shared` back
+    /// to Keychain so subsequent scrapes pick up refreshed `ct0` /
+    /// `auth_token` values that X issued via `Set-Cookie`.  X API
+    /// requests use `URLSession.shared`, which deposits response cookies
+    /// into the shared jar by default.
+    static func persistRotatedCookies() {
+        let jar = HTTPCookieStorage.shared
+        let xCookies = (jar.cookies ?? []).filter {
+            let domain = $0.domain.lowercased()
+            return domain.contains("x.com") || domain.contains("twitter.com")
+        }
+        guard !xCookies.isEmpty else { return }
+        cookieStore.save(xCookies)
     }
 
     // MARK: - Request Building

--- a/Shared/X Integration/XProfileScraper+QueryIDs.swift
+++ b/Shared/X Integration/XProfileScraper+QueryIDs.swift
@@ -105,7 +105,7 @@ extension XProfileScraper {
         // Step 3: Fetch the bundle JS
         let bundleText: String
         do {
-            let (data, _) = try await URLSession.shared.data(from: bundleURL)
+            let (data, _) = try await URLSession.shared.data(for: .sakura(url: bundleURL))
             guard let text = String(data: data, encoding: .utf8) else {
                 print("[XProfileScraper:QueryIDs] ERROR: Could not decode bundle JS")
                 return

--- a/Shared/X Integration/XProfileScraper.swift
+++ b/Shared/X Integration/XProfileScraper.swift
@@ -22,8 +22,12 @@ struct XProfileScrapeResult: Sendable {
 }
 
 /// Fetches tweets from an X (Twitter) profile using GraphQL API calls.
-/// Retweets are excluded. Requires the user to be logged in via the default
-/// WKWebsiteDataStore so that session cookies are available.
+///
+/// Retweets are excluded.  Session cookies are kept in a Keychain-backed
+/// store (`cookieStore`) populated from the login WebView on success and,
+/// for users upgrading from older builds, by a one-time migration from
+/// `WKWebsiteDataStore`.  WebKit is still used for the JS-bundle query-ID
+/// fetch (which has no Keychain equivalent) but not for cookie storage.
 final class XProfileScraper {
 
     /// Per-request timeout used for every URLRequest this scraper builds.
@@ -61,6 +65,18 @@ final class XProfileScraper {
     // swiftlint:enable line_length
 
     static let targetTweetCount = 50
+
+    /// Keychain-backed persistent cookie jar.  Using Keychain (instead of
+    /// `WKWebsiteDataStore.default()` as the source of truth) removes the
+    /// MainActor WKWebView warming step from every cookie read, makes
+    /// `hasXSession()` a cheap synchronous call, and lets cold-launch
+    /// scrapes work without waiting for WebKit to restore cookies from
+    /// disk.  WebKit is still the target of the login UI — we export
+    /// cookies from it to Keychain on login success and on a one-time
+    /// migration.
+    static let cookieStore = KeychainCookieStore(
+        service: "com.tsubuzaki.SakuraRSS.XCookies"
+    )
 
     /// Serialises access so only one fetch runs at a time.
     private static var activeScrape: Task<XProfileScrapeResult, Never>?
@@ -162,65 +178,22 @@ final class XProfileScraper {
         return String(url.dropFirst("x-profile://".count))
     }
 
-    /// UserDefaults key used to cache the X session state so that
-    /// it is available immediately on cold launch (before the WebKit
-    /// cookie store has finished loading from disk).
-    private static let xSessionCacheKey = "XProfileScraper.hasSession"
-
     /// Checks if the user has X cookies (i.e. is logged in).
     ///
-    /// On a cold app launch the WebKit cookie store may not have
-    /// finished restoring cookies from disk yet, which causes this
-    /// method to incorrectly return `false`.  To work around this,
-    /// we cache the result in UserDefaults and, when the cookie store
-    /// returns an empty result while the cache says we were previously
-    /// logged in, we retry once after a short delay to give WebKit
-    /// time to load.
-    @MainActor
+    /// Kept `async` for API stability with the old WebKit-backed
+    /// implementation; the body is a synchronous Keychain read.
     static func hasXSession() async -> Bool {
-        await warmCookieStore()
-        let store = WKWebsiteDataStore.default()
-        let cookies = await store.httpCookieStore.allCookies()
-        let found = cookies.contains { cookie in
-            let domain = cookie.domain.lowercased()
-            return (domain.contains("x.com") || domain.contains("twitter.com"))
-                && (cookie.name == "auth_token" || cookie.name == "ct0")
-        }
-
-        if found {
-            UserDefaults.standard.set(true, forKey: xSessionCacheKey)
-            return true
-        }
-
-        // Cookie store returned nothing — if we were previously logged
-        // in, retry once after a brief delay so WebKit can finish
-        // loading cookies from disk.
-        if UserDefaults.standard.bool(forKey: xSessionCacheKey) {
-            try? await Task.sleep(for: .milliseconds(500))
-            let retryResult = await retryHasXSession()
-            UserDefaults.standard.set(retryResult, forKey: xSessionCacheKey)
-            return retryResult
-        }
-
-        UserDefaults.standard.set(false, forKey: xSessionCacheKey)
-        return false
-    }
-
-    /// One retry of the cookie check (no further retries to avoid loops).
-    @MainActor
-    private static func retryHasXSession() async -> Bool {
-        let store = WKWebsiteDataStore.default()
-        let cookies = await store.httpCookieStore.allCookies()
+        guard let cookies = cookieStore.load() else { return false }
         return cookies.contains { cookie in
-            let domain = cookie.domain.lowercased()
-            return (domain.contains("x.com") || domain.contains("twitter.com"))
-                && (cookie.name == "auth_token" || cookie.name == "ct0")
+            cookie.name == "auth_token" || cookie.name == "ct0"
         }
     }
 
-    /// Clears X session cookies and cached query IDs.
+    /// Clears X session cookies (Keychain + WebKit) and cached query IDs.
     @MainActor
     static func clearXSession() async {
+        cookieStore.clear()
+
         let store = WKWebsiteDataStore.default()
         let cookies = await store.httpCookieStore.allCookies()
         for cookie in cookies where cookie.domain.lowercased().contains("x.com")
@@ -231,6 +204,45 @@ final class XProfileScraper {
         userTweetsQueryID = nil
         tweetDetailQueryID = nil
         queryIDsFetched = false
-        UserDefaults.standard.set(false, forKey: xSessionCacheKey)
+    }
+
+    /// Exports any X cookies present in the default `WKWebsiteDataStore`
+    /// into Keychain.  Called after the user completes the login flow in
+    /// `XLoginView` so that the scraper's Keychain-backed session check
+    /// can find them.
+    @MainActor
+    static func syncCookiesFromWebKit() async {
+        let store = WKWebsiteDataStore.default()
+        let allCookies = await store.httpCookieStore.allCookies()
+        let xCookies = allCookies.filter {
+            let domain = $0.domain.lowercased()
+            return domain.contains("x.com") || domain.contains("twitter.com")
+        }
+        guard !xCookies.isEmpty else { return }
+        cookieStore.save(xCookies)
+
+        #if DEBUG
+        print("[XProfileScraper] Synced \(xCookies.count) "
+              + "cookies from WebKit → Keychain")
+        #endif
+    }
+
+    /// One-time migration for users upgrading from the WebKit-only
+    /// storage model.  If Keychain is empty but the WebKit data store
+    /// holds X cookies from a prior install, copy them over so the user
+    /// stays signed in without having to log in again.
+    ///
+    /// Safe to call repeatedly — the Keychain-empty check makes it a
+    /// no-op after the first successful migration.
+    @MainActor
+    static func migrateWebKitCookiesIfNeeded() async {
+        // Fast path: already migrated.
+        if cookieStore.load() != nil { return }
+
+        // Force WebKit to restore its on-disk cookie store before we
+        // inspect it — on a cold launch `allCookies()` returns an empty
+        // array until a WKWebView has loaded a page from the domain.
+        await warmCookieStore()
+        await syncCookiesFromWebKit()
     }
 }

--- a/Widgets/ListWidget/ListWidgetProvider.swift
+++ b/Widgets/ListWidget/ListWidgetProvider.swift
@@ -98,7 +98,7 @@ struct ListWidgetProvider: AppIntentTimelineProvider {
                     if let cached = try? database.cachedImageData(for: imageURLString) {
                         rawData = cached
                     } else {
-                        if let (data, _) = try? await URLSession.shared.data(from: imageURL) {
+                        if let (data, _) = try? await URLSession.shared.data(for: .sakura(url: imageURL)) {
                             try? database.cacheImageData(data, for: imageURLString)
                             rawData = data
                         }

--- a/Widgets/SingleFeedWidget/SingleFeedProvider.swift
+++ b/Widgets/SingleFeedWidget/SingleFeedProvider.swift
@@ -78,7 +78,7 @@ struct SingleFeedProvider: AppIntentTimelineProvider {
                         #endif
                         rawData = cached
                     } else {
-                        if let (data, _) = try? await URLSession.shared.data(from: imageURL) {
+                        if let (data, _) = try? await URLSession.shared.data(for: .sakura(url: imageURL)) {
                             #if DEBUG
                             debugPrint("[Widget] Downloaded image \(imageURLString) (\(data.count) bytes)")
                             #endif


### PR DESCRIPTION
## Summary
Migrates Instagram session cookie storage from `WKWebsiteDataStore` to a new Keychain-backed `KeychainCookieStore`, eliminating the need for MainActor WebKit warming on every scrape and enabling reliable background refresh support.

## Key Changes

- **New `KeychainCookieStore` class**: Provides secure, persistent cookie storage using Keychain with `kSecAttrAccessibleAfterFirstUnlock` accessibility, allowing cookies to survive process relaunches and be readable from background tasks.

- **Synchronous cookie access**: `getInstagramCookies()` is now synchronous and thread-safe, removing the MainActor requirement and WebKit warming latency from every scrape operation.

- **Human-like request pacing**: 
  - Added `awaitHumanPacing()` to enforce randomized inter-scrape delays (3.5–9.0s baseline + 0.4–1.8s jitter) between consecutive profile fetches, preventing back-to-back automation signals when multiple feeds refresh simultaneously.
  - Added `awaitIntraScrapePause()` for delays between API calls within a single scrape (e.g., profile info → feed).
  - Tracks request completion time with `OSAllocatedUnfairLock` for Swift 6 strict concurrency compatibility.

- **Cookie rotation handling**: Cookies rotated by Instagram via `Set-Cookie` headers are now persisted back to Keychain at the end of each scrape, even if parsing fails, preventing Keychain drift and silent sign-outs.

- **Enhanced request fingerprinting**:
  - Added browser-parity headers (`Accept`, `Accept-Language`, `Cache-Control`, `Pragma`, `Connection`) to match genuine web traffic.
  - Added Instagram-internal headers (`x-asbd-id`, `x-ig-www-claim`) that are cheap tells for scraper detection.
  - Jittered request timeout (±1.5–2.5s) to avoid flat 15s fingerprint.
  - Dynamic referer headers based on request context (profile page for feed requests).

- **One-time migration**: `migrateWebKitCookiesIfNeeded()` handles users upgrading from WebKit-only storage, copying existing cookies to Keychain on first run.

- **Refresh interval jitter**: Instagram feed refresh now uses randomized intervals (30–40 minutes) instead of a fixed 30-minute cadence to avoid predictable automation patterns.

- **Background task handling**: `refreshAllFeeds(skipAuthenticatedScrapers:)` skips X and Instagram profile feeds during background refresh, as authenticated API calls from a locked device at fixed scheduler cadence is a stronger bot signal than any request fingerprint.

- **Login flow integration**: `syncCookiesFromWebKit()` exports cookies from the login WebView to Keychain on successful authentication.

## Implementation Details

- Uses `NSKeyedArchiver` with secure coding for cookie serialization.
- Shared `URLSession` instance per scrape to accumulate cookie rotations in a single jar.
- Maintains backward compatibility with existing async API surface while making the implementation synchronous internally.
- All timing delays use `Task.sleep(for:)` with proper error suppression for background contexts.

https://claude.ai/code/session_015ipf5Po9NUUMKfp8hWvGce