### PR TITLE
Add arXiv integration with PDF viewer and feed detection

### DIFF
--- a/SakuraRSS/Views/Shared/ArXivPDFViewerView.swift
+++ b/SakuraRSS/Views/Shared/ArXivPDFViewerView.swift
@@ -25,7 +25,7 @@ struct ArXivPDFViewerView: View {
         ZStack {
             if let document {
                 PDFKitView(document: document)
-                    .ignoresSafeArea(.container, edges: .bottom)
+                    .ignoresSafeArea()
             } else if isLoading {
                 ProgressView()
                     .controlSize(.large)

--- a/SakuraRSS/Views/Shared/ArXivPDFViewerView.swift
+++ b/SakuraRSS/Views/Shared/ArXivPDFViewerView.swift
@@ -25,7 +25,7 @@ struct ArXivPDFViewerView: View {
         ZStack {
             if let document {
                 PDFKitView(document: document)
-                    .ignoresSafeArea()
+                    .ignoresSafeArea(edges: .vertical)
             } else if isLoading {
                 ProgressView()
                     .controlSize(.large)

--- a/SakuraRSS/Views/Shared/ArXivPDFViewerView.swift
+++ b/SakuraRSS/Views/Shared/ArXivPDFViewerView.swift
@@ -1,0 +1,104 @@
+import PDFKit
+import SwiftUI
+
+/// Identifier passed to `.navigationDestination(item:)` for the arXiv PDF
+/// viewer. Using a dedicated type (rather than `URL`) avoids colliding with
+/// the article detail view's other URL-typed navigation destinations.
+struct ArXivPDFReference: Identifiable, Hashable {
+    let url: URL
+    let title: String
+    var id: URL { url }
+}
+
+/// In-app PDF viewer used for arXiv papers. Downloads the PDF with the
+/// standard Sakura user agent and renders it with PDFKit.
+struct ArXivPDFViewerView: View {
+
+    let url: URL
+    let title: String
+
+    @State private var document: PDFDocument?
+    @State private var loadError: String?
+    @State private var isLoading = true
+
+    var body: some View {
+        ZStack {
+            if let document {
+                PDFKitView(document: document)
+                    .ignoresSafeArea(.container, edges: .bottom)
+            } else if isLoading {
+                ProgressView()
+                    .controlSize(.large)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if let loadError {
+                VStack(spacing: 12) {
+                    Image(systemName: "exclamationmark.triangle")
+                        .font(.largeTitle)
+                        .foregroundStyle(.secondary)
+                    Text(loadError)
+                        .multilineTextAlignment(.center)
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal)
+                }
+            }
+        }
+        .navigationTitle(title)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                if document != nil {
+                    ShareLink(item: url) {
+                        Label("Article.Share", systemImage: "square.and.arrow.up")
+                    }
+                }
+            }
+        }
+        .task(id: url) {
+            await loadPDF()
+        }
+    }
+
+    private func loadPDF() async {
+        isLoading = true
+        loadError = nil
+        defer { isLoading = false }
+
+        do {
+            let request = URLRequest.sakura(url: url)
+            let (data, response) = try await URLSession.shared.data(for: request)
+            if let http = response as? HTTPURLResponse, http.statusCode != 200 {
+                loadError = String(localized: "ArXiv.PDF.LoadFailed")
+                return
+            }
+            if let doc = PDFDocument(data: data) {
+                document = doc
+            } else {
+                loadError = String(localized: "ArXiv.PDF.LoadFailed")
+            }
+        } catch {
+            loadError = String(localized: "ArXiv.PDF.LoadFailed")
+        }
+    }
+}
+
+private struct PDFKitView: UIViewRepresentable {
+
+    let document: PDFDocument
+
+    func makeUIView(context _: Context) -> PDFView {
+        let view = PDFView()
+        view.document = document
+        view.autoScales = true
+        view.displayMode = .singlePageContinuous
+        view.displayDirection = .vertical
+        view.usePageViewController(false)
+        view.backgroundColor = .systemBackground
+        return view
+    }
+
+    func updateUIView(_ uiView: PDFView, context _: Context) {
+        if uiView.document !== document {
+            uiView.document = document
+        }
+    }
+}

--- a/SakuraRSS/Views/Shared/Article Detail/ArticleDetailView+Actions.swift
+++ b/SakuraRSS/Views/Shared/Article Detail/ArticleDetailView+Actions.swift
@@ -26,6 +26,19 @@ extension ArticleDetailView {
                     }
                 }
 
+                if let pdfURL = ArXivHelper.pdfURL(forArticleURL: article.url) {
+                    OpenLinkButton(
+                        title: "ArXiv.ViewPDF",
+                        systemImage: "doc.richtext",
+                        action: {
+                            arXivPDFReference = ArXivPDFReference(
+                                url: pdfURL,
+                                title: article.title
+                            )
+                        }
+                    )
+                }
+
                 OpenLinkButton(
                     title: "Article.OpenInBrowser",
                     systemImage: article.isYouTubeURL && YouTubeHelper.isAppInstalled

--- a/SakuraRSS/Views/Shared/Article Detail/ArticleDetailView+Extraction.swift
+++ b/SakuraRSS/Views/Shared/Article Detail/ArticleDetailView+Extraction.swift
@@ -76,6 +76,17 @@ extension ArticleDetailView {
 
         // Automatic: use domain lists to determine the best extraction method
 
+        // For arXiv abstract pages, the RSS feed already contains the paper's
+        // abstract, and the arxiv.org abstract page itself is mostly metadata
+        // we don't want to render. Prefer the feed summary directly.
+        if let url = URL(string: article.url), ArXivHelper.isArXivAbstractURL(url) {
+            if let summary = article.summary, !summary.isEmpty {
+                extractedText = summary
+                try? DatabaseManager.shared.cacheArticleContent(summary, for: article.id)
+            }
+            return
+        }
+
         // For X post URLs (from non-X feeds), use the X API to fetch the tweet directly
         let isFromXFeed = feedManager.feed(forArticle: article)?.isXFeed == true
         if article.isXPostURL, !isFromXFeed,

--- a/SakuraRSS/Views/Shared/Article Detail/ArticleDetailView.swift
+++ b/SakuraRSS/Views/Shared/Article Detail/ArticleDetailView.swift
@@ -29,6 +29,7 @@ struct ArticleDetailView: View {
     @State var summarizationError: String?
     @State var showYouTubePlayer = false
     @State var showYouTubeSafari = false
+    @State var arXivPDFReference: ArXivPDFReference?
     @State var imageViewerURL: URL?
     @State var heroImageAspectRatio: CGFloat?
     @Namespace private var imageViewerNamespace
@@ -203,6 +204,9 @@ struct ArticleDetailView: View {
         }
         .navigationDestination(isPresented: $showYouTubePlayer) {
             YouTubePlayerView(article: article)
+        }
+        .navigationDestination(item: $arXivPDFReference) { reference in
+            ArXivPDFViewerView(url: reference.url, title: reference.title)
         }
         .sheet(isPresented: $showYouTubeSafari) {
             if let url = URL(string: article.url) {

--- a/Shared/FeedDiscovery.swift
+++ b/Shared/FeedDiscovery.swift
@@ -251,6 +251,9 @@ actor FeedDiscovery {
     /// Detects Bluesky, Mastodon, X/Twitter, and Instagram profile URLs
     /// and constructs their feed URLs.
     private func detectSocialMediaFeed(url: URL) async -> DiscoveredFeed? {
+        if let arXivFeed = detectArXivListFeed(url: url) {
+            return arXivFeed
+        }
         if UserDefaults.standard.bool(forKey: "Labs.XProfileFeeds"),
            let xFeed = detectXProfileFeed(url: url) {
             return xFeed
@@ -269,6 +272,22 @@ actor FeedDiscovery {
             return mastodonFeed
         }
         return nil
+    }
+
+    /// Detects arXiv subject listing URLs and rewrites them to the matching
+    /// RSS feed. arXiv publishes a standard RSS feed for each category
+    /// (e.g. `https://arxiv.org/list/cs.AI/recent` →
+    /// `https://rss.arxiv.org/rss/cs.AI`) so the normal RSS parser can handle
+    /// refreshes.
+    private func detectArXivListFeed(url: URL) -> DiscoveredFeed? {
+        guard let category = ArXivHelper.extractCategoryFromListURL(url) else {
+            return nil
+        }
+        return DiscoveredFeed(
+            title: "arXiv \(category)",
+            url: ArXivHelper.feedURL(forCategory: category),
+            siteURL: "https://arxiv.org/list/\(category)/recent"
+        )
     }
 
     /// Detects X/Twitter profile URLs and returns a pseudo-feed entry.

--- a/Shared/Localizable.xcstrings
+++ b/Shared/Localizable.xcstrings
@@ -1804,6 +1804,28 @@
         }
       }
     },
+    "ArXiv.PDF.LoadFailed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't load PDF."
+          }
+        }
+      }
+    },
+    "ArXiv.ViewPDF" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "View PDF"
+          }
+        }
+      }
+    },
     "Article.Bookmark" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Shared/arXiv Integration/ArXivHelper.swift
