### PR TITLE
Optimize battery usage throughout app

### DIFF
--- a/SakuraRSS/Classes/Feed Manager/FeedManager.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager.swift
@@ -155,9 +155,15 @@ final class FeedManager {
 
             try database.insertArticles(feedID: feed.id, articles: articleTuples)
 
-            let feedTitleForIndex = parsed.title.isEmpty ? feed.title : parsed.title
-            let articlesToIndex = try database.articles(forFeedID: feed.id, limit: articleTuples.count)
-            SpotlightIndexer.indexArticles(articlesToIndex, feedTitle: feedTitleForIndex)
+            // Skip Spotlight indexing under Low Power Mode so feeds still
+            // refresh while deferring the CoreSpotlight writes until LPM
+            // turns off.  The next successful refresh outside LPM will
+            // re-index the same articles.
+            if !ProcessInfo.processInfo.isLowPowerModeEnabled {
+                let feedTitleForIndex = parsed.title.isEmpty ? feed.title : parsed.title
+                let articlesToIndex = try database.articles(forFeedID: feed.id, limit: articleTuples.count)
+                SpotlightIndexer.indexArticles(articlesToIndex, feedTitle: feedTitleForIndex)
+            }
 
             if parsed.isPodcast && !feed.isPodcast {
                 try database.updateFeedIsPodcast(id: feed.id, isPodcast: true)

--- a/SakuraRSS/Classes/Feed Manager/FeedManager.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager.swift
@@ -221,24 +221,52 @@ final class FeedManager {
 
     /// Refreshes every feed.
     ///
-    /// - Parameter skipAuthenticatedScrapers: When `true`, X and Instagram
-    ///   profile feeds are skipped entirely.  Pass this from background
-    ///   refresh tasks.  Both scrapers' cookies now live in Keychain and
-    ///   so are technically available in the background, but hitting the
-    ///   Instagram/X APIs from a locked device at a fixed scheduler
-    ///   cadence is itself a strong bot-like signal — a stronger signal
-    ///   than anything else in the request fingerprint — so those
-    ///   scrapes are reserved for foreground use.  X additionally still
-    ///   depends on a JS-bundle query-ID fetch that is unreliable in a
-    ///   `BGAppRefreshTask`.
-    func refreshAllFeeds(skipAuthenticatedScrapers: Bool = false) async {
+    /// - Parameters:
+    ///   - skipAuthenticatedScrapers: When `true`, X and Instagram
+    ///     profile feeds are skipped entirely.  Pass this from background
+    ///     refresh tasks.  Both scrapers' cookies now live in Keychain and
+    ///     so are technically available in the background, but hitting the
+    ///     Instagram/X APIs from a locked device at a fixed scheduler
+    ///     cadence is itself a strong bot-like signal — a stronger signal
+    ///     than anything else in the request fingerprint — so those
+    ///     scrapes are reserved for foreground use.  X additionally still
+    ///     depends on a JS-bundle query-ID fetch that is unreliable in a
+    ///     `BGAppRefreshTask`.
+    ///   - respectCooldown: When `true`, feeds whose `lastFetched` is
+    ///     within the user-configured `BackgroundRefresh.Cooldown`
+    ///     window are skipped.  Feeds that have never been fetched
+    ///     (`lastFetched == nil`) always refresh.  Pass this from
+    ///     automatic triggers (background refresh, app startup,
+    ///     foreground re-enter).  Leave `false` for explicit user
+    ///     actions like pull-to-refresh, which should always refresh
+    ///     everything.
+    func refreshAllFeeds(
+        skipAuthenticatedScrapers: Bool = false,
+        respectCooldown: Bool = false
+    ) async {
         await MainActor.run { isLoading = true }
         defer { Task { @MainActor in self.isLoading = false } }
+
+        let cooldownSeconds: TimeInterval? = {
+            guard respectCooldown else { return nil }
+            let raw = UserDefaults.standard.string(forKey: "BackgroundRefresh.Cooldown")
+            let cooldown = raw.flatMap(FeedRefreshCooldown.init(rawValue:)) ?? .fiveMinutes
+            return cooldown.seconds
+        }()
+        let now = Date()
 
         let currentFeeds = feeds
         await withTaskGroup(of: Void.self) { group in
             for feed in currentFeeds {
                 if skipAuthenticatedScrapers, feed.isXFeed || feed.isInstagramFeed {
+                    continue
+                }
+                if let cooldownSeconds,
+                   let lastFetched = feed.lastFetched,
+                   now.timeIntervalSince(lastFetched) < cooldownSeconds {
+                    // Inside the cooldown window.  A nil lastFetched
+                    // means the feed has never been refreshed (new or
+                    // freshly imported), so it always proceeds.
                     continue
                 }
                 group.addTask {

--- a/SakuraRSS/Structs/BatchSummarizer.swift
+++ b/SakuraRSS/Structs/BatchSummarizer.swift
@@ -5,6 +5,37 @@ import FoundationModels
 /// then combines into a single summary.
 enum BatchSummarizer {
 
+    /// Minimum body length (in characters, after stripping HTML tags) for an
+    /// article to be worth handing to the LLM.  Articles shorter than this
+    /// are title-only stubs, placeholder/teaser bodies, or empty posts — all
+    /// of which cost LLM energy without improving the summary.
+    static let minArticleBodyCharacters = 200
+
+    /// Returns true when `summary` has enough real content (after stripping
+    /// HTML tags and whitespace) to contribute to an LLM summary, and is not
+    /// a trivial duplicate of the title.
+    static func hasUsefulContent(title: String, summary: String?) -> Bool {
+        guard let summary, !summary.isEmpty else { return false }
+
+        // Strip HTML tags with a simple regex — good enough for the check
+        // since we only need a character count, not a rendered result.
+        let stripped = summary
+            .replacingOccurrences(
+                of: "<[^>]+>",
+                with: "",
+                options: .regularExpression
+            )
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard stripped.count >= minArticleBodyCharacters else { return false }
+
+        // Reject bodies that are just the title repeated.
+        if stripped.caseInsensitiveCompare(title) == .orderedSame {
+            return false
+        }
+        return true
+    }
+
     /// Summarizes batches concurrently (max 3 at a time), then combines results if needed.
     static func summarize(
         batches: [String],

--- a/SakuraRSS/Structs/NLPProcessingCoordinator.swift
+++ b/SakuraRSS/Structs/NLPProcessingCoordinator.swift
@@ -1,4 +1,5 @@
 import Foundation
+import NaturalLanguage
 import os
 
 enum NLPProcessingCoordinator {
@@ -6,6 +7,11 @@ enum NLPProcessingCoordinator {
     #if DEBUG
     nonisolated static let logger = Logger(subsystem: "com.tsubuzaki.SakuraRSS", category: "NLPCoordinator")
     #endif
+
+    /// Number of articles processed per chunk before yielding back to the
+    /// cooperative scheduler.  Keeps main-thread hitches short when this
+    /// coordinator runs concurrently with scrolling.
+    private static let chunkSize = 20
 
     /// Processes unprocessed articles if Content Insights is enabled.
     /// Called after feed refresh completes.
@@ -19,6 +25,17 @@ enum NLPProcessingCoordinator {
             return
         }
 
+        // Skip all NLP processing while the device is in Low Power Mode.
+        // A non-BG caller (e.g. foreground refresh) reaches this path too,
+        // so gate here in addition to the BG-refresh gate in App.swift.
+        // Work resumes on the next refresh outside LPM.
+        if ProcessInfo.processInfo.isLowPowerModeEnabled {
+            #if DEBUG
+            logger.debug("processNewArticlesIfEnabled: Low Power Mode is on, deferring")
+            #endif
+            return
+        }
+
         let db = DatabaseManager.shared
         let sevenDaysAgo = Date().addingTimeInterval(-7 * 24 * 3600)
 
@@ -27,7 +44,7 @@ enum NLPProcessingCoordinator {
         logger.debug("processNewArticlesIfEnabled: starting")
         #endif
 
-        await Task.detached(priority: .userInitiated) {
+        await Task.detached(priority: .utility) {
             var idsToProcess = Set<Int64>()
             if let ids = try? db.unprocessedSentimentArticleIDs(since: sevenDaysAgo, limit: 200) {
                 idsToProcess.formUnion(ids)
@@ -40,12 +57,25 @@ enum NLPProcessingCoordinator {
             logger.debug("processNewArticlesIfEnabled: \(idsToProcess.count) articles to process")
             #endif
 
-            let orderedIDs = Array(idsToProcess)
-            for (index, id) in orderedIDs.enumerated() {
-                guard let article = try? db.article(byID: id) else { continue }
-                processArticleSync(article)
+            // Reuse a single sentiment tagger and a single name-type tagger
+            // across every article in this pass.  NLTagger construction is
+            // measurably expensive; setting `.string` on an existing tagger
+            // is cheap.
+            let sentimentTagger = NLTagger(tagSchemes: [.sentimentScore])
+            let nameTagger = NLTagger(tagSchemes: [.nameType])
 
-                if index > 0 && index % 50 == 0 {
+            let orderedIDs = Array(idsToProcess)
+            var processedSinceYield = 0
+            for id in orderedIDs {
+                guard let article = try? db.article(byID: id) else { continue }
+                processArticleSync(
+                    article,
+                    sentimentTagger: sentimentTagger,
+                    nameTagger: nameTagger
+                )
+                processedSinceYield += 1
+                if processedSinceYield >= chunkSize {
+                    processedSinceYield = 0
                     await Task.yield()
                 }
             }
@@ -70,7 +100,15 @@ enum NLPProcessingCoordinator {
     /// Extracts sentiment and entities for an article. Called only when
     /// Content Insights is enabled — the hybrid similarity ranker relies on
     /// entities being present, so both passes always run together.
-    private nonisolated static func processArticleSync(_ article: Article) {
+    ///
+    /// When `sentimentTagger` and `nameTagger` are supplied, they are reused
+    /// across articles by the batch caller.  The single-article path
+    /// constructs fresh taggers on each call.
+    private nonisolated static func processArticleSync(
+        _ article: Article,
+        sentimentTagger: NLTagger? = nil,
+        nameTagger: NLTagger? = nil
+    ) {
         let db = DatabaseManager.shared
         let text = [article.title, article.summary ?? ""]
             .filter { !$0.isEmpty }
@@ -80,12 +118,23 @@ enum NLPProcessingCoordinator {
         logger.debug("processArticleSync: article=\(article.id) title=\"\(article.title.prefix(60))\"")
         #endif
 
-        if let score = NLPProcessor.sentimentScore(for: text) {
-            try? db.updateSentimentScore(score, for: article.id)
+        let sentiment: Double?
+        if let sentimentTagger {
+            sentiment = NLPProcessor.sentimentScore(for: text, using: sentimentTagger)
+        } else {
+            sentiment = NLPProcessor.sentimentScore(for: text)
+        }
+        if let sentiment {
+            try? db.updateSentimentScore(sentiment, for: article.id)
         }
         try? db.markSentimentProcessed(articleId: article.id)
 
-        let entities = NLPProcessor.extractEntities(from: text)
+        let entities: [NLPProcessor.EntityResult]
+        if let nameTagger {
+            entities = NLPProcessor.extractEntities(from: text, using: nameTagger)
+        } else {
+            entities = NLPProcessor.extractEntities(from: text)
+        }
         if !entities.isEmpty {
             try? db.insertEntities(
                 entities.map { (name: $0.name, type: $0.type) },

--- a/SakuraRSS/Structs/NLPProcessingCoordinator.swift
+++ b/SakuraRSS/Structs/NLPProcessingCoordinator.swift
@@ -11,7 +11,7 @@ enum NLPProcessingCoordinator {
     /// Number of articles processed per chunk before yielding back to the
     /// cooperative scheduler.  Keeps main-thread hitches short when this
     /// coordinator runs concurrently with scrolling.
-    private static let chunkSize = 20
+    nonisolated private static let chunkSize = 20
 
     /// Processes unprocessed articles if Content Insights is enabled.
     /// Called after feed refresh completes.

--- a/SakuraRSS/Views/App.swift
+++ b/SakuraRSS/Views/App.swift
@@ -40,6 +40,7 @@ struct SakuraRSSApp: App {
                     UserDefaults.standard.set(false, forKey: "App.StartupInProgress")
                     feedManager.updateBadgeCount()
                     requestReviewIfNeeded()
+                    reindexSpotlightIfSchemaChanged()
                     // Kick off NLP insight processing after startup
                     // completes so it never holds up badge refresh or
                     // any other MainActor-visible work.  Skip entirely
@@ -83,6 +84,22 @@ struct SakuraRSSApp: App {
         if launchCount == 3 {
             requestReview()
         }
+    }
+
+    /// Runs a one-time full Spotlight reindex when the on-device index
+    /// schema doesn't match the current build's `SpotlightIndexer.schemaVersion`.
+    /// Does NOT gate on Low Power Mode: if the schema has changed, search
+    /// is broken until the reindex runs.  In the steady state — when the
+    /// stored version already matches — this method is a single
+    /// `UserDefaults` read and returns immediately.
+    private func reindexSpotlightIfSchemaChanged() {
+        let defaults = UserDefaults.standard
+        let storedRaw = defaults.object(forKey: SpotlightIndexer.schemaVersionDefaultsKey) as? Int
+        guard storedRaw != SpotlightIndexer.schemaVersion else { return }
+
+        SpotlightIndexer.removeAllArticles()
+        feedManager.reindexAllArticlesInSpotlight()
+        defaults.set(SpotlightIndexer.schemaVersion, forKey: SpotlightIndexer.schemaVersionDefaultsKey)
     }
 
     private func handleOpenURL(_ url: URL) {

--- a/SakuraRSS/Views/App.swift
+++ b/SakuraRSS/Views/App.swift
@@ -15,7 +15,7 @@ struct SakuraRSSApp: App {
     @AppStorage("ForceWhileYouSlept") private var forceWhileYouSlept: Bool = false
     @AppStorage("ForceTodaysSummary") private var forceTodaysSummary: Bool = false
     @AppStorage("BackgroundRefresh.Enabled") private var backgroundRefreshEnabled: Bool = true
-    @AppStorage("BackgroundRefresh.Interval") private var refreshInterval: Int = 60
+    @AppStorage("BackgroundRefresh.Interval") private var refreshInterval: Int = 240
     private let backgroundTaskID = "com.tsubuzaki.SakuraRSS.RefreshFeeds"
 
     var body: some Scene {
@@ -42,9 +42,13 @@ struct SakuraRSSApp: App {
                     requestReviewIfNeeded()
                     // Kick off NLP insight processing after startup
                     // completes so it never holds up badge refresh or
-                    // any other MainActor-visible work.
-                    Task.detached(priority: .utility) {
-                        await NLPProcessingCoordinator.processNewArticlesIfEnabled()
+                    // any other MainActor-visible work.  Skip entirely
+                    // under Low Power Mode — NLTagger work is deferred
+                    // until LPM turns off.
+                    if !ProcessInfo.processInfo.isLowPowerModeEnabled {
+                        Task.detached(priority: .utility) {
+                            await NLPProcessingCoordinator.processNewArticlesIfEnabled()
+                        }
                     }
                 }
                 .onReceive(
@@ -258,13 +262,21 @@ struct SakuraRSSApp: App {
         }
         let request = BGAppRefreshTaskRequest(identifier: backgroundTaskID)
         let refreshInterval = UserDefaults.standard.integer(forKey: "BackgroundRefresh.Interval")
-        let minutes = refreshInterval > 0 ? refreshInterval : 60
+        let minutes = refreshInterval > 0 ? refreshInterval : 240
         request.earliestBeginDate = Date(timeIntervalSinceNow: TimeInterval(minutes * 60))
         try? BGTaskScheduler.shared.submit(request)
     }
 
     private func handleAppRefresh(task: BGAppRefreshTask) {
+        // Always reschedule the next window before deciding what to run.
         scheduleAppRefresh()
+
+        // Respect Low Power Mode: do no background work at all, just
+        // complete cleanly so the system doesn't count this as a failure.
+        if ProcessInfo.processInfo.isLowPowerModeEnabled {
+            task.setTaskCompleted(success: true)
+            return
+        }
 
         let refreshTask = Task {
             let manager = FeedManager()

--- a/SakuraRSS/Views/App.swift
+++ b/SakuraRSS/Views/App.swift
@@ -36,7 +36,7 @@ struct SakuraRSSApp: App {
                     if UserDefaults.standard.bool(forKey: "Labs.InstagramProfileFeeds") {
                         await InstagramProfileScraper.migrateWebKitCookiesIfNeeded()
                     }
-                    await feedManager.refreshAllFeeds()
+                    await feedManager.refreshAllFeeds(respectCooldown: true)
                     UserDefaults.standard.set(false, forKey: "App.StartupInProgress")
                     feedManager.updateBadgeCount()
                     requestReviewIfNeeded()
@@ -280,7 +280,10 @@ struct SakuraRSSApp: App {
 
         let refreshTask = Task {
             let manager = FeedManager()
-            await manager.refreshAllFeeds(skipAuthenticatedScrapers: true)
+            await manager.refreshAllFeeds(
+                skipAuthenticatedScrapers: true,
+                respectCooldown: true
+            )
             await NLPProcessingCoordinator.processNewArticlesIfEnabled()
             manager.updateBadgeCount()
         }

--- a/SakuraRSS/Views/App.swift
+++ b/SakuraRSS/Views/App.swift
@@ -12,6 +12,7 @@ struct SakuraRSSApp: App {
     @State private var feedManager = FeedManager()
     @State private var pendingFeedURL: String?
     @State private var pendingArticleID: Int64?
+    @State private var lastForegroundWorkAt: Date?
     @AppStorage("ForceWhileYouSlept") private var forceWhileYouSlept: Bool = false
     @AppStorage("ForceTodaysSummary") private var forceTodaysSummary: Bool = false
     @AppStorage("BackgroundRefresh.Enabled") private var backgroundRefreshEnabled: Bool = true
@@ -55,8 +56,19 @@ struct SakuraRSSApp: App {
                 .onReceive(
                     NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)
                 ) { _ in
-                    feedManager.loadFromDatabase()
+                    // Always update the badge — cheap and user-visible.
                     feedManager.updateBadgeCount()
+                    // Debounce the rest of the foreground chain.  Rapid
+                    // app switches trigger willEnterForeground every
+                    // time, and re-running the DB reload + widget
+                    // reload + unfetched-feed refresh each time is
+                    // wasted energy when nothing has had time to change.
+                    let now = Date()
+                    if let last = lastForegroundWorkAt, now.timeIntervalSince(last) < 5 * 60 {
+                        return
+                    }
+                    lastForegroundWorkAt = now
+                    feedManager.loadFromDatabase()
                     WidgetCenter.shared.reloadAllTimelines()
                     Task {
                         await feedManager.refreshUnfetchedFeeds()

--- a/SakuraRSS/Views/Home/TodaysSummaryView+Generation.swift
+++ b/SakuraRSS/Views/Home/TodaysSummaryView+Generation.swift
@@ -6,7 +6,13 @@ extension TodaysSummaryView {
     static let snippetCharLimit = 150
 
     func generateSummary(for date: Date) async {
-        let articles = feedManager.todaySummaryArticles()
+        // Skip articles that are title-only, have empty/placeholder bodies,
+        // or whose body is just the title repeated.  Removing these up
+        // front means fewer LLM calls (lower energy) *and* a better
+        // summary — the LLM has more signal to work with.
+        let articles = feedManager.todaySummaryArticles().filter { article in
+            BatchSummarizer.hasUsefulContent(title: article.title, summary: article.summary)
+        }
         guard !articles.isEmpty else { return }
 
         if articles.count < 5 {

--- a/SakuraRSS/Views/Home/TodaysSummaryView.swift
+++ b/SakuraRSS/Views/Home/TodaysSummaryView.swift
@@ -17,6 +17,9 @@ struct TodaysSummaryView: View {
     @State private var isExpanded = false
     @State var generationFailed = false
     @State var generationError: String?
+    /// True when auto-generation was skipped because Low Power Mode is on.
+    /// In this state the user must tap the refresh button to start.
+    @State private var deferredForLowPowerMode = false
 
     private var isSupported: Bool {
         SystemLanguageModel.default.availability == .available
@@ -125,6 +128,10 @@ struct TodaysSummaryView: View {
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
                 }
+            } else if deferredForLowPowerMode && summary.isEmpty {
+                Text("TodaysSummary.LowPowerModePrompt")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
             } else if generationFailed {
                 VStack(alignment: .leading, spacing: 4) {
                     Text("TodaysSummary.Failed")
@@ -211,6 +218,17 @@ struct TodaysSummaryView: View {
             return
         }
 
+        // Under Low Power Mode we do not auto-run the on-device LLM —
+        // the user must tap the refresh button to kick off generation.
+        // This is the single most expensive recurring operation in the
+        // app; making it opt-in under LPM is a large battery win and
+        // the inline hint below explains why nothing is happening.
+        if ProcessInfo.processInfo.isLowPowerModeEnabled {
+            deferredForLowPowerMode = true
+            hasGenerated = true
+            return
+        }
+
         // Wait for initial feed refresh to complete before generating
         while feedManager.isLoading {
             try? await Task.sleep(for: .milliseconds(200))
@@ -227,6 +245,7 @@ struct TodaysSummaryView: View {
             isExpanded = false
             generationFailed = false
             generationError = nil
+            deferredForLowPowerMode = false
         }
         await generateSummary(for: today)
     }

--- a/SakuraRSS/Views/Home/WhileYouSleptView+Generation.swift
+++ b/SakuraRSS/Views/Home/WhileYouSleptView+Generation.swift
@@ -6,7 +6,13 @@ extension WhileYouSleptView {
     static let snippetCharLimit = 150
 
     func generateSummary(for date: Date) async {
-        let articles = feedManager.overnightArticles()
+        // Skip articles that are title-only, have empty/placeholder bodies,
+        // or whose body is just the title repeated.  Removing these up
+        // front means fewer LLM calls (lower energy) *and* a better
+        // summary — the LLM has more signal to work with.
+        let articles = feedManager.overnightArticles().filter { article in
+            BatchSummarizer.hasUsefulContent(title: article.title, summary: article.summary)
+        }
         guard !articles.isEmpty else { return }
 
         if articles.count < 5 {

--- a/SakuraRSS/Views/Home/WhileYouSleptView.swift
+++ b/SakuraRSS/Views/Home/WhileYouSleptView.swift
@@ -16,6 +16,9 @@ struct WhileYouSleptView: View {
     @State var hasGenerated = false
     @State private var isExpanded = false
     @State var generationFailed = false
+    /// True when auto-generation was skipped because Low Power Mode is on.
+    /// In this state the user must tap the refresh button to start.
+    @State private var deferredForLowPowerMode = false
 
     private var isSupported: Bool {
         SystemLanguageModel.default.availability == .available
@@ -124,6 +127,10 @@ struct WhileYouSleptView: View {
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
                 }
+            } else if deferredForLowPowerMode && summary.isEmpty {
+                Text("WhileYouSlept.LowPowerModePrompt")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
             } else if generationFailed {
                 Text("WhileYouSlept.Failed")
                     .font(.subheadline)
@@ -203,6 +210,14 @@ struct WhileYouSleptView: View {
             return
         }
 
+        // Under Low Power Mode we do not auto-run the on-device LLM —
+        // the user must tap the refresh button to kick off generation.
+        if ProcessInfo.processInfo.isLowPowerModeEnabled {
+            deferredForLowPowerMode = true
+            hasGenerated = true
+            return
+        }
+
         // Wait for initial feed refresh to complete before generating
         while feedManager.isLoading {
             try? await Task.sleep(for: .milliseconds(200))
@@ -218,6 +233,7 @@ struct WhileYouSleptView: View {
             summary = ""
             isExpanded = false
             generationFailed = false
+            deferredForLowPowerMode = false
         }
         await generateSummary(for: today)
     }

--- a/SakuraRSS/Views/More/MoreView.swift
+++ b/SakuraRSS/Views/More/MoreView.swift
@@ -7,7 +7,7 @@ struct MoreView: View {
     @Environment(FeedManager.self) var feedManager
     @Environment(\.dismiss) private var dismiss
     @AppStorage("BackgroundRefresh.Enabled") private var backgroundRefreshEnabled: Bool = true
-    @AppStorage("BackgroundRefresh.Interval") private var refreshInterval: Int = 60
+    @AppStorage("BackgroundRefresh.Interval") private var refreshInterval: Int = 240
     @AppStorage("Display.DefaultStyle") private var defaultDisplayStyle: FeedDisplayStyle = .inbox
     @AppStorage("Display.MarkAllReadPosition") private var markAllReadPosition: MarkAllReadPosition = .bottom
     @AppStorage("Display.UnreadBadgeMode") private var unreadBadgeMode: UnreadBadgeMode = .none

--- a/SakuraRSS/Views/More/MoreView.swift
+++ b/SakuraRSS/Views/More/MoreView.swift
@@ -8,6 +8,7 @@ struct MoreView: View {
     @Environment(\.dismiss) private var dismiss
     @AppStorage("BackgroundRefresh.Enabled") private var backgroundRefreshEnabled: Bool = true
     @AppStorage("BackgroundRefresh.Interval") private var refreshInterval: Int = 240
+    @AppStorage("BackgroundRefresh.Cooldown") private var refreshCooldown: FeedRefreshCooldown = .fiveMinutes
     @AppStorage("Display.DefaultStyle") private var defaultDisplayStyle: FeedDisplayStyle = .inbox
     @AppStorage("Display.MarkAllReadPosition") private var markAllReadPosition: MarkAllReadPosition = .bottom
     @AppStorage("Display.UnreadBadgeMode") private var unreadBadgeMode: UnreadBadgeMode = .none
@@ -101,8 +102,20 @@ struct MoreView: View {
                             Text("Settings.RefreshInterval")
                         }
                     }
+                    Picker(selection: $refreshCooldown) {
+                        Text("Settings.RefreshCooldown.Off").tag(FeedRefreshCooldown.off)
+                        Text("Settings.RefreshCooldown.1min").tag(FeedRefreshCooldown.oneMinute)
+                        Text("Settings.RefreshCooldown.5min").tag(FeedRefreshCooldown.fiveMinutes)
+                        Text("Settings.RefreshCooldown.10min").tag(FeedRefreshCooldown.tenMinutes)
+                        Text("Settings.RefreshCooldown.30min").tag(FeedRefreshCooldown.thirtyMinutes)
+                        Text("Settings.RefreshCooldown.1hour").tag(FeedRefreshCooldown.oneHour)
+                    } label: {
+                        Text("Settings.RefreshCooldown")
+                    }
                 } header: {
                     Text("Settings.Section.Refresh")
+                } footer: {
+                    Text("Settings.RefreshCooldown.Footer")
                 }
 
                 Section {

--- a/SakuraRSS/Views/Shared/CachedAsyncImage.swift
+++ b/SakuraRSS/Views/Shared/CachedAsyncImage.swift
@@ -119,7 +119,15 @@ struct CachedAsyncImage<Placeholder: View>: View {
                 #endif
                 return nil
             }
-            try? database.cacheImageData(data, for: urlString)
+            // Skip the SQLite write if a concurrent loader has already
+            // populated the memory cache for this URL.  That task either
+            // already wrote the DB row or is about to, so a second write
+            // is wasted I/O on the write path.  The memory-cache check
+            // is what matters — the DB copy fills itself in on any later
+            // miss if the memory cache gets evicted.
+            if await memoryCache.image(forKey: urlString) == nil {
+                try? database.cacheImageData(data, for: urlString)
+            }
             await memoryCache.setImage(downloadedImage, forKey: urlString)
             return downloadedImage
         } catch {

--- a/SakuraRSS/Views/Shared/FaviconImage.swift
+++ b/SakuraRSS/Views/Shared/FaviconImage.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import ObjectiveC
 
 struct FaviconImage: View {
 
@@ -71,6 +72,80 @@ struct FaviconImage: View {
     }
 }
 
+// MARK: - Derived Metrics (memoized)
+//
+// Every pixel-sampling routine below used to run on every SwiftUI body
+// evaluation — i.e. once per favicon, per list row, per scroll tick.  The
+// FaviconDerivedMetrics struct captures the raw results of each sampling
+// pass once and is attached to the UIImage via an associated object, so
+// the hot path becomes a dictionary read.  FaviconCache also persists
+// the struct as a small JSON sidecar next to the cached PNG, so newly
+// launched sessions can skip the sampling entirely when the favicon
+// has been seen before.
+
+struct FaviconDerivedMetrics: Codable {
+    /// Twelve corner alpha samples (3 per corner) from a 32×32 downscaled
+    /// version of the image.
+    let cornerAlphas: [UInt8]
+    /// Centre-pixel alpha from the same downscaled sample.
+    let centerAlpha: UInt8
+    /// True when the image was too small (<8px) to corner-sample reliably.
+    let cornerSampleUnavailable: Bool
+    /// Average RGB of every opaque pixel (16×16 sample), or `nil` when the
+    /// image has no opaque pixels.
+    let averageColor: [Double]?
+    /// Average relative luminance (ITU-R BT.709) across opaque pixels.
+    let averageLuminance: Double
+    /// True when virtually every opaque pixel is near-black.
+    let isNearBlack: Bool
+}
+
+private final class FaviconDerivedMetricsBox: NSObject {
+    let metrics: FaviconDerivedMetrics
+    init(_ metrics: FaviconDerivedMetrics) { self.metrics = metrics }
+}
+
+private nonisolated(unsafe) var faviconDerivedMetricsKey: UInt8 = 0
+
+extension UIImage {
+
+    /// In-memory memoized metrics attached to this UIImage instance.
+    var faviconDerivedMetrics: FaviconDerivedMetrics? {
+        get {
+            (objc_getAssociatedObject(self, &faviconDerivedMetricsKey) as? FaviconDerivedMetricsBox)?.metrics
+        }
+        set {
+            let box = newValue.map { FaviconDerivedMetricsBox($0) }
+            objc_setAssociatedObject(
+                self,
+                &faviconDerivedMetricsKey,
+                box,
+                .OBJC_ASSOCIATION_RETAIN_NONATOMIC
+            )
+        }
+    }
+
+    /// Returns the cached metrics, computing and attaching them on first call.
+    @discardableResult
+    func ensureFaviconDerivedMetrics() -> FaviconDerivedMetrics {
+        if let existing = faviconDerivedMetrics { return existing }
+        let cornerSample = _rawSampleCornerAlphas()
+        let averageRGB = _rawAverageColorComponents()
+        let luminance = _rawAverageLuminance()
+        let nearBlack = _rawIsNearBlack()
+        let metrics = FaviconDerivedMetrics(
+            cornerAlphas: cornerSample?.corners ?? [],
+            centerAlpha: cornerSample?.centerAlpha ?? 0,
+            cornerSampleUnavailable: cornerSample == nil,
+            averageColor: averageRGB.map { [Double($0.red), Double($0.green), Double($0.blue)] },
+            averageLuminance: Double(luminance),
+            isNearBlack: nearBlack
+        )
+        faviconDerivedMetrics = metrics
+        return metrics
+    }
+}
+
 // MARK: - Shape Detection
 
 extension UIImage {
@@ -82,7 +157,7 @@ extension UIImage {
     }
 
     /// Samples corner and center pixel alpha values from a downscaled version of the image.
-    private func sampleCornerAlphas() -> (corners: [UInt8], centerAlpha: UInt8)? {
+    fileprivate func _rawSampleCornerAlphas() -> (corners: [UInt8], centerAlpha: UInt8)? {
         guard let cgImage = cgImage else { return nil }
         let width = cgImage.width
         let height = cgImage.height
@@ -125,15 +200,17 @@ extension UIImage {
     /// Returns `true` when the image corners are transparent and the centre is opaque,
     /// indicating the favicon is already circular (or rounded) and needs no inset treatment.
     var isCircular: Bool {
-        guard let sample = sampleCornerAlphas() else { return false }
-        return sample.corners.allSatisfy { $0 <= 25 } && sample.centerAlpha >= 200
+        let metrics = ensureFaviconDerivedMetrics()
+        guard !metrics.cornerSampleUnavailable else { return false }
+        return metrics.cornerAlphas.allSatisfy { $0 <= 25 } && metrics.centerAlpha >= 200
     }
 
     /// Returns `true` when all corners are opaque, meaning the image completely fills
     /// the square and can be clipped to a circle at full size without needing an inset.
     var isFilledSquare: Bool {
-        guard let sample = sampleCornerAlphas() else { return false }
-        return sample.corners.allSatisfy { $0 >= 200 }
+        let metrics = ensureFaviconDerivedMetrics()
+        guard !metrics.cornerSampleUnavailable else { return false }
+        return metrics.cornerAlphas.allSatisfy { $0 >= 200 }
     }
 }
 
@@ -141,7 +218,7 @@ extension UIImage {
 
 extension UIImage {
     var isDark: Bool {
-        averageLuminance < 0.3
+        ensureFaviconDerivedMetrics().averageLuminance < 0.3
     }
 
     /// Returns `true` when the image contains any transparent pixels.
@@ -151,49 +228,14 @@ extension UIImage {
 
     /// Computes the average colour of all opaque pixels as a SwiftUI `Color`.
     var averageColor: Color {
-        guard let cgImage = cgImage else { return .gray }
-
-        let sampleSize = 16
-        let colorSpace = CGColorSpaceCreateDeviceRGB()
-        var pixelData = [UInt8](repeating: 0, count: sampleSize * sampleSize * 4)
-
-        guard let context = CGContext(
-            data: &pixelData,
-            width: sampleSize,
-            height: sampleSize,
-            bitsPerComponent: 8,
-            bytesPerRow: sampleSize * 4,
-            space: colorSpace,
-            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
-        ) else { return .gray }
-
-        context.draw(cgImage, in: CGRect(x: 0, y: 0, width: sampleSize, height: sampleSize))
-
-        var totalR: CGFloat = 0
-        var totalG: CGFloat = 0
-        var totalB: CGFloat = 0
-        var opaqueCount: CGFloat = 0
-
-        for index in 0..<(sampleSize * sampleSize) {
-            let offset = index * 4
-            let alpha = CGFloat(pixelData[offset + 3]) / 255.0
-            guard alpha > 0.1 else { continue }
-            totalR += CGFloat(pixelData[offset]) / 255.0
-            totalG += CGFloat(pixelData[offset + 1]) / 255.0
-            totalB += CGFloat(pixelData[offset + 2]) / 255.0
-            opaqueCount += 1
+        guard let rgb = ensureFaviconDerivedMetrics().averageColor, rgb.count >= 3 else {
+            return .gray
         }
-
-        guard opaqueCount > 0 else { return .gray }
-        return Color(
-            red: totalR / opaqueCount,
-            green: totalG / opaqueCount,
-            blue: totalB / opaqueCount
-        )
+        return Color(red: rgb[0], green: rgb[1], blue: rgb[2])
     }
 
-    /// Returns an RGB tuple of the average colour of all opaque pixels.
-    var averageColorComponents: (red: CGFloat, green: CGFloat, blue: CGFloat)? {
+    /// Raw 16×16 averaged RGB sample of opaque pixels.
+    fileprivate func _rawAverageColorComponents() -> (red: CGFloat, green: CGFloat, blue: CGFloat)? {
         guard let cgImage = cgImage else { return nil }
 
         let sampleSize = 16
@@ -231,6 +273,14 @@ extension UIImage {
         return (totalR / opaqueCount, totalG / opaqueCount, totalB / opaqueCount)
     }
 
+    /// Returns an RGB tuple of the average colour of all opaque pixels.
+    var averageColorComponents: (red: CGFloat, green: CGFloat, blue: CGFloat)? {
+        guard let rgb = ensureFaviconDerivedMetrics().averageColor, rgb.count >= 3 else {
+            return nil
+        }
+        return (CGFloat(rgb[0]), CGFloat(rgb[1]), CGFloat(rgb[2]))
+    }
+
     /// Returns a background colour derived from the favicon's average colour,
     /// lightened in light mode or darkened in dark mode, suitable for card backgrounds.
     func cardBackgroundColor(isDarkMode: Bool) -> Color {
@@ -260,46 +310,15 @@ extension UIImage {
     /// A near-white tint derived from the average colour of the image,
     /// suitable as a subtle background behind a transparent favicon.
     var nearWhiteAverageColor: Color {
-        guard let cgImage = cgImage else { return Color(.secondarySystemBackground) }
-
-        let sampleSize = 16
-        let colorSpace = CGColorSpaceCreateDeviceRGB()
-        var pixelData = [UInt8](repeating: 0, count: sampleSize * sampleSize * 4)
-
-        guard let context = CGContext(
-            data: &pixelData,
-            width: sampleSize,
-            height: sampleSize,
-            bitsPerComponent: 8,
-            bytesPerRow: sampleSize * 4,
-            space: colorSpace,
-            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
-        ) else { return Color(.secondarySystemBackground) }
-
-        context.draw(cgImage, in: CGRect(x: 0, y: 0, width: sampleSize, height: sampleSize))
-
-        var totalR: CGFloat = 0
-        var totalG: CGFloat = 0
-        var totalB: CGFloat = 0
-        var opaqueCount: CGFloat = 0
-
-        for index in 0..<(sampleSize * sampleSize) {
-            let offset = index * 4
-            let alpha = CGFloat(pixelData[offset + 3]) / 255.0
-            guard alpha > 0.1 else { continue }
-            totalR += CGFloat(pixelData[offset]) / 255.0
-            totalG += CGFloat(pixelData[offset + 1]) / 255.0
-            totalB += CGFloat(pixelData[offset + 2]) / 255.0
-            opaqueCount += 1
+        guard let rgb = ensureFaviconDerivedMetrics().averageColor, rgb.count >= 3 else {
+            return Color(.secondarySystemBackground)
         }
-
-        guard opaqueCount > 0 else { return Color(.secondarySystemBackground) }
-        let avgR = totalR / opaqueCount
-        let avgG = totalG / opaqueCount
-        let avgB = totalB / opaqueCount
+        let avgR = rgb[0]
+        let avgG = rgb[1]
+        let avgB = rgb[2]
 
         // Mix 85% white with 15% of the average colour
-        let whiteBlend: CGFloat = 0.85
+        let whiteBlend: Double = 0.85
         return Color(
             red: whiteBlend + (1 - whiteBlend) * avgR,
             green: whiteBlend + (1 - whiteBlend) * avgG,
@@ -310,6 +329,10 @@ extension UIImage {
     /// Returns `true` when virtually all opaque pixels are near-black,
     /// meaning the icon would be invisible on a dark background.
     var isNearBlack: Bool {
+        ensureFaviconDerivedMetrics().isNearBlack
+    }
+
+    fileprivate func _rawIsNearBlack() -> Bool {
         guard let cgImage = cgImage else { return false }
 
         let sampleSize = 16
@@ -347,7 +370,7 @@ extension UIImage {
         return Double(nearBlackCount) / Double(opaqueCount) > 0.9
     }
 
-    private var averageLuminance: CGFloat {
+    fileprivate func _rawAverageLuminance() -> CGFloat {
         guard let cgImage = cgImage else { return 1.0 }
 
         let sampleSize = 16

--- a/SakuraRSS/Views/Shared/FaviconImage.swift
+++ b/SakuraRSS/Views/Shared/FaviconImage.swift
@@ -83,7 +83,7 @@ struct FaviconImage: View {
 // launched sessions can skip the sampling entirely when the favicon
 // has been seen before.
 
-struct FaviconDerivedMetrics: Codable {
+nonisolated struct FaviconDerivedMetrics: Codable, Sendable {
     /// Twelve corner alpha samples (3 per corner) from a 32×32 downscaled
     /// version of the image.
     let cornerAlphas: [UInt8]
@@ -100,7 +100,7 @@ struct FaviconDerivedMetrics: Codable {
     let isNearBlack: Bool
 }
 
-private final class FaviconDerivedMetricsBox: NSObject {
+private nonisolated final class FaviconDerivedMetricsBox: NSObject, @unchecked Sendable {
     let metrics: FaviconDerivedMetrics
     init(_ metrics: FaviconDerivedMetrics) { self.metrics = metrics }
 }
@@ -110,7 +110,7 @@ private nonisolated(unsafe) var faviconDerivedMetricsKey: UInt8 = 0
 extension UIImage {
 
     /// In-memory memoized metrics attached to this UIImage instance.
-    var faviconDerivedMetrics: FaviconDerivedMetrics? {
+    nonisolated var faviconDerivedMetrics: FaviconDerivedMetrics? {
         get {
             (objc_getAssociatedObject(self, &faviconDerivedMetricsKey) as? FaviconDerivedMetricsBox)?.metrics
         }
@@ -127,7 +127,7 @@ extension UIImage {
 
     /// Returns the cached metrics, computing and attaching them on first call.
     @discardableResult
-    func ensureFaviconDerivedMetrics() -> FaviconDerivedMetrics {
+    nonisolated func ensureFaviconDerivedMetrics() -> FaviconDerivedMetrics {
         if let existing = faviconDerivedMetrics { return existing }
         let cornerSample = _rawSampleCornerAlphas()
         let averageRGB = _rawAverageColorComponents()
@@ -157,7 +157,7 @@ extension UIImage {
     }
 
     /// Samples corner and center pixel alpha values from a downscaled version of the image.
-    fileprivate func _rawSampleCornerAlphas() -> (corners: [UInt8], centerAlpha: UInt8)? {
+    fileprivate nonisolated func _rawSampleCornerAlphas() -> (corners: [UInt8], centerAlpha: UInt8)? {
         guard let cgImage = cgImage else { return nil }
         let width = cgImage.width
         let height = cgImage.height
@@ -235,7 +235,7 @@ extension UIImage {
     }
 
     /// Raw 16×16 averaged RGB sample of opaque pixels.
-    fileprivate func _rawAverageColorComponents() -> (red: CGFloat, green: CGFloat, blue: CGFloat)? {
+    fileprivate nonisolated func _rawAverageColorComponents() -> (red: CGFloat, green: CGFloat, blue: CGFloat)? {
         guard let cgImage = cgImage else { return nil }
 
         let sampleSize = 16
@@ -332,7 +332,7 @@ extension UIImage {
         ensureFaviconDerivedMetrics().isNearBlack
     }
 
-    fileprivate func _rawIsNearBlack() -> Bool {
+    fileprivate nonisolated func _rawIsNearBlack() -> Bool {
         guard let cgImage = cgImage else { return false }
 
         let sampleSize = 16
@@ -370,7 +370,7 @@ extension UIImage {
         return Double(nearBlackCount) / Double(opaqueCount) > 0.9
     }
 
-    fileprivate func _rawAverageLuminance() -> CGFloat {
+    fileprivate nonisolated func _rawAverageLuminance() -> CGFloat {
         guard let cgImage = cgImage else { return 1.0 }
 
         let sampleSize = 16

--- a/Shared/Favicon Cache/FaviconCache+Fetching.swift
+++ b/Shared/Favicon Cache/FaviconCache+Fetching.swift
@@ -12,6 +12,9 @@ extension FaviconCache {
         if let pngData = result.pngData() {
             try? pngData.write(to: filePath)
         }
+        // Compute and persist the derived-metrics sidecar next to the PNG
+        // so subsequent launches don't need to re-sample the pixels.
+        attachDerivedMetrics(cacheKey: cacheKey, to: result)
         memoryCache[cacheKey] = result
         return result
     }

--- a/Shared/Favicon Cache/FaviconCache.swift
+++ b/Shared/Favicon Cache/FaviconCache.swift
@@ -50,6 +50,7 @@ actor FaviconCache {
             let skipTrim = FaviconSkipTrimDomains.shouldSkipTrimming(feedDomain: domain)
                 || FaviconCircularDomains.shouldUseCircleIcon(feedDomain: domain)
             let result = skipTrim ? image : await image.trimmed()
+            attachDerivedMetrics(cacheKey: cacheKey, to: result)
             memoryCache[cacheKey] = result
             return result
         }
@@ -65,6 +66,7 @@ actor FaviconCache {
             failedLookups.remove(cacheKey)
             let filePath = cacheDirectory.appendingPathComponent(sanitizedFileName(cacheKey))
             try? FileManager.default.removeItem(at: filePath)
+            try? FileManager.default.removeItem(at: metricsSidecarURL(for: cacheKey))
         }
         await withTaskGroup(of: Void.self) { group in
             for entry in entries {
@@ -109,5 +111,32 @@ actor FaviconCache {
     func sanitizedFileName(_ key: String) -> String {
         key.replacingOccurrences(of: "/", with: "_")
             .replacingOccurrences(of: ":", with: "_") + ".png"
+    }
+
+    // MARK: - Derived Metrics Sidecar
+
+    /// JSON sidecar URL holding FaviconDerivedMetrics for a cached favicon.
+    /// Stored next to the PNG so `refreshFavicons`/`clearCache` wipe both
+    /// together by iterating the directory.
+    func metricsSidecarURL(for cacheKey: String) -> URL {
+        cacheDirectory.appendingPathComponent(sanitizedFileName(cacheKey) + ".meta.json")
+    }
+
+    /// Attaches the cached metrics to the image.  If the sidecar already
+    /// exists on disk it's decoded and attached as-is; otherwise the
+    /// metrics are computed from the pixels now and the sidecar is
+    /// written, so subsequent app launches avoid the pixel sampling
+    /// work entirely.
+    func attachDerivedMetrics(cacheKey: String, to image: UIImage) {
+        let url = metricsSidecarURL(for: cacheKey)
+        if let data = try? Data(contentsOf: url),
+           let metrics = try? JSONDecoder().decode(FaviconDerivedMetrics.self, from: data) {
+            image.faviconDerivedMetrics = metrics
+            return
+        }
+        let metrics = image.ensureFaviconDerivedMetrics()
+        if let data = try? JSONEncoder().encode(metrics) {
+            try? data.write(to: url)
+        }
     }
 }

--- a/Shared/Favicon Cache/FaviconCache.swift
+++ b/Shared/Favicon Cache/FaviconCache.swift
@@ -6,17 +6,18 @@ actor FaviconCache {
     static let shared = FaviconCache()
 
     /// Dedicated URLSession used for every favicon-related network fetch.
-    /// Favicons are cosmetic and must not fail just because an image takes
-    /// a long time to download, so this session effectively bypasses the
-    /// normal request / resource timeouts.  `httpAdditionalHeaders` sets
-    /// a Safari-parity User-Agent on every request so the default
-    /// `CFNetwork` UA (which leaks the app bundle ID and iOS version) is
-    /// never sent.
+    /// Favicons are cosmetic, and hanging on a slow or unreachable host
+    /// keeps a request slot — and radio time — alive for far longer than
+    /// a missing icon is worth.  Keep the timeouts tight (3 seconds) and
+    /// disable `waitsForConnectivity` so we never sit on a request while
+    /// the device is offline.  `httpAdditionalHeaders` sets a Safari-parity
+    /// User-Agent on every request so the default `CFNetwork` UA (which
+    /// leaks the app bundle ID and iOS version) is never sent.
     nonisolated static let urlSession: URLSession = {
         let config = URLSessionConfiguration.default
-        config.timeoutIntervalForRequest = 600
-        config.timeoutIntervalForResource = 600
-        config.waitsForConnectivity = true
+        config.timeoutIntervalForRequest = 3
+        config.timeoutIntervalForResource = 3
+        config.waitsForConnectivity = false
         config.httpAdditionalHeaders = ["User-Agent": sakuraUserAgent]
         return URLSession(configuration: config)
     }()

--- a/Shared/Localizable.xcstrings
+++ b/Shared/Localizable.xcstrings
@@ -24646,6 +24646,65 @@
         }
       }
     },
+    "TodaysSummary.LowPowerModePrompt" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stromsparmodus ist aktiv. Tippen Sie auf Aktualisieren, um die Zusammenfassung zu erstellen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Low Power Mode is on. Tap refresh to generate the summary."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le mode économie d'énergie est activé. Appuyez sur actualiser pour générer le résumé."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Risparmio energetico attivo. Tocca aggiorna per generare il riepilogo."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "低電力モードがオンです。更新をタップして要約を作成してください。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "저전력 모드가 켜져 있습니다. 새로고침을 눌러 요약을 생성하세요."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chế độ nguồn điện thấp đang bật. Nhấn làm mới để tạo bản tóm tắt."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "低电量模式已开启。点按刷新以生成摘要。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "低耗電模式已開啟。點一下重新整理以產生摘要。"
+          }
+        }
+      }
+    },
     "TodaysSummary.PartialPrompt" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -25291,6 +25350,65 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "正在摘要夜間內容⋯"
+          }
+        }
+      }
+    },
+    "WhileYouSlept.LowPowerModePrompt" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stromsparmodus ist aktiv. Tippen Sie auf Aktualisieren, um die Zusammenfassung zu erstellen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Low Power Mode is on. Tap refresh to generate the summary."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le mode économie d'énergie est activé. Appuyez sur actualiser pour générer le résumé."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Risparmio energetico attivo. Tocca aggiorna per generare il riepilogo."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "低電力モードがオンです。更新をタップして要約を作成してください。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "저전력 모드가 켜져 있습니다. 새로고침을 눌러 요약을 생성하세요."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chế độ nguồn điện thấp đang bật. Nhấn làm mới để tạo bản tóm tắt."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "低电量模式已开启。点按刷新以生成摘要。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "低耗電模式已開啟。點一下重新整理以產生摘要。"
           }
         }
       }

--- a/Shared/Localizable.xcstrings
+++ b/Shared/Localizable.xcstrings
@@ -19514,6 +19514,208 @@
         }
       }
     },
+    "Settings.RefreshCooldown" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mindestabstand zwischen Aktualisierungen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Per-Feed Cooldown"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Délai entre actualisations"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Intervallo minimo per feed"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "フィード更新の間隔"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "피드별 재시도 간격"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Khoảng thời gian tối thiểu giữa các lần làm mới"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "每个订阅源的冷却时间"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "每個訂閱源的冷卻時間"
+          }
+        }
+      }
+    },
+    "Settings.RefreshCooldown.Off" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Aus" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Off" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Désactivé" } },
+        "it" : { "stringUnit" : { "state" : "translated", "value" : "Disattivato" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "オフ" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "끔" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "Tắt" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "关闭" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "關閉" } }
+      }
+    },
+    "Settings.RefreshCooldown.1min" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "1 Minute" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "1 minute" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "1 minute" } },
+        "it" : { "stringUnit" : { "state" : "translated", "value" : "1 minuto" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "1分" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "1분" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "1 phút" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "1 分钟" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "1 分鐘" } }
+      }
+    },
+    "Settings.RefreshCooldown.5min" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "5 Minuten" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "5 minutes" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "5 minutes" } },
+        "it" : { "stringUnit" : { "state" : "translated", "value" : "5 minuti" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "5分" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "5분" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "5 phút" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "5 分钟" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "5 分鐘" } }
+      }
+    },
+    "Settings.RefreshCooldown.10min" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "10 Minuten" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "10 minutes" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "10 minutes" } },
+        "it" : { "stringUnit" : { "state" : "translated", "value" : "10 minuti" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "10分" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "10분" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "10 phút" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "10 分钟" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "10 分鐘" } }
+      }
+    },
+    "Settings.RefreshCooldown.30min" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "30 Minuten" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "30 minutes" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "30 minutes" } },
+        "it" : { "stringUnit" : { "state" : "translated", "value" : "30 minuti" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "30分" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "30분" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "30 phút" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "30 分钟" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "30 分鐘" } }
+      }
+    },
+    "Settings.RefreshCooldown.1hour" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "1 Stunde" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "1 hour" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "1 heure" } },
+        "it" : { "stringUnit" : { "state" : "translated", "value" : "1 ora" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "1時間" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "1시간" } },
+        "vi" : { "stringUnit" : { "state" : "translated", "value" : "1 giờ" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "1 小时" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "1 小時" } }
+      }
+    },
+    "Settings.RefreshCooldown.Footer" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Feeds, die innerhalb dieses Zeitraums automatisch aktualisiert wurden, werden übersprungen. Das manuelle Herunterziehen zum Aktualisieren lädt immer alles neu. Neu hinzugefügte Feeds werden sofort geladen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Feeds refreshed automatically within this window are skipped. Pull-to-refresh always refreshes everything. Newly added feeds always refresh."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les flux déjà actualisés automatiquement dans cette fenêtre sont ignorés. Tirer pour actualiser rafraîchit toujours tout. Les nouveaux flux sont toujours actualisés."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "I feed aggiornati automaticamente entro questa finestra vengono saltati. Il pull-to-refresh aggiorna sempre tutto. I feed appena aggiunti si aggiornano sempre."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "この期間内に自動更新されたフィードはスキップされます。プルダウン更新では常にすべてが更新されます。新しく追加されたフィードは必ず更新されます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 기간 동안 자동으로 새로고친 피드는 건너뜁니다. 당겨서 새로고침은 항상 전체를 새로고칩니다. 새로 추가된 피드는 항상 새로고칩니다."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Các nguồn được làm mới tự động trong khoảng thời gian này sẽ bị bỏ qua. Kéo để làm mới luôn làm mới tất cả. Nguồn mới thêm luôn được làm mới."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在此时间窗口内自动刷新过的订阅源会被跳过。下拉刷新始终会刷新所有订阅源。新添加的订阅源始终会刷新。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在此時間範圍內已自動重新整理的訂閱源會被略過。下拉重新整理一律重新整理全部。新加入的訂閱源一律重新整理。"
+          }
+        }
+      }
+    },
     "Settings.SearchDisplayStyle" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Shared/Models.swift
+++ b/Shared/Models.swift
@@ -170,6 +170,31 @@ nonisolated enum UnreadBadgeMode: String, CaseIterable, Sendable {
     case none
 }
 
+/// User-configurable cooldown between automatic per-feed refreshes.
+/// Applied when an automatic trigger (background refresh, app startup,
+/// foreground re-enter) asks to refresh every feed.  Does not affect
+/// explicit user-triggered refreshes such as pull-to-refresh.
+nonisolated enum FeedRefreshCooldown: String, CaseIterable, Sendable {
+    case off
+    case oneMinute
+    case fiveMinutes
+    case tenMinutes
+    case thirtyMinutes
+    case oneHour
+
+    /// Seconds to enforce, or `nil` when cooldown is disabled.
+    var seconds: TimeInterval? {
+        switch self {
+        case .off: return nil
+        case .oneMinute: return 60
+        case .fiveMinutes: return 5 * 60
+        case .tenMinutes: return 10 * 60
+        case .thirtyMinutes: return 30 * 60
+        case .oneHour: return 60 * 60
+        }
+    }
+}
+
 nonisolated struct FeedList: Identifiable, Hashable, Sendable {
     let id: Int64
     var name: String

--- a/Shared/NLP/NLPProcessor.swift
+++ b/Shared/NLP/NLPProcessor.swift
@@ -30,6 +30,14 @@ nonisolated enum NLPProcessor {
     static func extractEntities(from text: String) -> [EntityResult] {
         guard !text.isEmpty else { return [] }
         let tagger = NLTagger(tagSchemes: [.nameType])
+        return extractEntities(from: text, using: tagger)
+    }
+
+    /// Batch-friendly variant: reuses a caller-owned `NLTagger` across many
+    /// articles so tagger construction cost is amortized.  The caller is
+    /// responsible for passing a tagger initialized with `.nameType`.
+    static func extractEntities(from text: String, using tagger: NLTagger) -> [EntityResult] {
+        guard !text.isEmpty else { return [] }
         tagger.string = text
         let options: NLTagger.Options = [.omitWhitespace, .omitPunctuation, .joinNames]
 
@@ -71,6 +79,14 @@ nonisolated enum NLPProcessor {
     static func sentimentScore(for text: String) -> Double? {
         guard !text.isEmpty else { return nil }
         let tagger = NLTagger(tagSchemes: [.sentimentScore])
+        return sentimentScore(for: text, using: tagger)
+    }
+
+    /// Batch-friendly variant: reuses a caller-owned `NLTagger` across many
+    /// articles.  The caller is responsible for passing a tagger initialized
+    /// with `.sentimentScore`.
+    static func sentimentScore(for text: String, using tagger: NLTagger) -> Double? {
+        guard !text.isEmpty else { return nil }
         tagger.string = text
 
         var scores: [Double] = []

--- a/Shared/SpotlightIndexer.swift
+++ b/Shared/SpotlightIndexer.swift
@@ -5,6 +5,18 @@ nonisolated enum SpotlightIndexer {
 
     static let domainIdentifier = "com.tsubuzaki.SakuraRSS.article"
 
+    /// Schema version for the Spotlight searchable-item attributes produced
+    /// by `indexArticles`.  Bump this whenever the attribute shape changes
+    /// (fields added/removed/renamed) so the next launch triggers a
+    /// one-time full reindex.  The full reindex is otherwise never run
+    /// automatically — the per-feed-refresh incremental path keeps the
+    /// index up to date in the steady state.
+    static let schemaVersion: Int = 1
+
+    /// `UserDefaults` key holding the `schemaVersion` value that was in
+    /// effect the last time a full reindex completed.
+    static let schemaVersionDefaultsKey = "App.SpotlightIndexVersion"
+
     // MARK: - Indexing
 
     static func indexArticles(_ articles: [Article], feedTitle: String?) {

--- a/Widgets/AllArticlesWidget/ArticleProvider.swift
+++ b/Widgets/AllArticlesWidget/ArticleProvider.swift
@@ -22,7 +22,10 @@ struct ArticleProvider: TimelineProvider {
 
     func getTimeline(in _: Context, completion: @escaping (Timeline<ArticleEntry>) -> Void) {
         let entry = loadEntry()
-        let timeline = Timeline(entries: [entry], policy: .after(Date().addingTimeInterval(30 * 60)))
+        // Timeline refreshes every 90 minutes instead of every 30.  Widgets
+        // running outside the app process wake it on every reload; tripling
+        // the interval triples the battery savings for this path.
+        let timeline = Timeline(entries: [entry], policy: .after(Date().addingTimeInterval(90 * 60)))
         completion(timeline)
     }
 

--- a/Widgets/ListWidget/ListWidgetProvider.swift
+++ b/Widgets/ListWidget/ListWidgetProvider.swift
@@ -30,7 +30,10 @@ struct ListWidgetProvider: AppIntentTimelineProvider {
 
     func timeline(for configuration: ListWidgetIntent, in _: Context) async -> Timeline<ListWidgetEntry> {
         let entry = await loadEntry(for: configuration)
-        return Timeline(entries: [entry], policy: .after(Date().addingTimeInterval(30 * 60)))
+        // Timeline refreshes every 90 minutes instead of every 30.  Widgets
+        // running outside the app process wake it on every reload; tripling
+        // the interval triples the battery savings for this path.
+        return Timeline(entries: [entry], policy: .after(Date().addingTimeInterval(90 * 60)))
     }
 
     private func loadEntry(for configuration: ListWidgetIntent) async -> ListWidgetEntry {
@@ -90,6 +93,16 @@ struct ListWidgetProvider: AppIntentTimelineProvider {
             let pageStart = currentPage * perPage
             let pageArticles = Array(dbArticles.dropFirst(pageStart).prefix(perPage))
 
+            // Skip image network fetches when the top article IDs haven't
+            // changed since the last timeline build.  DB-cached images still
+            // resolve normally; this prevents retrying failing downloads on
+            // every 90-minute timeline wake.
+            let articleIDsMarker = pageArticles.map(\.id).map(String.init).joined(separator: ",")
+            let markerKey = "listWidgetMarker_\(listID)_\(layout.rawValue)_\(columns)_\(currentPage)"
+            let previousMarker = defaults?.string(forKey: markerKey)
+            let articleSetUnchanged = previousMarker == articleIDsMarker
+            defaults?.set(articleIDsMarker, forKey: markerKey)
+
             var widgetArticles: [ListWidgetArticle] = []
             for article in pageArticles {
                 var imageData: Data?
@@ -97,7 +110,7 @@ struct ListWidgetProvider: AppIntentTimelineProvider {
                     var rawData: Data?
                     if let cached = try? database.cachedImageData(for: imageURLString) {
                         rawData = cached
-                    } else {
+                    } else if !articleSetUnchanged {
                         if let (data, _) = try? await URLSession.shared.data(for: .sakura(url: imageURL)) {
                             try? database.cacheImageData(data, for: imageURLString)
                             rawData = data

--- a/Widgets/SingleFeedWidget/SingleFeedProvider.swift
+++ b/Widgets/SingleFeedWidget/SingleFeedProvider.swift
@@ -30,7 +30,10 @@ struct SingleFeedProvider: AppIntentTimelineProvider {
 
     func timeline(for configuration: SingleFeedIntent, in _: Context) async -> Timeline<SingleFeedEntry> {
         let entry = await loadEntry(for: configuration)
-        return Timeline(entries: [entry], policy: .after(Date().addingTimeInterval(30 * 60)))
+        // Timeline refreshes every 90 minutes instead of every 30.  Widgets
+        // running outside the app process wake it on every reload; tripling
+        // the interval triples the battery savings for this path.
+        return Timeline(entries: [entry], policy: .after(Date().addingTimeInterval(90 * 60)))
     }
 
     private func loadEntry(for configuration: SingleFeedIntent) async -> SingleFeedEntry {
@@ -67,6 +70,16 @@ struct SingleFeedProvider: AppIntentTimelineProvider {
             let pageStart = currentPage * perPage
             let pageArticles = Array(dbArticles.dropFirst(pageStart).prefix(perPage))
 
+            // Skip image network fetches when the top article IDs haven't
+            // changed since the last timeline build.  DB-cached images still
+            // resolve normally; this prevents retrying failing downloads on
+            // every 90-minute timeline wake.
+            let articleIDsMarker = pageArticles.map(\.id).map(String.init).joined(separator: ",")
+            let markerKey = "singleFeedMarker_\(feedID)_\(layout.rawValue)_\(columns)_\(currentPage)"
+            let previousMarker = defaults?.string(forKey: markerKey)
+            let articleSetUnchanged = previousMarker == articleIDsMarker
+            defaults?.set(articleIDsMarker, forKey: markerKey)
+
             var widgetArticles: [SingleFeedArticle] = []
             for article in pageArticles {
                 var imageData: Data?
@@ -77,7 +90,7 @@ struct SingleFeedProvider: AppIntentTimelineProvider {
                         debugPrint("[Widget] Image cache hit for \(imageURLString) (\(cached.count) bytes)")
                         #endif
                         rawData = cached
-                    } else {
+                    } else if !articleSetUnchanged {
                         if let (data, _) = try? await URLSession.shared.data(for: .sakura(url: imageURL)) {
                             #if DEBUG
                             debugPrint("[Widget] Downloaded image \(imageURLString) (\(data.count) bytes)")


### PR DESCRIPTION
## Summary

Implements all ten tier items from the battery impact audit, one
commit per item for reviewable-in-isolation diffs.

### Tier 1 — Highest-impact paths

- **T1-A `3bca2fe`** — Default BG refresh cadence from 1h → 4h. Early
  return from `BGAppRefreshTask` and skip NLP/Spotlight derivative work
  under Low Power Mode; feed fetch still runs.
- **T1-B `84d2bd9`** — `BatchSummarizer` filters out articles whose
  stripped-HTML body is empty, shorter than 200 chars, or identical
  to the title. Today's Summary / While You Slept auto-generation is
  replaced by a manual-tap prompt while LPM is on.

### Tier 2 — Meaningful-impact paths

- **T2-A `eacfaed`** — Memoize favicon pixel sampling
  (`cornerAlphas`, `averageLuminance`, `averageColor`,
  `nearWhiteAverageColor`, `isNearBlack`) on the `UIImage` via
  associated-object storage, with a JSON sidecar next to each cached
  favicon PNG so newly-launched sessions skip sampling entirely.
- **T2-B `b0b52f6`** — Per-feed refresh cooldown using the existing
  `lastFetched` column (no new migration). New
  `FeedRefreshCooldown` setting (`off` / `1m` / `5m` / `10m` / `30m` /
  `1h`, default `5m`) with localized picker + footer. Applies only to
  automatic triggers; pull-to-refresh remains unconditional.
- **T2-C `a63f46d`** — Widget timelines from 30 → 90 minutes across
  `SingleFeedWidget`, `ListWidget`, and `AllArticlesWidget`.  Added a
  per-widget marker (UserDefaults in the app group) that records the
  top article IDs; unchanged sets skip the network fetch path
  entirely, so failing image URLs aren't retried on every wake.
- **T2-D `85d6454`** — `NLPProcessingCoordinator` reuses a single
  `.sentimentScore` and single `.nameType` `NLTagger` across every
  article in a batch instead of constructing one per call. LPM gate
  at the entry point, priority dropped to `.utility`, chunks down to
  20 with `Task.yield()` between chunks.
- **T2-E `821e478`** — Full Spotlight reindex now only runs on a
  stored schema-version mismatch (`SpotlightIndexer.schemaVersion`,
  currently `1`).  Not gated on LPM: a schema change means search
  would otherwise be broken until LPM ends.
- **T2-F `39d4c2e`** — Favicon `URLSession` timeouts down from 600s
  to 3s; `waitsForConnectivity = false`.

### Tier 3 — Smaller but cheap wins

- **T3-A `e07b5e6`** — `CachedAsyncImage` re-checks the shared
  `ImageMemoryCache` after a successful download and skips the
  SQLite write when a concurrent loader already populated it.
- **T3-B `f53ab18`** — Debounce the `willEnterForegroundNotification`
  chain (DB reload + widget reload + `refreshUnfetchedFeeds`) with a
  5-minute floor. Badge update stays outside the gate.

### Build fixes

- **`ceab73b`** — Mark `FaviconDerivedMetrics` + `UIImage` memoization
  path `nonisolated` (project builds with
  `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`, so `FaviconCache`
  couldn't reach them).
- **`4cbdfa7`** — Same fix for `NLPProcessingCoordinator.chunkSize`.

## Test plan

- [ ] Feeds refresh on pull-to-refresh, foreground, and BG wake
- [ ] Cooldown skips recently-fetched feeds; NULL `lastFetched`
      always refreshes
- [ ] Today's Summary generates on tap outside LPM; under LPM the
      prompt appears and auto-generation is suppressed
- [ ] Favicons render with correct derived colors after relaunch
      (sidecars loaded from disk, no pixel sampling on hot path)
- [ ] All three widget variants render articles and cached images
- [ ] Spotlight returns results; bumping `spotlightIndexVersion`
      locally triggers exactly one full reindex on next launch
- [ ] LPM: BG refresh early-returns, NLP/Spotlight derivative work
      skipped, schema-version reindex still runs
- [ ] Instruments Energy Log comparison before/after on synthetic
      workload (BG refresh via LLDB `_simulateLaunchForTaskWithIdentifier`,
      favicon-heavy scrolling, widget reloads)

<https://claude.ai/code/session_01NevQM94gddYSzEW5W6BeUs>
