### PR TITLE
Add Reddit post scraper with native content extraction

### DIFF
--- a/SakuraRSS/Structs/ContentBlock.swift
+++ b/SakuraRSS/Structs/ContentBlock.swift
@@ -4,22 +4,27 @@ enum ContentBlock: Identifiable {
     case text(String)
     case image(URL, link: URL? = nil)
     case code(String)
+    case video(URL)
 
     var id: String {
         switch self {
         case .text(let text): return "text-\(text.hashValue)"
         case .image(let url, _): return "image-\(url.absoluteString)"
         case .code(let text): return "code-\(text.hashValue)"
+        case .video(let url): return "video-\(url.absoluteString)"
         }
     }
 
-    /// Strips image and code markers from text, returning plain text suitable for translation/summarization.
+    /// Strips image, video, and code markers from text, returning plain text suitable for translation/summarization.
     static func plainText(from text: String) -> String {
         text.replacingOccurrences(
             of: #"\{\{IMG\}\}.+?\{\{/IMG\}\}"#, with: "", options: .regularExpression
         )
         .replacingOccurrences(
             of: #"\{\{IMGLINK\}\}.+?\{\{/IMGLINK\}\}"#, with: "", options: .regularExpression
+        )
+        .replacingOccurrences(
+            of: #"\{\{VIDEO\}\}.+?\{\{/VIDEO\}\}"#, with: "", options: .regularExpression
         )
         .replacingOccurrences(of: "{{CODE}}", with: "")
         .replacingOccurrences(of: "{{/CODE}}", with: "")
@@ -37,6 +42,10 @@ enum ContentBlock: Identifiable {
         )
         result = result.replacingOccurrences(
             of: #"\{\{IMGLINK\}\}.+?\{\{/IMGLINK\}\}"#, with: "", options: .regularExpression
+        )
+        // Strip video markers
+        result = result.replacingOccurrences(
+            of: #"\{\{VIDEO\}\}.+?\{\{/VIDEO\}\}"#, with: "", options: .regularExpression
         )
         // Strip code markers, keeping content
         result = result.replacingOccurrences(of: "{{CODE}}", with: "")
@@ -75,8 +84,8 @@ enum ContentBlock: Identifiable {
     }
 
     static func parse(_ text: String) -> [ContentBlock] {
-        // Match both {{IMG}}…{{/IMG}} and {{CODE}}…{{/CODE}} markers
-        let pattern = #"\{\{(IMG|CODE)\}\}(.*?)\{\{/(IMG|CODE)\}\}"#
+        // Match {{IMG}}, {{CODE}}, and {{VIDEO}} markers.
+        let pattern = #"\{\{(IMG|CODE|VIDEO)\}\}(.*?)\{\{/(IMG|CODE|VIDEO)\}\}"#
         guard let regex = try? NSRegularExpression(pattern: pattern, options: .dotMatchesLineSeparators)
         else {
             return [.text(text)]
@@ -112,6 +121,10 @@ enum ContentBlock: Identifiable {
             if tag == "CODE" {
                 if !content.isEmpty {
                     blocks.append(.code(content))
+                }
+            } else if tag == "VIDEO" {
+                if let url = URL(string: content) {
+                    blocks.append(.video(url))
                 }
             } else {
                 // IMG — possibly with a link

--- a/SakuraRSS/Structs/ContentBlock.swift
+++ b/SakuraRSS/Structs/ContentBlock.swift
@@ -15,7 +15,7 @@ enum ContentBlock: Identifiable {
         }
     }
 
-    /// Strips image, video, and code markers from text, returning plain text suitable for translation/summarization.
+    /// Strips image and code markers from text, returning plain text suitable for translation/summarization.
     static func plainText(from text: String) -> String {
         text.replacingOccurrences(
             of: #"\{\{IMG\}\}.+?\{\{/IMG\}\}"#, with: "", options: .regularExpression
@@ -43,7 +43,6 @@ enum ContentBlock: Identifiable {
         result = result.replacingOccurrences(
             of: #"\{\{IMGLINK\}\}.+?\{\{/IMGLINK\}\}"#, with: "", options: .regularExpression
         )
-        // Strip video markers
         result = result.replacingOccurrences(
             of: #"\{\{VIDEO\}\}.+?\{\{/VIDEO\}\}"#, with: "", options: .regularExpression
         )
@@ -84,7 +83,6 @@ enum ContentBlock: Identifiable {
     }
 
     static func parse(_ text: String) -> [ContentBlock] {
-        // Match {{IMG}}, {{CODE}}, and {{VIDEO}} markers.
         let pattern = #"\{\{(IMG|CODE|VIDEO)\}\}(.*?)\{\{/(IMG|CODE|VIDEO)\}\}"#
         guard let regex = try? NSRegularExpression(pattern: pattern, options: .dotMatchesLineSeparators)
         else {

--- a/SakuraRSS/Views/Shared/Article Detail/ArticleDetailView+Extraction.swift
+++ b/SakuraRSS/Views/Shared/Article Detail/ArticleDetailView+Extraction.swift
@@ -36,6 +36,45 @@ extension ArticleDetailView {
         debugPrint("[Extract] Source: \(source.rawValue), content length: \(article.content?.count ?? 0): \(article.url)")
         #endif
 
+        // URL the generic extractor should run against. For link posts on
+        // Reddit, this is swapped below to the destination URL so readers see
+        // the linked article's content instead of the Reddit permalink HTML.
+        var contentURL: URL? = URL(string: article.url)
+        // True when the Reddit branch swapped in an off-reddit URL; the rest
+        // of the extraction flow must skip anything that reads from the
+        // Reddit RSS `article.content` (which is score/comment junk, not the
+        // linked article).
+        var isRedditLinkedArticle = false
+
+        // Reddit posts: resolve via the public /comments/{id}.json endpoint.
+        // Text/image/gallery/video posts produce a ready-to-cache marker
+        // string; link posts fall through to the generic extractor against
+        // the destination URL.
+        if feedManager.feed(forArticle: article)?.isRedditFeed == true {
+            do {
+                let result = try await RedditPostScraper.shared.fetchContent(for: article)
+                switch result {
+                case .markerString(let markerString):
+                    if !markerString.isEmpty {
+                        extractedText = markerString
+                        try? DatabaseManager.shared.cacheArticleContent(
+                            markerString, for: article.id
+                        )
+                        return
+                    }
+                    // Empty marker string — fall through to the generic
+                    // extractor so the user at least sees the RSS summary.
+                case .linkedArticle(let linkedURL):
+                    contentURL = linkedURL
+                    isRedditLinkedArticle = true
+                }
+            } catch {
+                #if DEBUG
+                debugPrint("[Extract] Reddit fetch failed, falling through: \(error)")
+                #endif
+            }
+        }
+
         switch source {
         case .feedText:
             if let content = article.content, !content.isEmpty {
@@ -122,7 +161,7 @@ extension ArticleDetailView {
             return
         }
 
-        if let content = article.content, !content.isEmpty {
+        if !isRedditLinkedArticle, let content = article.content, !content.isEmpty {
             let baseURL = URL(string: article.url)
             let text = ArticleExtractor.extractText(fromHTML: content,
                                                     baseURL: baseURL,
@@ -147,7 +186,7 @@ extension ArticleDetailView {
             #endif
         }
 
-        if let url = URL(string: article.url) {
+        if let url = contentURL {
             var text = await ArticleExtractor.extractText(fromURL: url,
                                                           excludeTitle: articleTitle)
             #if DEBUG

--- a/SakuraRSS/Views/Shared/Article Detail/ArticleDetailView+Extraction.swift
+++ b/SakuraRSS/Views/Shared/Article Detail/ArticleDetailView+Extraction.swift
@@ -36,20 +36,9 @@ extension ArticleDetailView {
         debugPrint("[Extract] Source: \(source.rawValue), content length: \(article.content?.count ?? 0): \(article.url)")
         #endif
 
-        // URL the generic extractor should run against. For link posts on
-        // Reddit, this is swapped below to the destination URL so readers see
-        // the linked article's content instead of the Reddit permalink HTML.
         var contentURL: URL? = URL(string: article.url)
-        // True when the Reddit branch swapped in an off-reddit URL; the rest
-        // of the extraction flow must skip anything that reads from the
-        // Reddit RSS `article.content` (which is score/comment junk, not the
-        // linked article).
         var isRedditLinkedArticle = false
 
-        // Reddit posts: resolve via the public /comments/{id}.json endpoint.
-        // Text/image/gallery/video posts produce a ready-to-cache marker
-        // string; link posts fall through to the generic extractor against
-        // the destination URL.
         if feedManager.feed(forArticle: article)?.isRedditFeed == true {
             do {
                 let result = try await RedditPostScraper.shared.fetchContent(for: article)
@@ -62,8 +51,6 @@ extension ArticleDetailView {
                         )
                         return
                     }
-                    // Empty marker string — fall through to the generic
-                    // extractor so the user at least sees the RSS summary.
                 case .linkedArticle(let linkedURL):
                     contentURL = linkedURL
                     isRedditLinkedArticle = true

--- a/SakuraRSS/Views/Shared/Article Detail/ArticleDetailView.swift
+++ b/SakuraRSS/Views/Shared/Article Detail/ArticleDetailView.swift
@@ -164,6 +164,8 @@ struct ArticleDetailView: View {
                             FitWidthImage(url: url, link: link, namespace: imageViewerNamespace) {
                                 imageViewerURL = url
                             }
+                        case .video(let url):
+                            VideoBlockView(url: url)
                         }
                     }
                     .id("\(showingSummary)-\(showingTranslation)")

--- a/SakuraRSS/Views/Shared/Article Detail/VideoBlockView.swift
+++ b/SakuraRSS/Views/Shared/Article Detail/VideoBlockView.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+import AVKit
+
+/// Renders a video content block inline in the article detail view.
+/// Wraps `AVPlayerViewController` so users get scrubbing, fullscreen, and
+/// Picture-in-Picture controls for free. Works with any AVPlayer-compatible
+/// URL (HLS, MP4, etc.), so it isn't tied to Reddit specifically.
+struct VideoBlockView: View {
+
+    let url: URL
+
+    var body: some View {
+        VideoPlayerRepresentable(url: url)
+            .aspectRatio(16.0 / 9.0, contentMode: .fit)
+            .frame(maxWidth: .infinity)
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+}
+
+private struct VideoPlayerRepresentable: UIViewControllerRepresentable {
+
+    let url: URL
+
+    func makeUIViewController(context: Context) -> AVPlayerViewController {
+        let controller = AVPlayerViewController()
+        controller.player = AVPlayer(url: url)
+        controller.allowsPictureInPicturePlayback = true
+        controller.videoGravity = .resizeAspect
+        return controller
+    }
+
+    func updateUIViewController(_ controller: AVPlayerViewController, context: Context) {
+        if (controller.player?.currentItem?.asset as? AVURLAsset)?.url != url {
+            controller.player = AVPlayer(url: url)
+        }
+    }
+}

--- a/SakuraRSS/Views/Shared/Article Detail/VideoBlockView.swift
+++ b/SakuraRSS/Views/Shared/Article Detail/VideoBlockView.swift
@@ -1,10 +1,6 @@
 import SwiftUI
 import AVKit
 
-/// Renders a video content block inline in the article detail view.
-/// Wraps `AVPlayerViewController` so users get scrubbing, fullscreen, and
-/// Picture-in-Picture controls for free. Works with any AVPlayer-compatible
-/// URL (HLS, MP4, etc.), so it isn't tied to Reddit specifically.
 struct VideoBlockView: View {
 
     let url: URL

--- a/SakuraRSS/Views/Shared/Feed Display Styles/ScrollStyleView.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/ScrollStyleView.swift
@@ -473,6 +473,8 @@ private struct ScrollExpandedArticleView: View {
                             }
                             .scaledToFit()
                             .clipShape(.rect(cornerRadius: 12))
+                        case .video(let url):
+                            VideoBlockView(url: url)
                         }
                     }
                 }

--- a/SakuraRSS/Views/Shared/YouTube Player/YouTubePlayerView.swift
+++ b/SakuraRSS/Views/Shared/YouTube Player/YouTubePlayerView.swift
@@ -273,6 +273,8 @@ struct YouTubePlayerView: View {
                                     }
                                     .aspectRatio(contentMode: .fit)
                                     .clipShape(RoundedRectangle(cornerRadius: 12))
+                                case .video(let url):
+                                    VideoBlockView(url: url)
                                 }
                             }
                             .id("\(showingSummary)-\(showingTranslation)")

--- a/Shared/Reddit Integration/RedditPostScraper+Extraction.swift
+++ b/Shared/Reddit Integration/RedditPostScraper+Extraction.swift
@@ -2,10 +2,6 @@ import Foundation
 
 extension RedditPostScraper {
 
-    /// Walks a decoded `/comments/{id}.json` listings array and produces a
-    /// `RedditPostFetchResult`. Reddit returns an array of two listings —
-    /// the first contains the post itself, the second contains comments
-    /// (which the reader intentionally ignores).
     static func extractResult(fromListings listings: [Any]) throws -> RedditPostFetchResult {
         guard let firstListing = listings.first as? [String: Any],
               let data = firstListing["data"] as? [String: Any],
@@ -18,13 +14,7 @@ extension RedditPostScraper {
         return extractResult(fromPost: post)
     }
 
-    /// Translates a single Reddit post payload into a renderable result.
-    /// Follows the priority order documented in the plan: crosspost parent,
-    /// gallery, native video, image hint, self text, off-reddit link,
-    /// unknown fallback.
     static func extractResult(fromPost post: [String: Any]) -> RedditPostFetchResult {
-        // 1. Crossposts — recurse into the parent post so the reader sees the
-        //    original content type rather than a wrapper.
         if let parents = post["crosspost_parent_list"] as? [[String: Any]],
            let parent = parents.first {
             return extractResult(fromPost: parent)
@@ -35,8 +25,6 @@ extension RedditPostScraper {
         let isSelf = (post["is_self"] as? Bool) ?? false
         let postHint = post["post_hint"] as? String
 
-        // Selftext is prepended to any media that follows so readers get the
-        // author's prose alongside the images/video in one scrollable flow.
         let selftext: String = {
             guard let raw = post["selftext"] as? String else { return "" }
             return raw.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -47,7 +35,6 @@ extension RedditPostScraper {
             markerLines.append(selftext)
         }
 
-        // 2. Gallery — emit one {{IMG}} line per gallery item.
         if isGallery, let galleryURLs = galleryImageURLs(from: post), !galleryURLs.isEmpty {
             for galleryURL in galleryURLs {
                 markerLines.append("{{IMG}}\(galleryURL){{/IMG}}")
@@ -55,7 +42,6 @@ extension RedditPostScraper {
             return .markerString(markerLines.joined(separator: "\n\n"))
         }
 
-        // 3. Native v.redd.it video — emit an HLS URL.
         if isVideo, let media = post["media"] as? [String: Any],
            let redditVideo = media["reddit_video"] as? [String: Any],
            let hls = redditVideo["hls_url"] as? String,
@@ -64,14 +50,12 @@ extension RedditPostScraper {
             return .markerString(markerLines.joined(separator: "\n\n"))
         }
 
-        // 4. Single image hint — emit the image URL directly.
         if postHint == "image", let urlString = post["url"] as? String,
            let imageURL = URL(string: unescapeHTMLEntities(urlString)) {
             markerLines.append("{{IMG}}\(imageURL.absoluteString){{/IMG}}")
             return .markerString(markerLines.joined(separator: "\n\n"))
         }
 
-        // 5. Pure self post — we already captured selftext above.
         if isSelf {
             if markerLines.isEmpty {
                 return .markerString("")
@@ -79,7 +63,6 @@ extension RedditPostScraper {
             return .markerString(markerLines.joined(separator: "\n\n"))
         }
 
-        // 6. Off-reddit link — short-circuit to the generic extractor.
         if let urlString = post["url"] as? String,
            let linkedURL = URL(string: unescapeHTMLEntities(urlString)),
            let host = linkedURL.host?.lowercased(),
@@ -88,16 +71,9 @@ extension RedditPostScraper {
             return .linkedArticle(linkedURL)
         }
 
-        // 7. Unknown shape — fall back to any selftext we have, or an empty
-        //    string (the caller will still have the RSS summary to show).
         return .markerString(markerLines.joined(separator: "\n\n"))
     }
 
-    // MARK: - Helpers
-
-    /// Resolves gallery item IDs into absolute image URLs by looking them up
-    /// in `media_metadata`. Reddit returns the `s.u` URL HTML-escaped with
-    /// `&amp;`, so we unescape to make them usable.
     private static func galleryImageURLs(from post: [String: Any]) -> [String]? {
         guard let galleryData = post["gallery_data"] as? [String: Any],
               let items = galleryData["items"] as? [[String: Any]],
@@ -121,9 +97,6 @@ extension RedditPostScraper {
         return urls
     }
 
-    /// Reddit JSON returns image URLs with `&amp;` in the query string even
-    /// with `raw_json=1` in some endpoints. Normalize them back to `&` so
-    /// URLSession fetches succeed.
     private static func unescapeHTMLEntities(_ input: String) -> String {
         input.replacingOccurrences(of: "&amp;", with: "&")
     }

--- a/Shared/Reddit Integration/RedditPostScraper+Extraction.swift
+++ b/Shared/Reddit Integration/RedditPostScraper+Extraction.swift
@@ -1,0 +1,130 @@
+import Foundation
+
+extension RedditPostScraper {
+
+    /// Walks a decoded `/comments/{id}.json` listings array and produces a
+    /// `RedditPostFetchResult`. Reddit returns an array of two listings —
+    /// the first contains the post itself, the second contains comments
+    /// (which the reader intentionally ignores).
+    static func extractResult(fromListings listings: [Any]) throws -> RedditPostFetchResult {
+        guard let firstListing = listings.first as? [String: Any],
+              let data = firstListing["data"] as? [String: Any],
+              let children = data["children"] as? [[String: Any]],
+              let postWrapper = children.first,
+              let post = postWrapper["data"] as? [String: Any] else {
+            throw RedditPostScraperError.parseFailed
+        }
+
+        return extractResult(fromPost: post)
+    }
+
+    /// Translates a single Reddit post payload into a renderable result.
+    /// Follows the priority order documented in the plan: crosspost parent,
+    /// gallery, native video, image hint, self text, off-reddit link,
+    /// unknown fallback.
+    static func extractResult(fromPost post: [String: Any]) -> RedditPostFetchResult {
+        // 1. Crossposts — recurse into the parent post so the reader sees the
+        //    original content type rather than a wrapper.
+        if let parents = post["crosspost_parent_list"] as? [[String: Any]],
+           let parent = parents.first {
+            return extractResult(fromPost: parent)
+        }
+
+        let isGallery = (post["is_gallery"] as? Bool) ?? false
+        let isVideo = (post["is_video"] as? Bool) ?? false
+        let isSelf = (post["is_self"] as? Bool) ?? false
+        let postHint = post["post_hint"] as? String
+
+        // Selftext is prepended to any media that follows so readers get the
+        // author's prose alongside the images/video in one scrollable flow.
+        let selftext: String = {
+            guard let raw = post["selftext"] as? String else { return "" }
+            return raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        }()
+
+        var markerLines: [String] = []
+        if !selftext.isEmpty {
+            markerLines.append(selftext)
+        }
+
+        // 2. Gallery — emit one {{IMG}} line per gallery item.
+        if isGallery, let galleryURLs = galleryImageURLs(from: post), !galleryURLs.isEmpty {
+            for galleryURL in galleryURLs {
+                markerLines.append("{{IMG}}\(galleryURL){{/IMG}}")
+            }
+            return .markerString(markerLines.joined(separator: "\n\n"))
+        }
+
+        // 3. Native v.redd.it video — emit an HLS URL.
+        if isVideo, let media = post["media"] as? [String: Any],
+           let redditVideo = media["reddit_video"] as? [String: Any],
+           let hls = redditVideo["hls_url"] as? String,
+           !hls.isEmpty {
+            markerLines.append("{{VIDEO}}\(unescapeHTMLEntities(hls)){{/VIDEO}}")
+            return .markerString(markerLines.joined(separator: "\n\n"))
+        }
+
+        // 4. Single image hint — emit the image URL directly.
+        if postHint == "image", let urlString = post["url"] as? String,
+           let imageURL = URL(string: unescapeHTMLEntities(urlString)) {
+            markerLines.append("{{IMG}}\(imageURL.absoluteString){{/IMG}}")
+            return .markerString(markerLines.joined(separator: "\n\n"))
+        }
+
+        // 5. Pure self post — we already captured selftext above.
+        if isSelf {
+            if markerLines.isEmpty {
+                return .markerString("")
+            }
+            return .markerString(markerLines.joined(separator: "\n\n"))
+        }
+
+        // 6. Off-reddit link — short-circuit to the generic extractor.
+        if let urlString = post["url"] as? String,
+           let linkedURL = URL(string: unescapeHTMLEntities(urlString)),
+           let host = linkedURL.host?.lowercased(),
+           host != "reddit.com",
+           !host.hasSuffix(".reddit.com") {
+            return .linkedArticle(linkedURL)
+        }
+
+        // 7. Unknown shape — fall back to any selftext we have, or an empty
+        //    string (the caller will still have the RSS summary to show).
+        return .markerString(markerLines.joined(separator: "\n\n"))
+    }
+
+    // MARK: - Helpers
+
+    /// Resolves gallery item IDs into absolute image URLs by looking them up
+    /// in `media_metadata`. Reddit returns the `s.u` URL HTML-escaped with
+    /// `&amp;`, so we unescape to make them usable.
+    private static func galleryImageURLs(from post: [String: Any]) -> [String]? {
+        guard let galleryData = post["gallery_data"] as? [String: Any],
+              let items = galleryData["items"] as? [[String: Any]],
+              let mediaMetadata = post["media_metadata"] as? [String: Any] else {
+            return nil
+        }
+
+        var urls: [String] = []
+        for item in items {
+            guard let mediaID = item["media_id"] as? String,
+                  let entry = mediaMetadata[mediaID] as? [String: Any],
+                  let source = entry["s"] as? [String: Any] else {
+                continue
+            }
+            if let urlString = source["u"] as? String {
+                urls.append(unescapeHTMLEntities(urlString))
+            } else if let gif = source["gif"] as? String {
+                urls.append(unescapeHTMLEntities(gif))
+            }
+        }
+        return urls
+    }
+
+    /// Reddit JSON returns image URLs with `&amp;` in the query string even
+    /// with `raw_json=1` in some endpoints. Normalize them back to `&` so
+    /// URLSession fetches succeed.
+    private static func unescapeHTMLEntities(_ input: String) -> String {
+        input.replacingOccurrences(of: "&amp;", with: "&")
+    }
+}

--- a/Shared/Reddit Integration/RedditPostScraper+Fetching.swift
+++ b/Shared/Reddit Integration/RedditPostScraper+Fetching.swift
@@ -2,10 +2,6 @@ import Foundation
 
 extension RedditPostScraper {
 
-    /// Hits `/comments/{id}.json?raw_json=1` and hands the decoded payload to
-    /// the extraction step. One automatic retry on HTTP 429 after a short
-    /// backoff. Throws on failure so `extractArticleContent()`'s error path
-    /// can fall through to the generic extractor.
     func performFetch(postID: String) async throws -> RedditPostFetchResult {
         guard let url = Self.jsonURL(for: postID) else {
             throw RedditPostScraperError.invalidURL

--- a/Shared/Reddit Integration/RedditPostScraper+Fetching.swift
+++ b/Shared/Reddit Integration/RedditPostScraper+Fetching.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+extension RedditPostScraper {
+
+    /// Hits `/comments/{id}.json?raw_json=1` and hands the decoded payload to
+    /// the extraction step. One automatic retry on HTTP 429 after a short
+    /// backoff. Throws on failure so `extractArticleContent()`'s error path
+    /// can fall through to the generic extractor.
+    func performFetch(postID: String) async throws -> RedditPostFetchResult {
+        guard let url = Self.jsonURL(for: postID) else {
+            throw RedditPostScraperError.invalidURL
+        }
+
+        var request = URLRequest(url: url)
+        request.setValue(sakuraUserAgent, forHTTPHeaderField: "User-Agent")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        let (data, response) = try await sendWithRetry(request: request)
+
+        if let http = response as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
+            throw RedditPostScraperError.badResponse
+        }
+
+        let json = try JSONSerialization.jsonObject(with: data)
+        guard let listings = json as? [Any] else {
+            throw RedditPostScraperError.parseFailed
+        }
+
+        return try Self.extractResult(fromListings: listings)
+    }
+
+    private func sendWithRetry(request: URLRequest) async throws -> (Data, URLResponse) {
+        let (data, response) = try await URLSession.shared.data(for: request)
+        if let http = response as? HTTPURLResponse, http.statusCode == 429 {
+            try? await Task.sleep(nanoseconds: 2_000_000_000)
+            return try await URLSession.shared.data(for: request)
+        }
+        return (data, response)
+    }
+}

--- a/Shared/Reddit Integration/RedditPostScraper.swift
+++ b/Shared/Reddit Integration/RedditPostScraper.swift
@@ -1,0 +1,113 @@
+import Foundation
+
+/// Result of resolving a Reddit post into renderable content.
+///
+/// - `markerString`: A fully-formed `ContentBlock` marker string (mix of
+///   plain text, `{{IMG}}…{{/IMG}}`, and `{{VIDEO}}…{{/VIDEO}}`) ready to be
+///   cached and parsed by `ContentBlock.parse(_:)`.
+/// - `linkedArticle`: The post is a link post that points off-reddit. Callers
+///   should fall through to the generic article extractor against this URL
+///   instead of the Reddit permalink.
+enum RedditPostFetchResult: Sendable {
+    case markerString(String)
+    case linkedArticle(URL)
+}
+
+/// Scrapes Reddit's public `/comments/{id}.json` endpoint (no auth required)
+/// and translates posts into the same `ContentBlock` marker-string format
+/// that generic articles use. Reddit feeds continue to be refreshed through
+/// the regular RSS pipeline; this scraper is only consulted from
+/// `ArticleDetailView`'s extraction step to fetch the full post content.
+final class RedditPostScraper: @unchecked Sendable {
+
+    static let shared = RedditPostScraper()
+
+    // MARK: - LRU cache
+
+    /// Small in-memory LRU so backing out and reopening the same post in one
+    /// session doesn't refetch the JSON.
+    private let cacheCapacity = 16
+    private var cache: [String: RedditPostFetchResult] = [:]
+    private var cacheOrder: [String] = []
+    private let cacheQueue = DispatchQueue(label: "RedditPostScraper.cache")
+
+    private init() {}
+
+    func cachedResult(for postID: String) -> RedditPostFetchResult? {
+        cacheQueue.sync {
+            guard let value = cache[postID] else { return nil }
+            if let index = cacheOrder.firstIndex(of: postID) {
+                cacheOrder.remove(at: index)
+                cacheOrder.append(postID)
+            }
+            return value
+        }
+    }
+
+    func storeResult(_ result: RedditPostFetchResult, for postID: String) {
+        cacheQueue.sync {
+            if cache[postID] != nil {
+                if let index = cacheOrder.firstIndex(of: postID) {
+                    cacheOrder.remove(at: index)
+                }
+            }
+            cache[postID] = result
+            cacheOrder.append(postID)
+            while cacheOrder.count > cacheCapacity {
+                let evicted = cacheOrder.removeFirst()
+                cache.removeValue(forKey: evicted)
+            }
+        }
+    }
+
+    func clearCache() {
+        cacheQueue.sync {
+            cache.removeAll()
+            cacheOrder.removeAll()
+        }
+    }
+
+    // MARK: - Post ID extraction
+
+    /// Extracts the base-36 post ID from a Reddit permalink such as
+    /// `https://www.reddit.com/r/swift/comments/abc123/some_title/`.
+    nonisolated static func postID(from articleURL: URL) -> String? {
+        let components = articleURL.pathComponents.filter { $0 != "/" }
+        guard let commentsIndex = components.firstIndex(where: { $0.lowercased() == "comments" }),
+              commentsIndex + 1 < components.count else { return nil }
+        let candidate = components[commentsIndex + 1]
+        return candidate.isEmpty ? nil : candidate
+    }
+
+    /// Constructs the public JSON endpoint for a post.
+    nonisolated static func jsonURL(for postID: String) -> URL? {
+        URL(string: "https://www.reddit.com/comments/\(postID).json?raw_json=1")
+    }
+
+    // MARK: - Public entry point
+
+    /// Fetches a Reddit post's content and returns it as either a renderable
+    /// marker string or a URL that should be extracted via the generic
+    /// `ArticleExtractor` flow.
+    func fetchContent(for article: Article) async throws -> RedditPostFetchResult {
+        guard let url = URL(string: article.url),
+              let postID = Self.postID(from: url) else {
+            throw RedditPostScraperError.invalidURL
+        }
+
+        if let cached = cachedResult(for: postID) {
+            return cached
+        }
+
+        let result = try await performFetch(postID: postID)
+        storeResult(result, for: postID)
+        return result
+    }
+}
+
+enum RedditPostScraperError: Error {
+    case invalidURL
+    case badResponse
+    case rateLimited
+    case parseFailed
+}

--- a/Shared/Reddit Integration/RedditPostScraper.swift
+++ b/Shared/Reddit Integration/RedditPostScraper.swift
@@ -1,31 +1,16 @@
 import Foundation
 
-/// Result of resolving a Reddit post into renderable content.
-///
-/// - `markerString`: A fully-formed `ContentBlock` marker string (mix of
-///   plain text, `{{IMG}}…{{/IMG}}`, and `{{VIDEO}}…{{/VIDEO}}`) ready to be
-///   cached and parsed by `ContentBlock.parse(_:)`.
-/// - `linkedArticle`: The post is a link post that points off-reddit. Callers
-///   should fall through to the generic article extractor against this URL
-///   instead of the Reddit permalink.
 enum RedditPostFetchResult: Sendable {
     case markerString(String)
     case linkedArticle(URL)
 }
 
-/// Scrapes Reddit's public `/comments/{id}.json` endpoint (no auth required)
-/// and translates posts into the same `ContentBlock` marker-string format
-/// that generic articles use. Reddit feeds continue to be refreshed through
-/// the regular RSS pipeline; this scraper is only consulted from
-/// `ArticleDetailView`'s extraction step to fetch the full post content.
+/// Fetches Reddit posts via the public `/comments/{id}.json` endpoint and
+/// translates them into `ContentBlock` marker strings.
 final class RedditPostScraper: @unchecked Sendable {
 
     static let shared = RedditPostScraper()
 
-    // MARK: - LRU cache
-
-    /// Small in-memory LRU so backing out and reopening the same post in one
-    /// session doesn't refetch the JSON.
     private let cacheCapacity = 16
     private var cache: [String: RedditPostFetchResult] = [:]
     private var cacheOrder: [String] = []
@@ -67,10 +52,6 @@ final class RedditPostScraper: @unchecked Sendable {
         }
     }
 
-    // MARK: - Post ID extraction
-
-    /// Extracts the base-36 post ID from a Reddit permalink such as
-    /// `https://www.reddit.com/r/swift/comments/abc123/some_title/`.
     nonisolated static func postID(from articleURL: URL) -> String? {
         let components = articleURL.pathComponents.filter { $0 != "/" }
         guard let commentsIndex = components.firstIndex(where: { $0.lowercased() == "comments" }),
@@ -79,16 +60,10 @@ final class RedditPostScraper: @unchecked Sendable {
         return candidate.isEmpty ? nil : candidate
     }
 
-    /// Constructs the public JSON endpoint for a post.
     nonisolated static func jsonURL(for postID: String) -> URL? {
         URL(string: "https://www.reddit.com/comments/\(postID).json?raw_json=1")
     }
 
-    // MARK: - Public entry point
-
-    /// Fetches a Reddit post's content and returns it as either a renderable
-    /// marker string or a URL that should be extracted via the generic
-    /// `ArticleExtractor` flow.
     func fetchContent(for article: Article) async throws -> RedditPostFetchResult {
         guard let url = URL(string: article.url),
               let postID = Self.postID(from: url) else {


### PR DESCRIPTION
## Summary
Adds native Reddit post content extraction that resolves Reddit posts via the public `/comments/{id}.json` endpoint and translates them into the same marker-string format used for generic articles. This allows Reddit feeds to display full post content (text, images, galleries, videos) directly in the reader instead of relying on RSS summaries.

## Key Changes

- **RedditPostScraper**: New singleton class that manages Reddit post fetching and caching
  - Extracts post IDs from Reddit permalinks
  - Constructs and fetches from the public JSON endpoint with automatic retry on rate limiting
  - Maintains a 16-item LRU cache to avoid refetching during a session

- **Content extraction pipeline**: Implements priority-based content resolution
  - Crossposts: Recursively unwraps to show original content
  - Galleries: Extracts all image URLs and emits `{{IMG}}` markers
  - Native videos: Extracts HLS URLs and emits `{{VIDEO}}` markers
  - Single images: Emits image URL with `{{IMG}}` markers
  - Self posts: Returns text content
  - Link posts: Falls through to generic article extractor for the destination URL
  - Handles HTML entity unescaping (`&amp;` → `&`) in URLs

- **ContentBlock**: Extended to support video content
  - New `case video(URL)` variant
  - Updated parsing regex to recognize `{{VIDEO}}…{{/VIDEO}}` markers
  - Updated plaintext and summary extraction to strip video markers

- **ArticleDetailView**: Integrated Reddit extraction into the article detail flow
  - Detects Reddit feeds and routes through `RedditPostScraper`
  - Swaps content URL for link posts so generic extractor targets the destination
  - Skips RSS content parsing for Reddit link posts (which contain junk data)

- **VideoBlockView**: New SwiftUI component for inline video playback
  - Wraps `AVPlayerViewController` with HLS/MP4 support
  - Provides scrubbing, fullscreen, and Picture-in-Picture controls
  - 16:9 aspect ratio with rounded corners

## Implementation Details

- Uses `@unchecked Sendable` for thread-safe cache access via `DispatchQueue`
- Respects HTTP 429 rate limits with 2-second backoff and automatic retry
- Includes proper error handling with fallback to generic extractor on failure
- Maintains backward compatibility—non-Reddit feeds are unaffected
- User-Agent header included in requests for Reddit API compliance

https://claude.ai/code/session_01BQB5GRoqwvYm1pJx7tyCW6