### PR TITLE
Add Clear This Page integration for distraction-free article reading

### DIFF
--- a/SakuraRSS/Views/Feeds/FeedEditSheet.swift
+++ b/SakuraRSS/Views/Feeds/FeedEditSheet.swift
@@ -153,6 +153,8 @@ struct FeedEditSheet: View {
                                 .tag(FeedOpenMode.inAppViewer)
                             Text("FeedEdit.OpenIn.InAppBrowser")
                                 .tag(FeedOpenMode.inAppBrowser)
+                            Text("FeedEdit.OpenIn.ClearThisPage")
+                                .tag(FeedOpenMode.clearThisPage)
                             Text("FeedEdit.OpenIn.Browser")
                                 .tag(FeedOpenMode.browser)
                         }

--- a/SakuraRSS/Views/More/ClearThisPageSettingsView.swift
+++ b/SakuraRSS/Views/More/ClearThisPageSettingsView.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+struct ClearThisPageSettingsView: View {
+
+    @Environment(\.openURL) private var openURL
+
+    var body: some View {
+        List {
+            Section {
+                Text("Settings.ClearThisPage.About")
+            } header: {
+                Text("Settings.ClearThisPage.AboutHeader")
+            }
+
+            Section {
+                Button {
+                    if let url = URL(string: "https://clearthis.page") {
+                        openURL(url)
+                    }
+                } label: {
+                    HStack {
+                        Text("Settings.ClearThisPage.LearnMore")
+                        Spacer()
+                        Image(systemName: "arrow.up.right.square")
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .tint(.primary)
+            } footer: {
+                Text("Settings.ClearThisPage.Footer")
+            }
+        }
+        .navigationTitle("Integrations.ClearThisPage")
+        .toolbarTitleDisplayMode(.inline)
+    }
+}

--- a/SakuraRSS/Views/More/MoreView.swift
+++ b/SakuraRSS/Views/More/MoreView.swift
@@ -134,6 +134,9 @@ struct MoreView: View {
                     NavigationLink("Integrations.Instagram") {
                         InstagramSettingsView()
                     }
+                    NavigationLink("Integrations.ClearThisPage") {
+                        ClearThisPageSettingsView()
+                    }
                 } header: {
                     Text("Settings.Section.Integrations")
                 }

--- a/SakuraRSS/Views/Shared/ArticleLink.swift
+++ b/SakuraRSS/Views/Shared/ArticleLink.swift
@@ -16,6 +16,7 @@ struct ArticleLink<Label: View>: View {
 
     @AppStorage("YouTube.OpenMode") private var youTubeOpenMode: YouTubeOpenMode = .inAppPlayer
     @State private var showSafari = false
+    @State private var showClearThisPage = false
 
     private var feedOpenMode: FeedOpenMode {
         guard let feed = feedManager.feed(forArticle: article),
@@ -105,6 +106,13 @@ struct ArticleLink<Label: View>: View {
                 } label: {
                     label()
                 }
+            } else if feedOpenMode == .clearThisPage {
+                Button {
+                    feedManager.markRead(article)
+                    showClearThisPage = true
+                } label: {
+                    label()
+                }
             } else if let url = URL(string: article.url), OpenInBrowserDomains.shouldOpenInBrowser(url: url) {
                 Button {
                     feedManager.markRead(article)
@@ -126,6 +134,11 @@ struct ArticleLink<Label: View>: View {
             if let url = URL(string: article.url) {
                 SafariView(url: url)
                     .ignoresSafeArea()
+            }
+        }
+        .sheet(isPresented: $showClearThisPage) {
+            if let url = URL(string: article.url) {
+                ClearThisPageView(url: url)
             }
         }
     }

--- a/SakuraRSS/Views/Shared/ClearThisPageView.swift
+++ b/SakuraRSS/Views/Shared/ClearThisPageView.swift
@@ -173,16 +173,15 @@ private struct ClearThisPageWebView: UIViewRepresentable {
             _pageTitle = pageTitle
         }
 
-        /// Only allow http(s) navigations. Cancels app-scheme links and
-        /// other potentially unsafe URL schemes that could be triggered
-        /// from the rendered page.
+        /// Only allow HTTPS navigations. Cancels cleartext HTTP, app-scheme
+        /// links, and other potentially unsafe URL schemes that could be
+        /// triggered from the rendered page.
         func webView(
             _: WKWebView,
             decidePolicyFor navigationAction: WKNavigationAction,
             decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
         ) {
-            guard let scheme = navigationAction.request.url?.scheme?.lowercased(),
-                  scheme == "https" || scheme == "http" else {
+            guard navigationAction.request.url?.scheme?.lowercased() == "https" else {
                 decisionHandler(.cancel)
                 return
             }

--- a/SakuraRSS/Views/Shared/ClearThisPageView.swift
+++ b/SakuraRSS/Views/Shared/ClearThisPageView.swift
@@ -7,6 +7,7 @@ import WebKit
 struct ClearThisPageView: View {
 
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.colorScheme) private var colorScheme
     let url: URL
     @State private var isLoading = true
     @State private var pageTitle: String = ""
@@ -15,6 +16,7 @@ struct ClearThisPageView: View {
         NavigationStack {
             ClearThisPageWebView(
                 url: url,
+                colorScheme: colorScheme,
                 isLoading: $isLoading,
                 pageTitle: $pageTitle
             )
@@ -45,17 +47,89 @@ struct ClearThisPageView: View {
 }
 
 /// Builds a clearthis.page URL that wraps the supplied article URL.
+/// Uses `URLComponents` so the article URL is properly percent-encoded
+/// without manual string interpolation.
 private func clearThisPageURL(for articleURL: URL) -> URL? {
-    guard let encoded = articleURL.absoluteString
-        .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else {
-        return nil
-    }
-    return URL(string: "https://clearthis.page/?u=\(encoded)")
+    var components = URLComponents()
+    components.scheme = "https"
+    components.host = "clearthis.page"
+    components.path = "/"
+    components.queryItems = [
+        URLQueryItem(name: "u", value: articleURL.absoluteString)
+    ]
+    return components.url
 }
+
+/// User script injected at document start. clearthis.page uses
+/// `dark-mode-switch.min.js`, which reads `localStorage['darkSwitch']`
+/// to decide whether to add `data-theme="dark"` to the `<body>` and check
+/// the `#darkSwitch` checkbox. This script seeds that storage value from
+/// the system color scheme (`prefers-color-scheme`), reapplies the body
+/// attribute itself for safety, hides the manual `.topbar` toggle since
+/// theme selection is automatic, and stays in sync if the system
+/// appearance changes while the WebView is open.
+private let clearThisPageThemeScript = """
+(function() {
+  function isDark() {
+    return window.matchMedia
+      && window.matchMedia('(prefers-color-scheme: dark)').matches;
+  }
+  function syncStorage() {
+    try {
+      if (isDark()) {
+        localStorage.setItem('darkSwitch', 'dark');
+      } else {
+        localStorage.removeItem('darkSwitch');
+      }
+    } catch (e) {}
+  }
+  function applyBodyAttribute() {
+    if (!document.body) { return; }
+    if (isDark()) {
+      document.body.setAttribute('data-theme', 'dark');
+    } else {
+      document.body.removeAttribute('data-theme');
+    }
+    var sw = document.getElementById('darkSwitch');
+    if (sw) { sw.checked = isDark(); }
+  }
+  function hideToggle() {
+    var topbar = document.querySelector('.topbar');
+    if (topbar && topbar.parentNode) {
+      topbar.parentNode.removeChild(topbar);
+    }
+  }
+  function applyAll() {
+    syncStorage();
+    applyBodyAttribute();
+    hideToggle();
+  }
+  // Seed storage immediately so the page's own dark-mode-switch script
+  // picks up the right value as soon as it runs.
+  syncStorage();
+  if (document.readyState !== 'loading') {
+    applyAll();
+  } else {
+    document.addEventListener('DOMContentLoaded', applyAll);
+  }
+  window.addEventListener('load', applyAll);
+  // React to system appearance changes while the WebView is open.
+  if (window.matchMedia) {
+    var mq = window.matchMedia('(prefers-color-scheme: dark)');
+    var listener = function() { applyAll(); };
+    if (mq.addEventListener) {
+      mq.addEventListener('change', listener);
+    } else if (mq.addListener) {
+      mq.addListener(listener);
+    }
+  }
+})();
+"""
 
 private struct ClearThisPageWebView: UIViewRepresentable {
 
     let url: URL
+    let colorScheme: ColorScheme
     @Binding var isLoading: Bool
     @Binding var pageTitle: String
 
@@ -66,17 +140,29 @@ private struct ClearThisPageWebView: UIViewRepresentable {
     func makeUIView(context: Context) -> WKWebView {
         let config = WKWebViewConfiguration()
         config.websiteDataStore = .nonPersistent()
+        let themeScript = WKUserScript(
+            source: clearThisPageThemeScript,
+            injectionTime: .atDocumentStart,
+            forMainFrameOnly: true
+        )
+        config.userContentController.addUserScript(themeScript)
         let webView = WKWebView(frame: .zero, configuration: config)
         webView.navigationDelegate = context.coordinator
         webView.allowsBackForwardNavigationGestures = true
         webView.customUserAgent = sakuraUserAgent
+        webView.overrideUserInterfaceStyle = colorScheme == .dark ? .dark : .light
         if let target = clearThisPageURL(for: url) {
             webView.load(URLRequest(url: target))
         }
         return webView
     }
 
-    func updateUIView(_: WKWebView, context _: Context) {}
+    func updateUIView(_ webView: WKWebView, context _: Context) {
+        let desired: UIUserInterfaceStyle = colorScheme == .dark ? .dark : .light
+        if webView.overrideUserInterfaceStyle != desired {
+            webView.overrideUserInterfaceStyle = desired
+        }
+    }
 
     final class Coordinator: NSObject, WKNavigationDelegate {
         @Binding var isLoading: Bool
@@ -87,28 +173,49 @@ private struct ClearThisPageWebView: UIViewRepresentable {
             _pageTitle = pageTitle
         }
 
-        @MainActor
-        func webView(_: WKWebView, didStartProvisionalNavigation _: WKNavigation!) {
-            isLoading = true
+        /// Only allow http(s) navigations. Cancels app-scheme links and
+        /// other potentially unsafe URL schemes that could be triggered
+        /// from the rendered page.
+        func webView(
+            _: WKWebView,
+            decidePolicyFor navigationAction: WKNavigationAction,
+            decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+        ) {
+            guard let scheme = navigationAction.request.url?.scheme?.lowercased(),
+                  scheme == "https" || scheme == "http" else {
+                decisionHandler(.cancel)
+                return
+            }
+            decisionHandler(.allow)
         }
 
-        @MainActor
-        func webView(_ webView: WKWebView, didFinish _: WKNavigation!) {
-            isLoading = false
-            if let title = webView.title, !title.isEmpty {
-                pageTitle = title
+        func webView(_: WKWebView, didStartProvisionalNavigation _: WKNavigation!) {
+            Task { @MainActor in
+                isLoading = true
             }
         }
 
-        @MainActor
-        func webView(_: WKWebView, didFail _: WKNavigation!, withError _: Error) {
-            isLoading = false
+        func webView(_ webView: WKWebView, didFinish _: WKNavigation!) {
+            let resolvedTitle = webView.title
+            Task { @MainActor in
+                isLoading = false
+                if let resolvedTitle, !resolvedTitle.isEmpty {
+                    pageTitle = resolvedTitle
+                }
+            }
         }
 
-        @MainActor
+        func webView(_: WKWebView, didFail _: WKNavigation!, withError _: Error) {
+            Task { @MainActor in
+                isLoading = false
+            }
+        }
+
         func webView(_: WKWebView, didFailProvisionalNavigation _: WKNavigation!,
                      withError _: Error) {
-            isLoading = false
+            Task { @MainActor in
+                isLoading = false
+            }
         }
     }
 }

--- a/SakuraRSS/Views/Shared/ClearThisPageView.swift
+++ b/SakuraRSS/Views/Shared/ClearThisPageView.swift
@@ -1,0 +1,114 @@
+import SwiftUI
+import WebKit
+
+/// Presents an article URL through the clearthis.page reader service in an
+/// embedded WebView. The service strips ads and clutter and reformats the
+/// page for distraction-free reading.
+struct ClearThisPageView: View {
+
+    @Environment(\.dismiss) private var dismiss
+    let url: URL
+    @State private var isLoading = true
+    @State private var pageTitle: String = ""
+
+    var body: some View {
+        NavigationStack {
+            ClearThisPageWebView(
+                url: url,
+                isLoading: $isLoading,
+                pageTitle: $pageTitle
+            )
+            .ignoresSafeArea(edges: .bottom)
+            .navigationTitle(pageTitle.isEmpty
+                ? String(localized: "ClearThisPage.Title")
+                : pageTitle)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    if isLoading {
+                        ProgressView()
+                    }
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    ShareLink(item: url) {
+                        Image(systemName: "square.and.arrow.up")
+                    }
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button(role: .close) {
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Builds a clearthis.page URL that wraps the supplied article URL.
+private func clearThisPageURL(for articleURL: URL) -> URL? {
+    guard let encoded = articleURL.absoluteString
+        .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else {
+        return nil
+    }
+    return URL(string: "https://clearthis.page/?u=\(encoded)")
+}
+
+private struct ClearThisPageWebView: UIViewRepresentable {
+
+    let url: URL
+    @Binding var isLoading: Bool
+    @Binding var pageTitle: String
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(isLoading: $isLoading, pageTitle: $pageTitle)
+    }
+
+    func makeUIView(context: Context) -> WKWebView {
+        let config = WKWebViewConfiguration()
+        config.websiteDataStore = .nonPersistent()
+        let webView = WKWebView(frame: .zero, configuration: config)
+        webView.navigationDelegate = context.coordinator
+        webView.allowsBackForwardNavigationGestures = true
+        webView.customUserAgent = sakuraUserAgent
+        if let target = clearThisPageURL(for: url) {
+            webView.load(URLRequest(url: target))
+        }
+        return webView
+    }
+
+    func updateUIView(_: WKWebView, context _: Context) {}
+
+    final class Coordinator: NSObject, WKNavigationDelegate {
+        @Binding var isLoading: Bool
+        @Binding var pageTitle: String
+
+        init(isLoading: Binding<Bool>, pageTitle: Binding<String>) {
+            _isLoading = isLoading
+            _pageTitle = pageTitle
+        }
+
+        @MainActor
+        func webView(_: WKWebView, didStartProvisionalNavigation _: WKNavigation!) {
+            isLoading = true
+        }
+
+        @MainActor
+        func webView(_ webView: WKWebView, didFinish _: WKNavigation!) {
+            isLoading = false
+            if let title = webView.title, !title.isEmpty {
+                pageTitle = title
+            }
+        }
+
+        @MainActor
+        func webView(_: WKWebView, didFail _: WKNavigation!, withError _: Error) {
+            isLoading = false
+        }
+
+        @MainActor
+        func webView(_: WKWebView, didFailProvisionalNavigation _: WKNavigation!,
+                     withError _: Error) {
+            isLoading = false
+        }
+    }
+}

--- a/Shared/Localizable.xcstrings
+++ b/Shared/Localizable.xcstrings
@@ -5108,6 +5108,17 @@
         }
       }
     },
+    "ClearThisPage.Title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clear This Page"
+          }
+        }
+      }
+    },
     "DataManagement.Cleanup.AllTime" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -7825,6 +7836,17 @@
         }
       }
     },
+    "FeedEdit.OpenIn.ClearThisPage" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clear This Page"
+          }
+        }
+      }
+    },
     "FeedEdit.OpenIn.InAppBrowser" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -10299,6 +10321,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "登入 Instagram"
+          }
+        }
+      }
+    },
+    "Integrations.ClearThisPage" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clear This Page"
           }
         }
       }
