### PR TITLE
Scroll display style improvements and overlay fixes

### DIFF
--- a/SakuraRSS/Views/Shared/Articles/ArticlesView.swift
+++ b/SakuraRSS/Views/Shared/Articles/ArticlesView.swift
@@ -209,7 +209,7 @@ struct ArticlesView: View {
             displayStyle = raw.flatMap(FeedDisplayStyle.init(rawValue:)) ?? fallback
         }
         .overlay {
-            if articles.isEmpty {
+            if articles.isEmpty && effectiveStyle != .scroll {
                 ContentUnavailableView {
                     Label("Articles.Empty.Title",
                           systemImage: "doc.text")

--- a/SakuraRSS/Views/Shared/Feed Display Styles/ScrollStyleView.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/ScrollStyleView.swift
@@ -367,7 +367,7 @@ private struct ScrollActionButtonsColumn: View {
     let shareURL: URL?
 
     var body: some View {
-        VStack(spacing: 24) {
+        VStack(spacing: 20) {
             Button(action: onOpenFeed) {
                 Group {
                     if let favicon {
@@ -387,17 +387,28 @@ private struct ScrollActionButtonsColumn: View {
             .accessibilityLabel(Text(feedName ?? ""))
 
             Button(action: onOpen) {
-                Image(systemName: article.isYouTubeURL ? "play.rectangle.fill" : "safari.fill")
+                labeledIcon(
+                    systemName: article.isYouTubeURL ? "play.rectangle.fill" : "safari.fill",
+                    label: Text("Article.OpenInBrowser")
+                )
             }
             .accessibilityLabel(Text("Article.OpenInBrowser"))
 
             Button(action: onCopy) {
-                Image(systemName: "square.on.square.fill")
+                labeledIcon(
+                    systemName: "square.on.square.fill",
+                    label: Text("Article.CopyLink")
+                )
             }
             .accessibilityLabel(Text("Article.CopyLink"))
 
             Button(action: onToggleBookmark) {
-                Image(systemName: article.isBookmarked ? "bookmark.fill" : "bookmark")
+                labeledIcon(
+                    systemName: article.isBookmarked ? "bookmark.fill" : "bookmark",
+                    label: Text(article.isBookmarked
+                                ? "Article.RemoveBookmark"
+                                : "Article.Bookmark")
+                )
             }
             .accessibilityLabel(Text(article.isBookmarked
                                      ? "Article.RemoveBookmark"
@@ -405,8 +416,11 @@ private struct ScrollActionButtonsColumn: View {
 
             if let shareURL {
                 ShareLink(item: shareURL) {
-                    Image(systemName: "square.and.arrow.up")
-                        .offset(y: -1)
+                    labeledIcon(
+                        systemName: "square.and.arrow.up",
+                        label: Text("Article.Share"),
+                        iconOffsetY: -1
+                    )
                 }
                 .accessibilityLabel(Text("Article.Share"))
             }
@@ -416,6 +430,21 @@ private struct ScrollActionButtonsColumn: View {
         .foregroundStyle(.white)
         .shadow(color: .black.opacity(0.35), radius: 2, y: 2)
         .buttonStyle(.plain)
+    }
+
+    private func labeledIcon(
+        systemName: String,
+        label: Text,
+        iconOffsetY: CGFloat = 0
+    ) -> some View {
+        VStack(spacing: 2) {
+            Image(systemName: systemName)
+                .offset(y: iconOffsetY)
+            label
+                .font(.system(size: 11, weight: .semibold))
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
+        }
     }
 }
 

--- a/SakuraRSS/Views/Shared/Feed Display Styles/ScrollStyleView.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/ScrollStyleView.swift
@@ -1,4 +1,6 @@
 import SwiftUI
+import FoundationModels
+@preconcurrency import Translation
 
 // MARK: - Scroll Style View
 
@@ -201,7 +203,8 @@ private struct ScrollArticlePage: View {
                         headerNamespace: headerNamespace,
                         onTapToCollapse: onTapContent,
                         onAdvance: onAdvance,
-                        onRetreat: onRetreat
+                        onRetreat: onRetreat,
+                        onOpenArticleURL: { openArticleURL() }
                     )
                 } else {
                     compactContentLayer
@@ -432,18 +435,60 @@ private struct ScrollExpandedArticleView: View {
     let onTapToCollapse: () -> Void
     let onAdvance: () -> Void
     let onRetreat: () -> Void
+    let onOpenArticleURL: () -> Void
 
     @State private var extractedText: String?
     @State private var isExtracting = true
     @State private var didStartExtraction = false
+
+    @State private var translatedText: String?
+    @State private var translatedTitle: String?
+    @State private var translatedSummary: String?
+    @State private var isTranslating = false
+    @State private var translationConfig: TranslationSession.Configuration?
+    @State private var showingTranslation = false
+    @State private var hasCachedTranslation = false
+
+    @State private var summarizedText: String?
+    @State private var isSummarizing = false
+    @State private var hasCachedSummary = false
+    @State private var showingSummary = false
+    @State private var summarizationError: String?
 
     @State private var scrollOffset: CGFloat = 0
     @State private var maxScrollOffset: CGFloat = 0
 
     private static let overscrollThreshold: CGFloat = 80
 
+    private var isAppleIntelligenceAvailable: Bool {
+        SystemLanguageModel.default.availability == .available
+    }
+
+    private var hasTranslationForCurrentMode: Bool {
+        if showingSummary {
+            return translatedSummary != nil
+        }
+        return translatedText != nil || hasCachedTranslation
+    }
+
     private var displayText: String? {
-        extractedText ?? article.summary
+        if showingSummary, let summarizedText {
+            if showingTranslation, let translatedSummary {
+                return translatedSummary
+            }
+            return summarizedText
+        }
+        if showingTranslation, let translatedText {
+            return translatedText
+        }
+        return extractedText ?? article.summary
+    }
+
+    private var displayTitle: String {
+        if showingTranslation, let translatedTitle {
+            return translatedTitle
+        }
+        return article.title
     }
 
     var body: some View {
@@ -451,12 +496,19 @@ private struct ScrollExpandedArticleView: View {
             VStack(alignment: .leading, spacing: 14) {
                 headerSection
 
+                actionButtons
+
                 if isExtracting && extractedText == nil {
                     ProgressView()
                         .tint(.white)
                         .frame(maxWidth: .infinity, alignment: .center)
                         .padding(.vertical, 20)
                 } else if let text = displayText {
+                    if showingSummary && summarizedText != nil {
+                        Text("AppleIntelligence.VerifyImportantInformation")
+                            .font(.caption)
+                            .foregroundStyle(.white.opacity(0.6))
+                    }
                     let blocks = ContentBlock.parse(text)
                     ForEach(blocks) { block in
                         switch block {
@@ -475,10 +527,15 @@ private struct ScrollExpandedArticleView: View {
                             .clipShape(.rect(cornerRadius: 12))
                         }
                     }
+                    .id("\(showingSummary)-\(showingTranslation)")
+                    .transition(.blurReplace)
                 }
 
                 Spacer(minLength: 40)
             }
+            .animation(.smooth.speed(2.0), value: showingSummary)
+            .animation(.smooth.speed(2.0), value: showingTranslation)
+            .animation(.smooth.speed(2.0), value: translatedText)
             .padding(.horizontal, 20)
             .padding(.top, 20 + contextInsets.top)
             .padding(.bottom, 40 + contextInsets.bottom)
@@ -519,6 +576,19 @@ private struct ScrollExpandedArticleView: View {
             guard !didStartExtraction else { return }
             didStartExtraction = true
             await loadArticleText()
+            loadCachedAIContent()
+        }
+        .translationTask(translationConfig) { session in
+            await handleTranslation(session: session)
+        }
+        .alert("Article.Summarize.Error", isPresented: Binding(
+            get: { summarizationError != nil },
+            set: { if !$0 { summarizationError = nil } }
+        )) {
+        } message: {
+            if let summarizationError {
+                Text(summarizationError)
+            }
         }
     }
 
@@ -545,7 +615,7 @@ private struct ScrollExpandedArticleView: View {
                 }
             }
 
-            Text(article.title)
+            Text(displayTitle)
                 .font(.system(.title2, weight: .bold))
                 .foregroundStyle(.white)
                 .matchedGeometryEffect(id: "headerTitle", in: headerNamespace)
@@ -570,6 +640,45 @@ private struct ScrollExpandedArticleView: View {
 
             Divider()
                 .overlay(.white.opacity(0.2))
+        }
+    }
+
+    // MARK: - Action buttons
+
+    private var actionButtons: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                if !isExtracting && displayText != nil {
+                    TranslateButton(
+                        hasTranslation: hasTranslationForCurrentMode,
+                        isTranslating: isTranslating,
+                        showingTranslation: $showingTranslation,
+                        onTranslate: { triggerTranslation() }
+                    )
+                    if isAppleIntelligenceAvailable {
+                        SummarizeButton(
+                            summarizedText: summarizedText,
+                            hasCachedSummary: hasCachedSummary,
+                            isSummarizing: isSummarizing,
+                            showingSummary: $showingSummary,
+                            onSummarize: {
+                                await summarizeArticle()
+                                return summarizedText != nil
+                            }
+                        )
+                    }
+                }
+
+                OpenLinkButton(
+                    title: "Article.OpenInBrowser",
+                    systemImage: article.isYouTubeURL && YouTubeHelper.isAppInstalled
+                        ? "play.rectangle" : "safari",
+                    action: { onOpenArticleURL() }
+                )
+            }
+            .buttonStyle(.bordered)
+            .tint(.white.opacity(0.2))
+            .foregroundStyle(.white)
         }
     }
 
@@ -609,6 +718,99 @@ private struct ScrollExpandedArticleView: View {
             try? DatabaseManager.shared.cacheArticleContent(result, for: article.id)
         }
         isExtracting = false
+    }
+
+    private func loadCachedAIContent() {
+        if let cached = try? DatabaseManager.shared.cachedArticleTranslation(for: article.id) {
+            translatedTitle = cached.title
+            translatedText = cached.text
+            translatedSummary = cached.summary
+            hasCachedTranslation = cached.title != nil || cached.text != nil
+            showingTranslation = hasCachedTranslation
+        }
+        if let cached = try? DatabaseManager.shared.cachedArticleSummary(for: article.id),
+           !cached.isEmpty {
+            hasCachedSummary = true
+        }
+    }
+
+    // MARK: - Translation
+
+    private func triggerTranslation() {
+        if translationConfig == nil {
+            translationConfig = .init()
+        } else {
+            translationConfig?.invalidate()
+        }
+    }
+
+    private func handleTranslation(session: TranslationSession) async {
+        isTranslating = true
+        defer { isTranslating = false }
+
+        if showingSummary, let summarizedText {
+            guard !summarizedText.isEmpty else { return }
+            do {
+                let response = try await session.translate(summarizedText)
+                translatedSummary = response.targetText
+                showingTranslation = true
+                try? DatabaseManager.shared.cacheTranslatedSummary(
+                    response.targetText, for: article.id
+                )
+            } catch {
+                // Translation failed; user can retry
+            }
+        } else {
+            let source = ContentBlock.plainText(from: extractedText ?? article.summary ?? "")
+            guard !source.isEmpty else { return }
+            do {
+                let requests = [
+                    TranslationSession.Request(sourceText: article.title),
+                    TranslationSession.Request(sourceText: source)
+                ]
+                let responses = try await session.translations(from: requests)
+                if responses.count >= 2 {
+                    translatedTitle = responses[0].targetText
+                    translatedText = responses[1].targetText
+                    hasCachedTranslation = true
+                    showingTranslation = true
+                    try? DatabaseManager.shared.cacheArticleTranslation(
+                        title: responses[0].targetText,
+                        text: responses[1].targetText,
+                        for: article.id
+                    )
+                }
+            } catch {
+                // Translation failed; user can retry
+            }
+        }
+    }
+
+    // MARK: - Summarization
+
+    private func summarizeArticle() async {
+        if let cached = try? DatabaseManager.shared.cachedArticleSummary(for: article.id),
+           !cached.isEmpty {
+            summarizedText = cached
+            return
+        }
+
+        let source = ContentBlock.plainText(from: extractedText ?? article.summary ?? "")
+        guard !source.isEmpty else { return }
+
+        isSummarizing = true
+        defer { isSummarizing = false }
+
+        let instructions = String(localized: "Article.Summarize.Prompt")
+
+        do {
+            let session = LanguageModelSession(instructions: instructions)
+            let response = try await session.respond(to: source)
+            summarizedText = response.content
+            try? DatabaseManager.shared.cacheArticleSummary(response.content, for: article.id)
+        } catch {
+            summarizationError = error.localizedDescription
+        }
     }
 }
 

--- a/SakuraRSS/Views/Shared/Feed Display Styles/ScrollStyleView.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/ScrollStyleView.swift
@@ -65,6 +65,18 @@ struct ScrollStyleView: View {
                             feedManager.markRead(prev)
                         }
                     }
+                    .onChange(of: articles.count) { oldValue, newValue in
+                        // When new articles are appended (e.g. via "Load older"),
+                        // scroll from the end-of-feed page to the first new item
+                        // so the user isn't stuck staring at the end marker.
+                        guard newValue > oldValue,
+                              currentID == .endOfFeed,
+                              oldValue < articles.count else { return }
+                        let firstNew = articles[oldValue]
+                        withAnimation(.smooth.speed(1.5)) {
+                            currentID = .article(firstNew.id)
+                        }
+                    }
                 }
                 .ignoresSafeArea(.container, edges: .vertical)
             }

--- a/SakuraRSS/Views/Shared/Feed Display Styles/ScrollStyleView.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/ScrollStyleView.swift
@@ -7,8 +7,8 @@ import FoundationModels
 /// A TikTok/Reels-inspired full-screen vertical pager where each article
 /// takes up the entire screen. Tapping the image or content preview expands
 /// the article to reveal the full extracted text; tapping again collapses it.
-/// When expanded, overscrolling past the top or bottom advances to the
-/// previous or next article respectively.
+/// When expanded, overscrolling past the top collapses back to the compact
+/// overlay and overscrolling past the bottom advances to the next article.
 struct ScrollStyleView: View {
 
     @Environment(FeedManager.self) var feedManager
@@ -39,8 +39,7 @@ struct ScrollStyleView: View {
                                     contextInsets: contextInsets,
                                     isExpanded: expandedArticleID == article.id,
                                     onTapContent: { handleTap(on: article) },
-                                    onAdvance: { advance(from: article) },
-                                    onRetreat: { retreat(from: article) }
+                                    onAdvance: { advance(from: article) }
                                 )
                                 .frame(width: pageSize.width, height: pageSize.height)
                                 .id(ScrollPageID.article(article.id))
@@ -134,14 +133,6 @@ struct ScrollStyleView: View {
         }
     }
 
-    private func retreat(from article: Article) {
-        guard let idx = articles.firstIndex(where: { $0.id == article.id }),
-              idx > 0 else { return }
-        withAnimation(.smooth.speed(1.5)) {
-            expandedArticleID = nil
-            currentID = .article(articles[idx - 1].id)
-        }
-    }
 }
 
 // MARK: - Page identifier
@@ -168,7 +159,6 @@ private struct ScrollArticlePage: View {
     let isExpanded: Bool
     let onTapContent: () -> Void
     let onAdvance: () -> Void
-    let onRetreat: () -> Void
 
     @State private var feed: Feed?
     @State private var favicon: UIImage?
@@ -215,7 +205,6 @@ private struct ScrollArticlePage: View {
                         headerNamespace: headerNamespace,
                         onTapToCollapse: onTapContent,
                         onAdvance: onAdvance,
-                        onRetreat: onRetreat,
                         onOpenArticleURL: { openArticleURL() }
                     )
                 } else {
@@ -327,16 +316,16 @@ private struct ScrollArticlePage: View {
     private var compactTextBlock: some View {
         VStack(alignment: .leading, spacing: 10) {
             Text(article.title)
-                .font(.subheadline.weight(.bold))
+                .font(.body.weight(.bold))
                 .foregroundStyle(.white)
-                .lineLimit(2)
+                .lineLimit(4)
                 .multilineTextAlignment(.leading)
                 .shadow(color: .black.opacity(0.6), radius: 4, y: 1)
                 .matchedGeometryEffect(id: "headerTitle", in: headerNamespace)
 
             if let summary = article.summary, !summary.isEmpty {
                 Text(ContentBlock.stripMarkdown(summary))
-                    .font(.subheadline)
+                    .font(.body)
                     .foregroundStyle(.white.opacity(0.9))
                     .lineLimit(3)
                     .multilineTextAlignment(.leading)
@@ -475,7 +464,6 @@ private struct ScrollExpandedArticleView: View {
     let headerNamespace: Namespace.ID
     let onTapToCollapse: () -> Void
     let onAdvance: () -> Void
-    let onRetreat: () -> Void
     let onOpenArticleURL: () -> Void
 
     @State private var extractedText: String?
@@ -608,7 +596,7 @@ private struct ScrollExpandedArticleView: View {
         .onScrollPhaseChange { _, newPhase in
             guard newPhase == .decelerating || newPhase == .idle else { return }
             if scrollOffset < -Self.overscrollThreshold {
-                onRetreat()
+                onTapToCollapse()
             } else if scrollOffset > maxScrollOffset + Self.overscrollThreshold {
                 onAdvance()
             }

--- a/SakuraRSS/Views/Shared/Feed Display Styles/ScrollStyleView.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/ScrollStyleView.swift
@@ -705,7 +705,10 @@ private struct ScrollExpandedArticleView: View {
             .buttonStyle(.bordered)
             .tint(.white.opacity(0.2))
             .foregroundStyle(.white)
+            .padding(.horizontal, 20)
         }
+        .padding(.horizontal, -20)
+        .scrollClipDisabled()
     }
 
     // MARK: - Extraction

--- a/SakuraRSS/Views/Shared/Feed Display Styles/ScrollStyleView.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/ScrollStyleView.swift
@@ -369,14 +369,14 @@ private struct ScrollActionButtonsColumn: View {
             Button(action: onOpenFeed) {
                 Group {
                     if let favicon {
-                        FaviconImage(favicon, size: 34, cornerRadius: 6, circle: isVideoFeed)
+                        FaviconImage(favicon, size: 48, cornerRadius: 8, circle: isVideoFeed)
                     } else if let acronymIcon {
-                        FaviconImage(acronymIcon, size: 34, cornerRadius: 6,
+                        FaviconImage(acronymIcon, size: 48, cornerRadius: 8,
                                      circle: isVideoFeed, skipInset: true)
                     } else if let feedName {
-                        InitialsAvatarView(feedName, size: 34, circle: isVideoFeed, cornerRadius: 6)
+                        InitialsAvatarView(feedName, size: 48, circle: isVideoFeed, cornerRadius: 8)
                     } else {
-                        Circle().fill(.white.opacity(0.2)).frame(width: 34, height: 34)
+                        Circle().fill(.white.opacity(0.2)).frame(width: 48, height: 48)
                     }
                 }
                 .contentShape(Rectangle())

--- a/SakuraRSS/Views/Shared/Feed Display Styles/ScrollStyleView.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/ScrollStyleView.swift
@@ -65,9 +65,6 @@ struct ScrollStyleView: View {
                         }
                     }
                     .onChange(of: articles.count) { oldValue, newValue in
-                        // When new articles are appended (e.g. via "Load older"),
-                        // scroll from the end-of-feed page to the first new item
-                        // so the user isn't stuck staring at the end marker.
                         guard newValue > oldValue,
                               currentID == .endOfFeed,
                               oldValue < articles.count else { return }
@@ -318,7 +315,7 @@ private struct ScrollArticlePage: View {
             Text(article.title)
                 .font(.body.weight(.bold))
                 .foregroundStyle(.white)
-                .lineLimit(4)
+                .lineLimit(3)
                 .multilineTextAlignment(.leading)
                 .shadow(color: .black.opacity(0.6), radius: 4, y: 1)
                 .matchedGeometryEffect(id: "headerTitle", in: headerNamespace)
@@ -327,7 +324,7 @@ private struct ScrollArticlePage: View {
                 Text(ContentBlock.stripMarkdown(summary))
                     .font(.body)
                     .foregroundStyle(.white.opacity(0.9))
-                    .lineLimit(3)
+                    .lineLimit(5)
                     .multilineTextAlignment(.leading)
                     .shadow(color: .black.opacity(0.6), radius: 4, y: 1)
             }


### PR DESCRIPTION
## Summary

A batch of fixes and enhancements for the scroll (TikTok/Reels-style) feed display style.

### Overlay fixes
- **Fix stacked empty overlays**: `ArticlesView`'s generic `Articles.Empty` content-unavailable overlay was rendering on top of `ScrollStyleView`'s own end-of-feed page when the feed was empty. Suppressed the generic overlay when the effective style is `.scroll` so the scroll style's end-of-feed page (with its "Load older articles" button) is the only thing shown.

### Compact overlay
- **Bigger typography**: title bumped from `.subheadline.bold` to `.body.bold` (line limit 3), and summary from `.subheadline` to `.body` (line limit 5), so the overlay is easier to read.
- **Labeled action icons**: each action button in the right-side column (open in browser, copy link, bookmark, share) now has a small caption underneath. The feed avatar button at the top is intentionally left unlabeled. Labels inherit the same white foreground and drop shadow as the icons.
- **Bigger feed avatar**: the profile/feed avatar at the top of the action column grew from 34pt to 48pt (corner radius 6 → 8) so it reads more clearly alongside the other icons and the body-sized title.

### Expanded overlay
- **Translate / Summarize / Open actions**: the expanded article reader was missing the translate, summarize, and open-in-browser buttons that `ArticleDetailView` provides. Added full translation + summarization state (mirroring `ArticleDetailView`'s pattern), cached content loading, the `translationTask`, a summarization error alert, and a horizontal row of action buttons below the article header.
- **Edge-to-edge action bar**: the new action row now extends to the screen edges instead of clipping at the body's 20pt inset, using a negative-padding trick on the horizontal ScrollView so the bounds reach the edges while the first button still aligns with the body text.
- **Overscroll behavior**:
  - **Top-edge overscroll** now collapses back to the compact overlay (previously it jumped to the previous article).
  - **Bottom-edge overscroll** still advances to the next article.
  - Dropped the now-unused `onRetreat` plumbing and `retreat(from:)` helper.

### Load-more flow
- **Scroll to first new article on load**: when the user taps "Load older articles" on the end-of-feed page, the scroll position now shifts to the first newly-added item instead of staying pinned at the end marker. Implemented via `.onChange(of: articles.count)` that only fires when the current page is `.endOfFeed`.

## Test plan
- [ ] Open an empty feed in scroll mode and confirm only the end-of-feed page shows (no stacked "Nothing Here" overlay).
- [ ] In scroll mode, verify compact-overlay title/summary render at body size and wrap to the new line limits.
- [ ] Verify each action icon in the right column has a small label underneath (except the feed avatar) and that the avatar is visibly larger.
- [ ] Tap an article to expand it and confirm the Translate, Summarize (if Apple Intelligence available), and Open in Browser buttons appear, and that they scroll edge-to-edge with no right-side clipping.
- [ ] Translate an article, toggle between original/translation, verify caching across re-expands.
- [ ] Summarize an article, toggle between original/summary, then translate the summary; verify the three-way toggle works.
- [ ] Overscroll to the top of an expanded article: confirm it collapses back to the compact overlay (not previous article).
- [ ] Overscroll past the bottom of an expanded article: confirm it advances to the next article.
- [ ] On the end-of-feed page, tap "Load older articles" and confirm the scroll position lands on the first newly-loaded article.