### PR TITLE
Fix Show Older content button clipping in Photos style

### DIFF
--- a/SakuraRSS/Views/Shared/Feed Display Styles/PhotosStyleView.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/PhotosStyleView.swift
@@ -17,6 +17,7 @@ struct PhotosStyleView: View {
                 }
                 if let onLoadMore {
                     LoadPreviousArticlesButton(action: onLoadMore)
+                        .padding(.horizontal, 16)
                         .padding(.vertical, 20)
                 }
             }


### PR DESCRIPTION
The LoadPreviousArticlesButton in PhotosStyleView was missing horizontal
padding, causing it to extend to the edges of the screen unlike the other
display styles (Grid, Magazine, Video) which all apply 16pt horizontal
padding to the button.