### PR TITLE
Replace NavigationLink with ArticleLink in similar content

### DIFF
--- a/SakuraRSS/Views/Shared/Article Detail/ArticleDetailView+SimilarContent.swift
+++ b/SakuraRSS/Views/Shared/Article Detail/ArticleDetailView+SimilarContent.swift
@@ -77,7 +77,7 @@ extension ArticleDetailView {
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(alignment: .top, spacing: 12) {
                     ForEach(similarArticles) { item in
-                        NavigationLink(value: item.article) {
+                        ArticleLink(article: item.article) {
                             SimilarArticleCard(item: item)
                         }
                         .buttonStyle(.plain)


### PR DESCRIPTION
## Summary
Updated the similar articles section in ArticleDetailView to use the custom `ArticleLink` component instead of the standard `NavigationLink` for consistent navigation behavior across the app.

## Changes
- Replaced `NavigationLink(value: item.article)` with `ArticleLink(article: item.article)` in the similar articles carousel
- This ensures similar article cards use the same navigation pattern as other article links in the application

## Details
The change maintains the same functionality while promoting code consistency by using the custom `ArticleLink` component throughout the article detail view. This allows for centralized control of article navigation behavior and any future enhancements to article link handling.

https://claude.ai/code/session_01Tz4BshPHywBoSKHmJfXPGh