### PR TITLE
Fix Mark All Read button appearing in wrong spot

### DIFF
--- a/SakuraRSS/Views/Feeds/FeedArticlesView.swift
+++ b/SakuraRSS/Views/Feeds/FeedArticlesView.swift
@@ -51,12 +51,8 @@ struct FeedArticlesView: View {
         .refreshable {
             try? await feedManager.refreshFeed(feed)
         }
-        .safeAreaInset(edge: .bottom, alignment: .leading, spacing: 0) {
-            if markAllReadPosition == .bottom {
-                ArticlesToolbar {
-                    feedManager.markAllRead(feed: feed)
-                }
-            }
+        .markAllReadToolbar(show: markAllReadPosition == .bottom) {
+            feedManager.markAllRead(feed: feed)
         }
     }
 }

--- a/SakuraRSS/Views/Home/AllArticlesView.swift
+++ b/SakuraRSS/Views/Home/AllArticlesView.swift
@@ -291,12 +291,8 @@ struct AllArticlesView: View {
         .refreshable {
             await feedManager.refreshAllFeeds()
         }
-        .safeAreaInset(edge: .bottom, alignment: .leading, spacing: 0) {
-            if markAllReadPosition == .bottom {
-                ArticlesToolbar {
-                    feedManager.markAllRead()
-                }
-            }
+        .markAllReadToolbar(show: markAllReadPosition == .bottom) {
+            feedManager.markAllRead()
         }
     }
 }

--- a/SakuraRSS/Views/Home/HomeSectionView.swift
+++ b/SakuraRSS/Views/Home/HomeSectionView.swift
@@ -43,12 +43,8 @@ struct HomeSectionView: View {
         .refreshable {
             await feedManager.refreshAllFeeds()
         }
-        .safeAreaInset(edge: .bottom, alignment: .leading, spacing: 0) {
-            if markAllReadPosition == .bottom {
-                ArticlesToolbar {
-                    feedManager.markAllRead(for: section)
-                }
-            }
+        .markAllReadToolbar(show: markAllReadPosition == .bottom) {
+            feedManager.markAllRead(for: section)
         }
     }
 }

--- a/SakuraRSS/Views/Home/ListSectionView.swift
+++ b/SakuraRSS/Views/Home/ListSectionView.swift
@@ -35,12 +35,8 @@ struct ListSectionView: View {
         .refreshable {
             await feedManager.refreshAllFeeds()
         }
-        .safeAreaInset(edge: .bottom, alignment: .leading, spacing: 0) {
-            if markAllReadPosition == .bottom {
-                ArticlesToolbar {
-                    feedManager.markAllRead(for: list)
-                }
-            }
+        .markAllReadToolbar(show: markAllReadPosition == .bottom) {
+            feedManager.markAllRead(for: list)
         }
     }
 }

--- a/SakuraRSS/Views/Shared/Articles/ArticlesToolbar.swift
+++ b/SakuraRSS/Views/Shared/Articles/ArticlesToolbar.swift
@@ -35,3 +35,20 @@ struct ArticlesToolbar: View {
         }
     }
 }
+
+extension View {
+    /// Attaches the floating Mark All Read button when `show` is true.
+    @ViewBuilder
+    func markAllReadToolbar(
+        show: Bool,
+        onMarkAllRead: @escaping () -> Void
+    ) -> some View {
+        if show {
+            self.safeAreaInset(edge: .bottom, alignment: .leading, spacing: 0) {
+                ArticlesToolbar(onMarkAllRead: onMarkAllRead)
+            }
+        } else {
+            self
+        }
+    }
+}


### PR DESCRIPTION
Lift the conditional out of the `safeAreaInset` closure via a new
`markAllReadToolbar` helper so the modifier is only attached when
the button should be shown.