### PR TITLE
Make Scroll display pages fill the full screen

### DIFF
--- a/SakuraRSS/Views/Shared/Feed Display Styles/ScrollStyleView.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/ScrollStyleView.swift
@@ -53,8 +53,8 @@ struct ScrollStyleView: View {
             .scrollTargetBehavior(.paging)
             .scrollPosition(id: $currentID, anchor: .center)
             .scrollDisabled(expandedArticleID != nil)
-            .ignoresSafeArea()
         }
+        .ignoresSafeArea()
         .background(Color.black.ignoresSafeArea())
         .navigationDestination(item: $youTubeArticle) { article in
             YouTubePlayerView(article: article)


### PR DESCRIPTION
The GeometryReader in ScrollStyleView was respecting safe area insets,
so each page was sized to the safe-area-inset height while the ScrollView
itself ignored safe areas. This caused each article page to fall short of
the screen edges, allowing the next page to peek through. Move
ignoresSafeArea() from the inner ScrollView onto the GeometryReader so the
reported page size matches the full screen.