@@ -18625,6 +18658,50 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "通知標記"
+          }
+        }
+      }
+    },
+    "Settings.ClearThisPage.About" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clear This Page is a third-party reader service that strips ads and clutter from web articles, presenting them in a clean, distraction-free format. When enabled for a feed, articles open inside an embedded WebView using https://clearthis.page."
+          }
+        }
+      }
+    },
+    "Settings.ClearThisPage.AboutHeader" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "About"
+          }
+        }
+      }
+    },
+    "Settings.ClearThisPage.Footer" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "To use Clear This Page for a feed, edit the feed and set its Open In option to Clear This Page."
+          }
+        }
+      }
+    },
+    "Settings.ClearThisPage.LearnMore" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Visit clearthis.page"
           }
         }
       }

--- a/Shared/Models.swift
+++ b/Shared/Models.swift
@@ -99,6 +99,7 @@ nonisolated enum FeedSection: String, CaseIterable, Sendable {
 nonisolated enum FeedOpenMode: String, CaseIterable, Sendable {
     case inAppViewer
     case inAppBrowser
+    case clearThisPage
     case browser
 }
 


### PR DESCRIPTION
## Summary
This PR adds integration with Clear This Page, a third-party reader service that strips ads and clutter from web articles. Users can now select Clear This Page as the "Open In" option for feeds, and articles will open in an embedded WebView with a clean, distraction-free reading experience.

## Key Changes
- **New View Components**:
  - `ClearThisPageView`: Main view that displays articles through the clearthis.page service in an embedded WebView with loading state, page title, and sharing capabilities
  - `ClearThisPageSettingsView`: Settings page with information about the service and a link to learn more
  - `ClearThisPageWebView`: UIViewRepresentable wrapper around WKWebView with navigation delegate to track loading state and page title

- **Model Updates**:
  - Added `clearThisPage` case to `FeedOpenMode` enum to support the new open mode

- **UI Integration**:
  - Updated `ArticleLink` to handle the new `.clearThisPage` open mode and present the ClearThisPageView in a sheet
  - Added Clear This Page option to feed edit sheet's "Open In" picker
  - Added navigation link to Clear This Page settings in MoreView under Integrations section

- **Localization**:
  - Added 7 new localization strings for UI labels, settings descriptions, and footer text

## Implementation Details
- The service URL is constructed by URL-encoding the article URL and appending it as a query parameter to `https://clearthis.page/?u=`
- WebView uses non-persistent data store for privacy
- Custom user agent is set to identify requests from SakuraRSS
- Loading state is tracked via WKNavigationDelegate callbacks
- Page title is extracted from the loaded webpage and displayed in the navigation bar
- Back/forward navigation gestures are enabled for better UX

https://claude.ai/code/session_01CujLoB72FU2Uj22hDGR7Dr