+++ b/Shared/arXiv Integration/ArXivHelper.swift
@@ -1,0 +1,122 @@
+import Foundation
+
+/// Helpers for detecting arXiv URLs and mapping them between list pages,
+/// RSS feeds, abstract pages, and PDF downloads.
+///
+/// arXiv publishes standard RSS feeds that already contain paper titles and
+/// abstracts, so a dedicated scraper isn't needed. Instead, when the user
+/// adds an arXiv list URL (e.g. `https://arxiv.org/list/cs.AI/recent`) we
+/// transparently rewrite it to the category's RSS feed
+/// (`https://rss.arxiv.org/rss/cs.AI`) so the standard RSSParser can handle
+/// refreshes.
+nonisolated enum ArXivHelper {
+
+    // MARK: - Host Detection
+
+    /// Returns `true` if the URL's host is an arXiv-owned domain.
+    static func isArXivHost(_ url: URL) -> Bool {
+        guard let host = url.host?.lowercased() else { return false }
+        return host == "arxiv.org"
+            || host == "www.arxiv.org"
+            || host == "export.arxiv.org"
+            || host == "rss.arxiv.org"
+    }
+
+    // MARK: - List URL → Feed URL
+
+    /// Returns `true` if the URL points to an arXiv subject listing page,
+    /// e.g. `https://arxiv.org/list/cs.AI/recent`.
+    static func isArXivListURL(_ url: URL) -> Bool {
+        guard isArXivHost(url) else { return false }
+        return extractCategoryFromListURL(url) != nil
+    }
+
+    /// Extracts the arXiv subject category (e.g. `cs.AI`, `math.CO`,
+    /// `physics.optics`) from a list URL. Returns `nil` if the URL isn't a
+    /// valid list URL.
+    static func extractCategoryFromListURL(_ url: URL) -> String? {
+        guard isArXivHost(url) else { return nil }
+        let components = url.path.split(separator: "/").map(String.init)
+        // Expected shape: ["list", "<category>", ...]
+        guard components.count >= 2, components[0] == "list" else { return nil }
+        let category = components[1]
+        guard isValidCategory(category) else { return nil }
+        return category
+    }
+
+    /// Returns the RSS feed URL for a given arXiv subject category.
+    static func feedURL(forCategory category: String) -> String {
+        "https://rss.arxiv.org/rss/\(category)"
+    }
+
+    /// Returns `true` if the given URL string points to an arXiv RSS feed.
+    static func isArXivFeedURL(_ urlString: String) -> Bool {
+        guard let url = URL(string: urlString), let host = url.host?.lowercased() else {
+            return false
+        }
+        if host == "rss.arxiv.org" && url.path.hasPrefix("/rss/") {
+            return true
+        }
+        if (host == "export.arxiv.org" || host == "arxiv.org") && url.path.hasPrefix("/rss/") {
+            return true
+        }
+        return false
+    }
+
+    // MARK: - Abstract & PDF URLs
+
+    /// Returns `true` if the URL points to an arXiv abstract page
+    /// (`/abs/<id>`).
+    static func isArXivAbstractURL(_ url: URL) -> Bool {
+        guard isArXivHost(url) else { return false }
+        return extractArXivID(from: url) != nil
+    }
+
+    /// Extracts the arXiv paper ID from an abstract or PDF URL.
+    /// Handles both the new (`2411.12345`) and legacy (`hep-th/0601001`)
+    /// identifier formats, plus any trailing version suffix (`v1`, `v2`, …).
+    static func extractArXivID(from url: URL) -> String? {
+        guard isArXivHost(url) else { return nil }
+        let path = url.path
+        let prefixes = ["/abs/", "/pdf/", "/html/"]
+        guard let prefix = prefixes.first(where: { path.hasPrefix($0) }) else {
+            return nil
+        }
+        var remainder = String(path.dropFirst(prefix.count))
+        if remainder.hasSuffix(".pdf") {
+            remainder = String(remainder.dropLast(4))
+        }
+        // Trim any trailing slash.
+        if remainder.hasSuffix("/") {
+            remainder = String(remainder.dropLast())
+        }
+        return remainder.isEmpty ? nil : remainder
+    }
+
+    /// Returns the canonical PDF URL for a given arXiv paper ID.
+    static func pdfURL(forID arXivID: String) -> URL? {
+        URL(string: "https://arxiv.org/pdf/\(arXivID).pdf")
+    }
+
+    /// Returns the canonical PDF URL for the article at the given URL string,
+    /// if it refers to an arXiv abstract or PDF page.
+    static func pdfURL(forArticleURL urlString: String) -> URL? {
+        guard let url = URL(string: urlString),
+              let arXivID = extractArXivID(from: url) else {
+            return nil
+        }
+        return pdfURL(forID: arXivID)
+    }
+
+    // MARK: - Validation
+
+    /// arXiv subject categories look like `cs`, `cs.AI`, `math.CO`,
+    /// `physics.optics`, `hep-th`, etc. We accept the conservative superset of
+    /// lowercase letters, digits, dots, and hyphens.
+    private static func isValidCategory(_ category: String) -> Bool {
+        guard !category.isEmpty, category.count <= 32 else { return false }
+        let allowed = CharacterSet(charactersIn:
+            "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.-")
+        return category.unicodeScalars.allSatisfy { allowed.contains($0) }
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds comprehensive arXiv support to Sakura RSS, including automatic feed detection for arXiv subject listings, an in-app PDF viewer for papers, and smart content extraction for arXiv articles.

## Key Changes

- **ArXivHelper utility** (`Shared/arXiv Integration/ArXivHelper.swift`): New helper module providing:
  - Host detection for arXiv-owned domains
  - Conversion of arXiv list URLs (e.g., `arxiv.org/list/cs.AI/recent`) to RSS feed URLs
  - Extraction and validation of arXiv subject categories
  - Paper ID extraction from abstract and PDF URLs
  - PDF URL generation for papers

- **Feed Discovery Integration**: Modified `FeedDiscovery.swift` to automatically detect arXiv subject listing URLs and rewrite them to the corresponding RSS feeds, allowing seamless subscription to arXiv categories

- **In-app PDF Viewer** (`SakuraRSS/Views/Shared/ArXivPDFViewerView.swift`): New SwiftUI view that:
  - Downloads PDFs with the standard Sakura user agent
  - Renders PDFs using PDFKit with continuous scrolling
  - Displays loading states and error handling
  - Includes share functionality

- **Article Detail Integration**: Enhanced `ArticleDetailView` to:
  - Detect arXiv abstract URLs and show a "View PDF" button
  - Navigate to the in-app PDF viewer when available
  - Use RSS feed summaries directly for arXiv articles (avoiding unnecessary web scraping of abstract pages)

- **Localization**: Added new strings for PDF loading errors and the "View PDF" button

## Implementation Details

- arXiv category validation uses a conservative character set (letters, digits, dots, hyphens) to handle both modern (`2411.12345`) and legacy (`hep-th/0601001`) identifier formats
- The PDF viewer uses a dedicated `ArXivPDFReference` type for navigation to avoid colliding with other URL-based navigation destinations
- Feed detection transparently rewrites list URLs to RSS feeds, leveraging arXiv's native RSS infrastructure rather than requiring custom scraping

https://claude.ai/code/session_018nzy4Z536NJ334EQCtM7tw