### PR TITLE
Match Following tab section headers to Discover tab style

### DIFF
--- a/SakuraRSS/Views/Feeds/FeedsListPage.swift
+++ b/SakuraRSS/Views/Feeds/FeedsListPage.swift
@@ -55,8 +55,8 @@ struct FeedsListPage: View {
                             }
                         } header: {
                             Text(section.localizedTitle)
-                                .font(.headline)
-                                .foregroundStyle(.secondary)
+                                .font(.title3)
+                                .fontWeight(.bold)
                         }
                     }
                 }


### PR DESCRIPTION
Use title3 bold headers in the Following (Feeds) tab feed category
sections so they match the section header style used in the Discover
tab, providing visual consistency across the two tabs.