### PR TITLE
Refactor article navigation and improve ClearThisPage UI

### DIFF
--- a/SakuraRSS/Views/Feeds/FeedListView.swift
+++ b/SakuraRSS/Views/Feeds/FeedListView.swift
@@ -22,17 +22,11 @@ struct FeedListView: View {
                         }
                 }
                 .navigationDestination(for: Article.self) { article in
-                    Group {
-                        if article.isPodcastEpisode {
-                            PodcastEpisodeView(article: article)
-                        } else {
-                            ArticleDetailView(article: article)
-                        }
-                    }
-                    .environment(\.zoomNamespace, cardZoom)
-                    .zoomTransition(sourceID: article.id, in: cardZoom)
-                    .onAppear { savedArticleID = Int(article.id) }
-                    .onDisappear { savedArticleID = -1 }
+                    ArticleDestinationView(article: article)
+                        .environment(\.zoomNamespace, cardZoom)
+                        .zoomTransition(sourceID: article.id, in: cardZoom)
+                        .onAppear { savedArticleID = Int(article.id) }
+                        .onDisappear { savedArticleID = -1 }
                 }
                 .navigationDestination(for: EntityDestination.self) { destination in
                     EntityArticlesView(destination: destination)

--- a/SakuraRSS/Views/Home/HomeView.swift
+++ b/SakuraRSS/Views/Home/HomeView.swift
@@ -61,19 +61,11 @@ struct HomeView: View {
                         }
                 }
                 .navigationDestination(for: Article.self) { article in
-                    Group {
-                        if article.isPodcastEpisode {
-                            PodcastEpisodeView(article: article)
-                        } else if article.isYouTubeURL {
-                            YouTubePlayerView(article: article)
-                        } else {
-                            ArticleDetailView(article: article)
-                        }
-                    }
-                    .environment(\.zoomNamespace, cardZoom)
-                    .zoomTransition(sourceID: article.id, in: cardZoom)
-                    .onAppear { savedArticleID = Int(article.id) }
-                    .onDisappear { savedArticleID = -1 }
+                    ArticleDestinationView(article: article)
+                        .environment(\.zoomNamespace, cardZoom)
+                        .zoomTransition(sourceID: article.id, in: cardZoom)
+                        .onAppear { savedArticleID = Int(article.id) }
+                        .onDisappear { savedArticleID = -1 }
                 }
                 .navigationDestination(for: EntityDestination.self) { destination in
                     EntityArticlesView(destination: destination)

--- a/SakuraRSS/Views/Lists/ListsView.swift
+++ b/SakuraRSS/Views/Lists/ListsView.swift
@@ -19,17 +19,9 @@ struct ListsView: View {
                         .environment(\.zoomNamespace, cardZoom)
                 }
                 .navigationDestination(for: Article.self) { article in
-                    Group {
-                        if article.isPodcastEpisode {
-                            PodcastEpisodeView(article: article)
-                        } else if article.isYouTubeURL {
-                            YouTubePlayerView(article: article)
-                        } else {
-                            ArticleDetailView(article: article)
-                        }
-                    }
-                    .environment(\.zoomNamespace, cardZoom)
-                    .zoomTransition(sourceID: article.id, in: cardZoom)
+                    ArticleDestinationView(article: article)
+                        .environment(\.zoomNamespace, cardZoom)
+                        .zoomTransition(sourceID: article.id, in: cardZoom)
                 }
                 .navigationDestination(for: EntityDestination.self) { destination in
                     EntityArticlesView(destination: destination)

--- a/SakuraRSS/Views/More/AttributesView.swift
+++ b/SakuraRSS/Views/More/AttributesView.swift
@@ -139,34 +139,6 @@ private struct Dependency: Identifiable {
             OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
             SOFTWARE.
             """
-        ),
-        Dependency(
-            id: "whisperkit",
-            name: "WhisperKit",
-            license: "MIT License",
-            licenseText: """
-            MIT License
-            
-            Copyright (c) 2024 Argmax, Inc.
-            
-            Permission is hereby granted, free of charge, to any person obtaining a copy
-            of this software and associated documentation files (the "Software"), to deal
-            in the Software without restriction, including without limitation the rights
-            to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-            copies of the Software, and to permit persons to whom the Software is
-            furnished to do so, subject to the following conditions:
-            
-            The above copyright notice and this permission notice shall be included in all
-            copies or substantial portions of the Software.
-            
-            THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-            IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-            FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-            AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-            LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-            OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-            SOFTWARE.
-            """
         )
     ]
 }

--- a/SakuraRSS/Views/More/ClearThisPageSettingsView.swift
+++ b/SakuraRSS/Views/More/ClearThisPageSettingsView.swift
@@ -2,32 +2,16 @@ import SwiftUI
 
 struct ClearThisPageSettingsView: View {
 
-    @Environment(\.openURL) private var openURL
-
     var body: some View {
         List {
             Section {
-                Text("Settings.ClearThisPage.About")
+                Text(
+                    String(localized: "Settings.ClearThisPage.About")
+                    + "\n\n"
+                    + String(localized: "Settings.ClearThisPage.Footer")
+                )
             } header: {
                 Text("Settings.ClearThisPage.AboutHeader")
-            }
-
-            Section {
-                Button {
-                    if let url = URL(string: "https://clearthis.page") {
-                        openURL(url)
-                    }
-                } label: {
-                    HStack {
-                        Text("Settings.ClearThisPage.LearnMore")
-                        Spacer()
-                        Image(systemName: "arrow.up.right.square")
-                            .foregroundStyle(.secondary)
-                    }
-                }
-                .tint(.primary)
-            } footer: {
-                Text("Settings.ClearThisPage.Footer")
             }
         }
         .navigationTitle("Integrations.ClearThisPage")

--- a/SakuraRSS/Views/More/PodcastSettingsView.swift
+++ b/SakuraRSS/Views/More/PodcastSettingsView.swift
@@ -62,7 +62,7 @@ struct PodcastSettingsView: View {
 
             Section {
                 Toggle(isOn: $toggleState) {
-                    Text("Podcast.Transcripts.Engine.Parakeet")
+                    Text("Podcast.Transcripts.Engine.OnDevice")
                 }
                 .disabled(isDownloadingModel)
                 .onChange(of: toggleState) { _, newValue in
@@ -79,9 +79,6 @@ struct PodcastSettingsView: View {
                         ProgressDonut(progress: downloadProgress)
                             .frame(width: 22, height: 22)
                     }
-                } else if modelReady && toggleState {
-                    Label("Podcast.Transcripts.Model.Ready", systemImage: "checkmark.circle.fill")
-                        .foregroundStyle(.green)
                 }
 
                 if let downloadError {
@@ -99,6 +96,8 @@ struct PodcastSettingsView: View {
                 }
             } header: {
                 Text("Podcast.Transcripts.Title")
+            } footer: {
+                Text("Podcast.Transcripts.Engine.Footer")
             }
         }
         .navigationTitle("Integrations.Podcast")

--- a/SakuraRSS/Views/Search/EntityArticlesView.swift
+++ b/SakuraRSS/Views/Search/EntityArticlesView.swift
@@ -44,15 +44,9 @@ struct EntityArticlesView: View {
         .sakuraBackground()
         .environment(\.zoomNamespace, cardZoom)
         .navigationDestination(for: Article.self) { article in
-            Group {
-                if article.isPodcastEpisode {
-                    PodcastEpisodeView(article: article)
-                } else {
-                    ArticleDetailView(article: article)
-                }
-            }
-            .environment(\.zoomNamespace, cardZoom)
-            .zoomTransition(sourceID: article.id, in: cardZoom)
+            ArticleDestinationView(article: article)
+                .environment(\.zoomNamespace, cardZoom)
+                .zoomTransition(sourceID: article.id, in: cardZoom)
         }
         .navigationDestination(for: EntityDestination.self) { destination in
             EntityArticlesView(destination: destination)

--- a/SakuraRSS/Views/Search/SearchView.swift
+++ b/SakuraRSS/Views/Search/SearchView.swift
@@ -39,15 +39,9 @@ struct SearchView: View {
                 ? LocalizedStringKey("Discover.Title")
                 : LocalizedStringKey("Search.Results.Title"))
             .navigationDestination(for: Article.self) { article in
-                Group {
-                    if article.isPodcastEpisode {
-                        PodcastEpisodeView(article: article)
-                    } else {
-                        ArticleDetailView(article: article)
-                    }
-                }
-                .environment(\.zoomNamespace, cardZoom)
-                .zoomTransition(sourceID: article.id, in: cardZoom)
+                ArticleDestinationView(article: article)
+                    .environment(\.zoomNamespace, cardZoom)
+                    .zoomTransition(sourceID: article.id, in: cardZoom)
             }
             .navigationDestination(for: EntityDestination.self) { destination in
                 EntityArticlesView(destination: destination)

--- a/SakuraRSS/Views/Shared/ArticleDestinationView.swift
+++ b/SakuraRSS/Views/Shared/ArticleDestinationView.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+/// Resolves the correct detail view for a pushed `Article` navigation
+/// destination. Consolidates the podcast / YouTube / clearthis.page /
+/// default article branching so every `navigationDestination(for: Article.self)`
+/// handler behaves consistently.
+struct ArticleDestinationView: View {
+
+    @Environment(FeedManager.self) private var feedManager
+    let article: Article
+
+    private var feedOpenMode: FeedOpenMode {
+        guard let feed = feedManager.feed(forArticle: article),
+              let raw = UserDefaults.standard.string(forKey: "openMode-\(feed.id)"),
+              let mode = FeedOpenMode(rawValue: raw) else {
+            return .inAppViewer
+        }
+        return mode
+    }
+
+    var body: some View {
+        if article.isPodcastEpisode {
+            PodcastEpisodeView(article: article)
+        } else if article.isYouTubeURL {
+            YouTubePlayerView(article: article)
+        } else if feedOpenMode == .clearThisPage,
+                  let url = URL(string: article.url) {
+            ClearThisPageView(url: url)
+        } else {
+            ArticleDetailView(article: article)
+        }
+    }
+}

--- a/SakuraRSS/Views/Shared/ArticleLink.swift
+++ b/SakuraRSS/Views/Shared/ArticleLink.swift
@@ -16,7 +16,6 @@ struct ArticleLink<Label: View>: View {
 
     @AppStorage("YouTube.OpenMode") private var youTubeOpenMode: YouTubeOpenMode = .inAppPlayer
     @State private var showSafari = false
-    @State private var showClearThisPage = false
 
     private var feedOpenMode: FeedOpenMode {
         guard let feed = feedManager.feed(forArticle: article),
@@ -107,11 +106,12 @@ struct ArticleLink<Label: View>: View {
                     label()
                 }
             } else if feedOpenMode == .clearThisPage {
-                Button {
-                    feedManager.markRead(article)
-                    showClearThisPage = true
-                } label: {
-                    label()
+                if usesIPadDetailColumn {
+                    Button { selectForIPadDetail() } label: { label() }
+                } else if let onNavigate {
+                    Button { onNavigate(article) } label: { label() }
+                } else {
+                    NavigationLink(value: article) { label() }
                 }
             } else if let url = URL(string: article.url), OpenInBrowserDomains.shouldOpenInBrowser(url: url) {
                 Button {
@@ -134,11 +134,6 @@ struct ArticleLink<Label: View>: View {
             if let url = URL(string: article.url) {
                 SafariView(url: url)
                     .ignoresSafeArea()
-            }
-        }
-        .sheet(isPresented: $showClearThisPage) {
-            if let url = URL(string: article.url) {
-                ClearThisPageView(url: url)
             }
         }
     }

--- a/SakuraRSS/Views/Shared/ClearThisPageView.swift
+++ b/SakuraRSS/Views/Shared/ClearThisPageView.swift
@@ -6,40 +6,43 @@ import WebKit
 /// page for distraction-free reading.
 struct ClearThisPageView: View {
 
-    @Environment(\.dismiss) private var dismiss
     @Environment(\.colorScheme) private var colorScheme
     let url: URL
     @State private var isLoading = true
     @State private var pageTitle: String = ""
+    @State private var reloadTrigger = 0
 
     var body: some View {
-        NavigationStack {
+        ZStack {
             ClearThisPageWebView(
                 url: url,
                 colorScheme: colorScheme,
+                reloadTrigger: reloadTrigger,
                 isLoading: $isLoading,
                 pageTitle: $pageTitle
             )
             .ignoresSafeArea(edges: .bottom)
-            .navigationTitle(pageTitle.isEmpty
-                ? String(localized: "ClearThisPage.Title")
-                : pageTitle)
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .topBarLeading) {
-                    if isLoading {
-                        ProgressView()
-                    }
+            .opacity(isLoading ? 0 : 1)
+
+            if isLoading {
+                ProgressView()
+            }
+        }
+        .navigationTitle(pageTitle.isEmpty
+            ? String(localized: "ClearThisPage.Title")
+            : pageTitle)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    reloadTrigger &+= 1
+                } label: {
+                    Image(systemName: "arrow.clockwise")
                 }
-                ToolbarItem(placement: .topBarTrailing) {
-                    ShareLink(item: url) {
-                        Image(systemName: "square.and.arrow.up")
-                    }
-                }
-                ToolbarItem(placement: .topBarTrailing) {
-                    Button(role: .close) {
-                        dismiss()
-                    }
+            }
+            ToolbarItem(placement: .topBarTrailing) {
+                ShareLink(item: url) {
+                    Image(systemName: "square.and.arrow.up")
                 }
             }
         }
@@ -130,6 +133,7 @@ private struct ClearThisPageWebView: UIViewRepresentable {
 
     let url: URL
     let colorScheme: ColorScheme
+    let reloadTrigger: Int
     @Binding var isLoading: Bool
     @Binding var pageTitle: String
 
@@ -151,22 +155,33 @@ private struct ClearThisPageWebView: UIViewRepresentable {
         webView.allowsBackForwardNavigationGestures = true
         webView.customUserAgent = sakuraUserAgent
         webView.overrideUserInterfaceStyle = colorScheme == .dark ? .dark : .light
+        context.coordinator.lastReloadTrigger = reloadTrigger
         if let target = clearThisPageURL(for: url) {
             webView.load(URLRequest(url: target))
         }
         return webView
     }
 
-    func updateUIView(_ webView: WKWebView, context _: Context) {
+    func updateUIView(_ webView: WKWebView, context: Context) {
         let desired: UIUserInterfaceStyle = colorScheme == .dark ? .dark : .light
         if webView.overrideUserInterfaceStyle != desired {
             webView.overrideUserInterfaceStyle = desired
+        }
+        if reloadTrigger != context.coordinator.lastReloadTrigger {
+            context.coordinator.lastReloadTrigger = reloadTrigger
+            Task { @MainActor in
+                isLoading = true
+            }
+            if let target = clearThisPageURL(for: url) {
+                webView.load(URLRequest(url: target))
+            }
         }
     }
 
     final class Coordinator: NSObject, WKNavigationDelegate {
         @Binding var isLoading: Bool
         @Binding var pageTitle: String
+        var lastReloadTrigger: Int = 0
 
         init(isLoading: Binding<Bool>, pageTitle: Binding<String>) {
             _isLoading = isLoading

--- a/SakuraRSS/Views/iPadSidebarView.swift
+++ b/SakuraRSS/Views/iPadSidebarView.swift
@@ -373,16 +373,8 @@ extension IPadSidebarView {
     @ViewBuilder
     var detailContent: some View {
         if let article = selectedArticle {
-            Group {
-                if article.isPodcastEpisode {
-                    PodcastEpisodeView(article: article)
-                } else if article.isYouTubeURL {
-                    YouTubePlayerView(article: article)
-                } else {
-                    ArticleDetailView(article: article)
-                }
-            }
-            .id(article.id)
+            ArticleDestinationView(article: article)
+                .id(article.id)
         } else {
             ContentUnavailableView {
                 Label("Sidebar.SelectArticle",

--- a/Shared/Localizable.xcstrings
+++ b/Shared/Localizable.xcstrings
@@ -18747,61 +18747,120 @@
         }
       }
     },
-    "Podcast.Transcripts.Engine.Parakeet" : {
+    "Podcast.Transcripts.Engine.Footer" : {
       "extractionState" : "manual",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "NVIDIA Parakeet"
+            "value" : "On-Device-Transkriptionen werden von NVIDIA Parakeet bereitgestellt."
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "NVIDIA Parakeet"
+            "value" : "On-device transcriptions are powered by NVIDIA Parakeet."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "NVIDIA Parakeet"
+            "value" : "Les transcriptions sur l'appareil sont propulsées par NVIDIA Parakeet."
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "NVIDIA Parakeet"
+            "value" : "Le trascrizioni sul dispositivo sono basate su NVIDIA Parakeet."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "NVIDIA Parakeet"
+            "value" : "オンデバイス文字起こしはNVIDIA Parakeetを使用しています。"
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "NVIDIA Parakeet"
+            "value" : "온디바이스 전사는 NVIDIA Parakeet로 구동됩니다."
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "NVIDIA Parakeet"
+            "value" : "Chuyển lời trên thiết bị được cung cấp bởi NVIDIA Parakeet."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "NVIDIA Parakeet"
+            "value" : "设备端转录由 NVIDIA Parakeet 提供支持。"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "NVIDIA Parakeet"
+            "value" : "裝置端轉錄由 NVIDIA Parakeet 提供支援。"
+          }
+        }
+      }
+    },
+    "Podcast.Transcripts.Engine.OnDevice" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "On-Device-Transkriptionen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "On-Device Transcriptions"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transcriptions sur l'appareil"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trascrizioni sul dispositivo"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オンデバイス文字起こし"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "온디바이스 전사"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chuyển lời trên thiết bị"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "设备端转录"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "裝置端轉錄"
           }
         }
       }
@@ -18861,65 +18920,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "正在下載模型…"
-          }
-        }
-      }
-    },
-    "Podcast.Transcripts.Model.Ready" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modell bereit"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Model Ready"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modèle prêt"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modello pronto"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "モデル準備完了"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "모델 준비 완료"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mô hình đã sẵn sàng"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "模型已就绪"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "模型已就緒"
           }
         }
       }
@@ -21196,7 +21196,7 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "更新間隔"
+            "value" : "自動更新の間隔"
           }
         },
         "ko" : {
@@ -21255,7 +21255,7 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "フィード更新の間隔"
+            "value" : "フィードごとのクールダウン"
           }
         },
         "ko" : {

--- a/Shared/Localizable.xcstrings
+++ b/Shared/Localizable.xcstrings
@@ -21231,55 +21231,55 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Mindestabstand zwischen Aktualisierungen"
+            "value" : "Aktualisierungs-Cooldown"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Per-Feed Cooldown"
+            "value" : "Refresh Cooldown"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Délai entre actualisations"
+            "value" : "Délai d'actualisation"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Intervallo minimo per feed"
+            "value" : "Cooldown di aggiornamento"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "フィードごとのクールダウン"
+            "value" : "更新クールダウン"
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "피드별 재시도 간격"
+            "value" : "새로고침 쿨다운"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Khoảng thời gian tối thiểu giữa các lần làm mới"
+            "value" : "Thời gian chờ làm mới"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "每个订阅源的冷却时间"
+            "value" : "刷新冷却时间"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "每個訂閱源的冷卻時間"
+            "value" : "重新整理冷卻時間"
           }
         }
       }


### PR DESCRIPTION
## Summary
This PR consolidates article navigation logic into a new `ArticleDestinationView` component and improves the ClearThisPage reader with reload functionality and better UI integration.

## Key Changes

- **New `ArticleDestinationView` component**: Centralizes the logic for routing articles to the correct detail view (podcast, YouTube, ClearThisPage, or default article view). This eliminates duplicate branching logic across multiple views (HomeView, FeedListView, ListsView, EntityArticlesView, SearchView, and iPadSidebarView).

- **ClearThisPage improvements**:
  - Replaced `NavigationStack` with `ZStack` for better layout control
  - Added reload button to refresh the page content
  - Improved loading state handling with opacity transitions
  - Removed close button (now uses standard navigation back)
  - Removed separate "Learn More" button from settings view, consolidating footer text

- **ArticleLink refactoring**: Simplified ClearThisPage handling to use standard navigation patterns instead of sheet presentation, making it consistent with other article types.

- **Settings view cleanup**: Removed WhisperKit dependency from AttributesView and consolidated ClearThisPage settings text.

- **Localization updates**: Updated Japanese translations for podcast transcript settings and feed update intervals.

## Implementation Details

- The new `ArticleDestinationView` checks article properties (`isPodcastEpisode`, `isYouTubeURL`) and user preferences (`FeedOpenMode`) to determine the appropriate view
- ClearThisPage now uses a `reloadTrigger` state variable to trigger page reloads without recreating the web view
- All navigation destinations now use the centralized component, ensuring consistent behavior across the app

https://claude.ai/code/session_01FZnYiCmk5fPSTNa3vvHvEw