### PR TITLE
Preserve user-edited feed titles and cap X/Instagram follows

### DIFF
--- a/SakuraRSS/Classes/Feed Manager/FeedManager+InstagramProfile.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+InstagramProfile.swift
@@ -87,20 +87,27 @@ extension FeedManager {
         // means the Instagram profile photo only auto-installs on the
         // very first fetch; to pull a fresh profile photo, the user
         // can delete the custom icon in the edit sheet.
+        // If the user has customized the feed title, preserve their
+        // override on refresh — `effectiveTitle` always carries the
+        // stored title in that case so `updateFeedDetails` never
+        // silently overwrites it with the scraped display name.
+        let effectiveTitle = feed.isTitleCustomized ? feed.title : feedTitle
         let shouldInstallProfilePhoto = profileImage != nil && feed.customIconURL == nil
         if shouldInstallProfilePhoto, let image = profileImage {
             await FaviconCache.shared.setCustomFavicon(image, feedID: feed.id, skipTrimming: true)
             try? await Task.detached {
                 try database.updateFeedDetails(
-                    id: feed.id, title: feedTitle, url: feed.url,
-                    customIconURL: "photo"
+                    id: feed.id, title: effectiveTitle, url: feed.url,
+                    customIconURL: "photo",
+                    isTitleCustomized: feed.isTitleCustomized
                 )
             }.value
-        } else if feed.title != feedTitle {
+        } else if feed.title != effectiveTitle {
             try? await Task.detached {
                 try database.updateFeedDetails(
-                    id: feed.id, title: feedTitle, url: feed.url,
-                    customIconURL: feed.customIconURL
+                    id: feed.id, title: effectiveTitle, url: feed.url,
+                    customIconURL: feed.customIconURL,
+                    isTitleCustomized: feed.isTitleCustomized
                 )
             }.value
         }

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+InstagramProfile.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+InstagramProfile.swift
@@ -78,39 +78,13 @@ extension FeedManager {
             SpotlightIndexer.indexArticles(articlesToIndex, feedTitle: feedTitle)
         }.value
 
-        // Cache favicon and update feed details.
-        //
-        // Only install the downloaded profile photo when the feed has
-        // no custom icon yet (`customIconURL == nil`).  Once the user —
-        // or a prior refresh — has assigned any custom icon, preserve
-        // it across refreshes so it isn't silently overwritten.  This
-        // means the Instagram profile photo only auto-installs on the
-        // very first fetch; to pull a fresh profile photo, the user
-        // can delete the custom icon in the edit sheet.
-        // If the user has customized the feed title, preserve their
-        // override on refresh — `effectiveTitle` always carries the
-        // stored title in that case so `updateFeedDetails` never
-        // silently overwrites it with the scraped display name.
-        let effectiveTitle = feed.isTitleCustomized ? feed.title : feedTitle
-        let shouldInstallProfilePhoto = profileImage != nil && feed.customIconURL == nil
-        if shouldInstallProfilePhoto, let image = profileImage {
-            await FaviconCache.shared.setCustomFavicon(image, feedID: feed.id, skipTrimming: true)
-            try? await Task.detached {
-                try database.updateFeedDetails(
-                    id: feed.id, title: effectiveTitle, url: feed.url,
-                    customIconURL: "photo",
-                    isTitleCustomized: feed.isTitleCustomized
-                )
-            }.value
-        } else if feed.title != effectiveTitle {
-            try? await Task.detached {
-                try database.updateFeedDetails(
-                    id: feed.id, title: effectiveTitle, url: feed.url,
-                    customIconURL: feed.customIconURL,
-                    isTitleCustomized: feed.isTitleCustomized
-                )
-            }.value
-        }
+        // Cache favicon and update feed details.  The shared helper
+        // honours `isTitleCustomized` and only installs the downloaded
+        // profile photo when `customIconURL == nil`, so a user-assigned
+        // icon or title survives every refresh.
+        await applyScraperMetadataRefresh(
+            feed: feed, scrapedTitle: feedTitle, profileImage: profileImage
+        )
 
         if reloadData {
             await loadFromDatabaseInBackground()

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+XProfile.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+XProfile.swift
@@ -66,39 +66,13 @@ extension FeedManager {
             SpotlightIndexer.indexArticles(articlesToIndex, feedTitle: feedTitle)
         }.value
 
-        // Cache favicon and update feed details.
-        //
-        // Only install the downloaded profile photo when the feed has
-        // no custom icon yet (`customIconURL == nil`).  Once the user —
-        // or a prior refresh — has assigned any custom icon, preserve
-        // it across refreshes so it isn't silently overwritten.  This
-        // means the X profile photo only auto-installs on the very
-        // first fetch; to pull a fresh profile photo, the user can
-        // delete the custom icon in the edit sheet.
-        // If the user has customized the feed title, preserve their
-        // override on refresh — `effectiveTitle` always carries the
-        // stored title in that case so `updateFeedDetails` never
-        // silently overwrites it with the scraped display name.
-        let effectiveTitle = feed.isTitleCustomized ? feed.title : feedTitle
-        let shouldInstallProfilePhoto = profileImage != nil && feed.customIconURL == nil
-        if shouldInstallProfilePhoto, let image = profileImage {
-            await FaviconCache.shared.setCustomFavicon(image, feedID: feed.id, skipTrimming: true)
-            try? await Task.detached {
-                try database.updateFeedDetails(
-                    id: feed.id, title: effectiveTitle, url: feed.url,
-                    customIconURL: "photo",
-                    isTitleCustomized: feed.isTitleCustomized
-                )
-            }.value
-        } else if feed.title != effectiveTitle {
-            try? await Task.detached {
-                try database.updateFeedDetails(
-                    id: feed.id, title: effectiveTitle, url: feed.url,
-                    customIconURL: feed.customIconURL,
-                    isTitleCustomized: feed.isTitleCustomized
-                )
-            }.value
-        }
+        // Cache favicon and update feed details.  The shared helper
+        // honours `isTitleCustomized` and only installs the downloaded
+        // profile photo when `customIconURL == nil`, so a user-assigned
+        // icon or title survives every refresh.
+        await applyScraperMetadataRefresh(
+            feed: feed, scrapedTitle: feedTitle, profileImage: profileImage
+        )
 
         if reloadData {
             await loadFromDatabaseInBackground()

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+XProfile.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+XProfile.swift
@@ -75,20 +75,27 @@ extension FeedManager {
         // means the X profile photo only auto-installs on the very
         // first fetch; to pull a fresh profile photo, the user can
         // delete the custom icon in the edit sheet.
+        // If the user has customized the feed title, preserve their
+        // override on refresh — `effectiveTitle` always carries the
+        // stored title in that case so `updateFeedDetails` never
+        // silently overwrites it with the scraped display name.
+        let effectiveTitle = feed.isTitleCustomized ? feed.title : feedTitle
         let shouldInstallProfilePhoto = profileImage != nil && feed.customIconURL == nil
         if shouldInstallProfilePhoto, let image = profileImage {
             await FaviconCache.shared.setCustomFavicon(image, feedID: feed.id, skipTrimming: true)
             try? await Task.detached {
                 try database.updateFeedDetails(
-                    id: feed.id, title: feedTitle, url: feed.url,
-                    customIconURL: "photo"
+                    id: feed.id, title: effectiveTitle, url: feed.url,
+                    customIconURL: "photo",
+                    isTitleCustomized: feed.isTitleCustomized
                 )
             }.value
-        } else if feed.title != feedTitle {
+        } else if feed.title != effectiveTitle {
             try? await Task.detached {
                 try database.updateFeedDetails(
-                    id: feed.id, title: feedTitle, url: feed.url,
-                    customIconURL: feed.customIconURL
+                    id: feed.id, title: effectiveTitle, url: feed.url,
+                    customIconURL: feed.customIconURL,
+                    isTitleCustomized: feed.isTitleCustomized
                 )
             }.value
         }

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+YouTubePlaylist.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+YouTubePlaylist.swift
@@ -63,38 +63,13 @@ extension FeedManager {
             SpotlightIndexer.indexArticles(articlesToIndex, feedTitle: feedTitle)
         }.value
 
-        // Only install the downloaded channel avatar when the feed has
-        // no custom icon yet. Once the user — or a prior refresh — has
-        // assigned any custom icon, preserve it across refreshes so it
-        // isn't silently overwritten. The avatar auto-installs on the
-        // very first fetch; to pull a fresh avatar, the user can delete
-        // the custom icon in the edit sheet.
-        // If the user has customized the feed title, preserve their
-        // override on refresh — `effectiveTitle` always carries the
-        // stored title in that case so `updateFeedDetails` never
-        // silently overwrites it with the scraped playlist title.
-        let effectiveTitle = feed.isTitleCustomized ? feed.title : feedTitle
-        let shouldInstallAvatar = avatarImage != nil && feed.customIconURL == nil
-        if shouldInstallAvatar, let image = avatarImage {
-            await FaviconCache.shared.setCustomFavicon(
-                image, feedID: feed.id, skipTrimming: true
-            )
-            try? await Task.detached {
-                try database.updateFeedDetails(
-                    id: feed.id, title: effectiveTitle, url: feed.url,
-                    customIconURL: "photo",
-                    isTitleCustomized: feed.isTitleCustomized
-                )
-            }.value
-        } else if feed.title != effectiveTitle {
-            try? await Task.detached {
-                try database.updateFeedDetails(
-                    id: feed.id, title: effectiveTitle, url: feed.url,
-                    customIconURL: feed.customIconURL,
-                    isTitleCustomized: feed.isTitleCustomized
-                )
-            }.value
-        }
+        // Cache favicon and update feed details.  The shared helper
+        // honours `isTitleCustomized` and only installs the downloaded
+        // channel avatar when `customIconURL == nil`, so a user-assigned
+        // icon or title survives every refresh.
+        await applyScraperMetadataRefresh(
+            feed: feed, scrapedTitle: feedTitle, profileImage: avatarImage
+        )
 
         if reloadData {
             await loadFromDatabaseInBackground()

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+YouTubePlaylist.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+YouTubePlaylist.swift
@@ -69,6 +69,11 @@ extension FeedManager {
         // isn't silently overwritten. The avatar auto-installs on the
         // very first fetch; to pull a fresh avatar, the user can delete
         // the custom icon in the edit sheet.
+        // If the user has customized the feed title, preserve their
+        // override on refresh — `effectiveTitle` always carries the
+        // stored title in that case so `updateFeedDetails` never
+        // silently overwrites it with the scraped playlist title.
+        let effectiveTitle = feed.isTitleCustomized ? feed.title : feedTitle
         let shouldInstallAvatar = avatarImage != nil && feed.customIconURL == nil
         if shouldInstallAvatar, let image = avatarImage {
             await FaviconCache.shared.setCustomFavicon(
@@ -76,15 +81,17 @@ extension FeedManager {
             )
             try? await Task.detached {
                 try database.updateFeedDetails(
-                    id: feed.id, title: feedTitle, url: feed.url,
-                    customIconURL: "photo"
+                    id: feed.id, title: effectiveTitle, url: feed.url,
+                    customIconURL: "photo",
+                    isTitleCustomized: feed.isTitleCustomized
                 )
             }.value
-        } else if feed.title != feedTitle {
+        } else if feed.title != effectiveTitle {
             try? await Task.detached {
                 try database.updateFeedDetails(
-                    id: feed.id, title: feedTitle, url: feed.url,
-                    customIconURL: feed.customIconURL
+                    id: feed.id, title: effectiveTitle, url: feed.url,
+                    customIconURL: feed.customIconURL,
+                    isTitleCustomized: feed.isTitleCustomized
                 )
             }.value
         }

--- a/SakuraRSS/Classes/Feed Manager/FeedManager.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager.swift
@@ -1,6 +1,7 @@
 import CoreSpotlight
 import Foundation
 import SwiftUI
+import UIKit
 @preconcurrency import UserNotifications
 
 @Observable
@@ -113,6 +114,43 @@ final class FeedManager {
     func toggleMuted(_ feed: Feed) {
         try? database.updateFeedMuted(id: feed.id, isMuted: !feed.isMuted)
         loadFromDatabase()
+    }
+
+    /// Applies a title/icon update from a social-feed scraper (X,
+    /// Instagram, YouTube playlist).  Each scraper fetches a display
+    /// name and optionally a profile photo; this helper centralizes
+    /// the "install the photo on first fetch, honour user-customized
+    /// titles, otherwise just sync the scraped title" logic the three
+    /// paths share so the title-customization rule lives in exactly
+    /// one place.
+    func applyScraperMetadataRefresh(
+        feed: Feed,
+        scrapedTitle: String,
+        profileImage: UIImage?
+    ) async {
+        let effectiveTitle = feed.isTitleCustomized ? feed.title : scrapedTitle
+        let shouldInstallProfilePhoto = profileImage != nil && feed.customIconURL == nil
+        let database = database
+        if shouldInstallProfilePhoto, let image = profileImage {
+            await FaviconCache.shared.setCustomFavicon(
+                image, feedID: feed.id, skipTrimming: true
+            )
+            try? await Task.detached {
+                try database.updateFeedDetails(
+                    id: feed.id, title: effectiveTitle, url: feed.url,
+                    customIconURL: "photo",
+                    isTitleCustomized: feed.isTitleCustomized
+                )
+            }.value
+        } else if feed.title != effectiveTitle {
+            try? await Task.detached {
+                try database.updateFeedDetails(
+                    id: feed.id, title: effectiveTitle, url: feed.url,
+                    customIconURL: feed.customIconURL,
+                    isTitleCustomized: feed.isTitleCustomized
+                )
+            }.value
+        }
     }
 
     func updateFeedDetails(_ feed: Feed, title: String, url: String,

--- a/SakuraRSS/Classes/Feed Manager/FeedManager.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager.swift
@@ -70,6 +70,23 @@ final class FeedManager {
         guard !database.feedExists(url: url) else {
             throw FeedError.alreadyExists
         }
+        // Enforce per-host follow caps for authenticated scraper feeds
+        // (X, Instagram).  Unbounded follows on these hosts translate
+        // into rate-limit / account-lock pressure at refresh time, so
+        // the cap is applied at insert to keep the fleet small enough
+        // for the 30-minute refresh cadence to stay safe.
+        let newHost = URL(string: siteURL)?.host
+            ?? URL(string: url)?.host
+            ?? ""
+        if let key = FollowLimitSetDomains.limitKey(for: newHost),
+           let limit = FollowLimitSetDomains.limits[key] {
+            let current = feeds.filter { existing in
+                FollowLimitSetDomains.limitKey(for: existing.domain) == key
+            }.count
+            if current >= limit {
+                throw FeedError.followLimitExceeded(host: key, limit: limit)
+            }
+        }
         let feedID = try database.insertFeed(
             title: title, url: url, siteURL: siteURL,
             description: description, faviconURL: faviconURL,
@@ -100,8 +117,16 @@ final class FeedManager {
 
     func updateFeedDetails(_ feed: Feed, title: String, url: String,
                            customIconURL: String?) {
+        // A user-driven title change (from the edit sheet) flips the
+        // `isTitleCustomized` flag so future refreshes won't overwrite
+        // it.  If the user never touched the title we leave the existing
+        // flag alone — that way a user who previously customized and is
+        // now only editing the URL or icon doesn't accidentally clear
+        // their override.
+        let titleIsCustomized = feed.isTitleCustomized || title != feed.title
         try? database.updateFeedDetails(id: feed.id, title: title, url: url,
-                                        customIconURL: customIconURL)
+                                        customIconURL: customIconURL,
+                                        isTitleCustomized: titleIsCustomized)
         if title != feed.title {
             generateAcronymIcon(feedID: feed.id, title: title)
         }
@@ -170,7 +195,12 @@ final class FeedManager {
             } else if !parsed.isPodcast && feed.isPodcast {
                 try database.updateFeedIsPodcast(id: feed.id, isPodcast: false)
             }
-            if updateTitle, !parsed.title.isEmpty, parsed.title != feed.title {
+            // Respect user-customized titles: when the user has edited the
+            // title via the edit sheet, the refresh should never silently
+            // overwrite that override with whatever the remote feed
+            // currently advertises.
+            if updateTitle, !feed.isTitleCustomized,
+               !parsed.title.isEmpty, parsed.title != feed.title {
                 try database.updateFeed(id: feed.id, title: parsed.title, category: feed.category)
             }
             try database.updateFeedLastFetched(id: feed.id, date: Date())
@@ -376,11 +406,14 @@ final class FeedManager {
 
 enum FeedError: LocalizedError {
     case alreadyExists
+    case followLimitExceeded(host: String, limit: Int)
 
     var errorDescription: String? {
         switch self {
         case .alreadyExists:
             String(localized: "FeedError.AlreadyExists")
+        case .followLimitExceeded(let host, let limit):
+            String(localized: "FeedError.FollowLimitExceeded \(host) \(limit)")
         }
     }
 }

--- a/Shared/Database Manager/DatabaseManager+Feeds.swift
+++ b/Shared/Database Manager/DatabaseManager+Feeds.swift
@@ -58,12 +58,14 @@ nonisolated extension DatabaseManager {
     }
 
     func updateFeedDetails(id: Int64, title: String, url: String,
-                           customIconURL: String?) throws {
+                           customIconURL: String?,
+                           isTitleCustomized: Bool) throws {
         let target = feeds.filter(feedID == id)
         try database.run(target.update(
             feedTitle <- title,
             feedURL <- url,
-            feedCustomIconURL <- customIconURL
+            feedCustomIconURL <- customIconURL,
+            feedIsTitleCustomized <- isTitleCustomized
         ))
     }
 
@@ -102,7 +104,8 @@ nonisolated extension DatabaseManager {
             isPodcast: (try? row.get(feedIsPodcast)) ?? false,
             isMuted: (try? row.get(feedIsMuted)) ?? false,
             customIconURL: try? row.get(feedCustomIconURL),
-            acronymIcon: try? row.get(feedAcronymIcon)
+            acronymIcon: try? row.get(feedAcronymIcon),
+            isTitleCustomized: (try? row.get(feedIsTitleCustomized)) ?? false
         )
     }
 }

--- a/Shared/Database Manager/DatabaseManager+FixUp.swift
+++ b/Shared/Database Manager/DatabaseManager+FixUp.swift
@@ -16,6 +16,7 @@ nonisolated extension DatabaseManager {
         _ = try? database.run(feeds.addColumn(feedIsMuted, defaultValue: false))
         _ = try? database.run(feeds.addColumn(feedCustomIconURL))
         _ = try? database.run(feeds.addColumn(feedAcronymIcon))
+        _ = try? database.run(feeds.addColumn(feedIsTitleCustomized, defaultValue: false))
 
         // articles table
         _ = try? database.run(articles.addColumn(articleFeedID, defaultValue: 0))

--- a/Shared/Database Manager/DatabaseManager.swift
+++ b/Shared/Database Manager/DatabaseManager.swift
@@ -22,6 +22,7 @@ nonisolated final class DatabaseManager: @unchecked Sendable {
     let feedIsMuted = SQLite.Expression<Bool>("is_muted")
     let feedCustomIconURL = SQLite.Expression<String?>("custom_icon_url")
     let feedAcronymIcon = SQLite.Expression<Data?>("acronym_icon")
+    let feedIsTitleCustomized = SQLite.Expression<Bool>("is_title_customized")
 
     let imageCache = Table("image_cache")
     let imageCacheURL = SQLite.Expression<String>("url")
@@ -189,6 +190,7 @@ nonisolated final class DatabaseManager: @unchecked Sendable {
             table.column(feedIsMuted, defaultValue: false)
             table.column(feedCustomIconURL)
             table.column(feedAcronymIcon)
+            table.column(feedIsTitleCustomized, defaultValue: false)
         })
 
         try database.run(articles.create(ifNotExists: true) { table in

--- a/Shared/Domain Options/FollowLimitSetDomains.swift
+++ b/Shared/Domain Options/FollowLimitSetDomains.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Caps how many feeds a user can follow on specific hosts.
+///
+/// Hosts with an entry here are scraped via authenticated flows (X,
+/// Instagram) where hitting the upstream API at an unbounded cadence
+/// is a strong bot-like signal and invites rate-limit or account-lock
+/// penalties.  The limit is enforced in `FeedManager.addFeed` before
+/// any insert happens, so the cap applies to every path that adds a
+/// feed (Add Feed sheet, share extension, OPML import, etc.).
+nonisolated enum FollowLimitSetDomains {
+
+    /// Maximum followed feeds per host.  Keys match `URL.host` output
+    /// (lowercased, no scheme or trailing slash).  Subdomains of a
+    /// listed host share the same cap.
+    static let limits: [String: Int] = [
+        "x.com": 30,
+        "instagram.com": 10
+    ]
+
+    /// Returns the follow limit that applies to the given feed domain,
+    /// or `nil` if no limit is configured for the host.
+    static func followLimit(for feedDomain: String) -> Int? {
+        guard let key = limitKey(for: feedDomain) else { return nil }
+        return limits[key]
+    }
+
+    /// Returns the canonical host key a feed domain maps to — e.g.
+    /// both `www.x.com` and `x.com` resolve to `"x.com"`.  Used to
+    /// group existing feeds by their limit bucket when enforcing the
+    /// cap.  Returns `nil` when no bucket applies.
+    static func limitKey(for feedDomain: String) -> String? {
+        let host = feedDomain.lowercased()
+        if limits[host] != nil {
+            return host
+        }
+        for source in limits.keys where host.hasSuffix(".\(source)") {
+            return source
+        }
+        return nil
+    }
+}

--- a/Shared/Localizable.xcstrings
+++ b/Shared/Localizable.xcstrings
@@ -8120,6 +8120,65 @@
         }
       }
     },
+    "FeedError.FollowLimitExceeded %@ %lld" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Du folgst bereits dem Maximum von %2$lld Feeds auf %1$@."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You are already following the maximum of %2$lld feeds on %1$@."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vous suivez déjà le maximum de %2$lld flux sur %1$@."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stai già seguendo il massimo di %2$lld feed su %1$@."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ のフィードは最大 %2$lld 件までしかフォローできません。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@에서 최대 %2$lld개의 피드를 이미 팔로우하고 있습니다."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bạn đã theo dõi tối đa %2$lld nguồn cấp dữ liệu trên %1$@."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "你已关注 %1$@ 上最多 %2$lld 个订阅源。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "你已追蹤 %1$@ 上最多 %2$lld 個訂閱源。"
+          }
+        }
+      }
+    },
     "FeedList.Empty.AddFeed" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Shared/Models.swift
+++ b/Shared/Models.swift
@@ -13,6 +13,10 @@ nonisolated struct Feed: Identifiable, Hashable, Sendable {
     var isMuted: Bool
     var customIconURL: String?
     var acronymIcon: Data?
+    /// `true` when the user has manually edited the feed's title.
+    /// Refreshes must not overwrite a customized title with whatever the
+    /// remote feed currently advertises.
+    var isTitleCustomized: Bool
 
     var domain: String {
         URL(string: siteURL)?.host ?? URL(string: url)?.host ?? ""


### PR DESCRIPTION
Adds an `isTitleCustomized` flag on `Feed` so refresh paths (RSS, X,
Instagram, YouTube playlist) stop clobbering a title the user set in
the edit sheet, and introduces `FollowLimitSetDomains` to cap X feeds
at 30 and Instagram feeds at 10, enforced in `FeedManager.addFeed`.

https://claude.ai/code/session_011X1JimDbJvndZJtwiGuogu