### PR TITLE
Fix marker collision in extracted article text

### DIFF
--- a/SakuraRSS/Structs/ContentBlock.swift
+++ b/SakuraRSS/Structs/ContentBlock.swift
@@ -30,9 +30,6 @@ enum ContentBlock: Identifiable {
         .replacingOccurrences(of: "{{/CODE}}", with: "")
         .replacingOccurrences(of: #"\n{3,}"#, with: "\n\n", options: .regularExpression)
         .trimmingCharacters(in: .whitespacesAndNewlines)
-        // Restore any literal marker sequences that were escaped at
-        // extraction time so consumers (translation, summarization,
-        // previews) see the article's original text.
         return ArticleMarker.unescape(stripped)
     }
 
@@ -83,8 +80,6 @@ enum ContentBlock: Identifiable {
         result = result.replacingOccurrences(
             of: #"\n{3,}"#, with: "\n\n", options: .regularExpression
         )
-        // Restore any literal marker sequences that were escaped at
-        // extraction time so previews show the article's original text.
         result = ArticleMarker.unescape(result)
         return result.trimmingCharacters(in: .whitespacesAndNewlines)
     }

--- a/SakuraRSS/Structs/ContentBlock.swift
+++ b/SakuraRSS/Structs/ContentBlock.swift
@@ -17,7 +17,7 @@ enum ContentBlock: Identifiable {
 
     /// Strips image and code markers from text, returning plain text suitable for translation/summarization.
     static func plainText(from text: String) -> String {
-        text.replacingOccurrences(
+        let stripped = text.replacingOccurrences(
             of: #"\{\{IMG\}\}.+?\{\{/IMG\}\}"#, with: "", options: .regularExpression
         )
         .replacingOccurrences(
@@ -30,6 +30,10 @@ enum ContentBlock: Identifiable {
         .replacingOccurrences(of: "{{/CODE}}", with: "")
         .replacingOccurrences(of: #"\n{3,}"#, with: "\n\n", options: .regularExpression)
         .trimmingCharacters(in: .whitespacesAndNewlines)
+        // Restore any literal marker sequences that were escaped at
+        // extraction time so consumers (translation, summarization,
+        // previews) see the article's original text.
+        return ArticleMarker.unescape(stripped)
     }
 
     /// Strips Markdown formatting from text, returning plain text suitable for content previews.
@@ -79,6 +83,9 @@ enum ContentBlock: Identifiable {
         result = result.replacingOccurrences(
             of: #"\n{3,}"#, with: "\n\n", options: .regularExpression
         )
+        // Restore any literal marker sequences that were escaped at
+        // extraction time so previews show the article's original text.
+        result = ArticleMarker.unescape(result)
         return result.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
@@ -86,14 +93,14 @@ enum ContentBlock: Identifiable {
         let pattern = #"\{\{(IMG|CODE|VIDEO)\}\}(.*?)\{\{/(IMG|CODE|VIDEO)\}\}"#
         guard let regex = try? NSRegularExpression(pattern: pattern, options: .dotMatchesLineSeparators)
         else {
-            return [.text(text)]
+            return [.text(ArticleMarker.unescape(text))]
         }
 
         let nsText = text as NSString
         let matches = regex.matches(in: text, range: NSRange(location: 0, length: nsText.length))
 
         guard !matches.isEmpty else {
-            return [.text(text)]
+            return [.text(ArticleMarker.unescape(text))]
         }
 
         let linkPattern = #"^(.+?)\{\{IMGLINK\}\}(.+?)\{\{/IMGLINK\}\}$"#
@@ -109,7 +116,7 @@ enum ContentBlock: Identifiable {
                     with: NSRange(location: lastEnd, length: match.range.location - lastEnd)
                 ).trimmingCharacters(in: .whitespacesAndNewlines)
                 if !before.isEmpty {
-                    blocks.append(.text(before))
+                    blocks.append(.text(ArticleMarker.unescape(before)))
                 }
             }
 
@@ -118,7 +125,7 @@ enum ContentBlock: Identifiable {
 
             if tag == "CODE" {
                 if !content.isEmpty {
-                    blocks.append(.code(content))
+                    blocks.append(.code(ArticleMarker.unescape(content)))
                 }
             } else if tag == "VIDEO" {
                 if let url = URL(string: content) {
@@ -149,7 +156,7 @@ enum ContentBlock: Identifiable {
             let after = nsText.substring(from: lastEnd)
                 .trimmingCharacters(in: .whitespacesAndNewlines)
             if !after.isEmpty {
-                blocks.append(.text(after))
+                blocks.append(.text(ArticleMarker.unescape(after)))
             }
         }
 

--- a/SakuraRSS/Views/Shared/Article Detail/ArticleDetailView+Extraction.swift
+++ b/SakuraRSS/Views/Shared/Article Detail/ArticleDetailView+Extraction.swift
@@ -122,9 +122,6 @@ extension ArticleDetailView {
            await XProfileScraper.hasXSession() {
             let scraper = XProfileScraper()
             if let tweet = await scraper.fetchSingleTweet(tweetID: tweetID) {
-                // Escape any literal marker sequences in the user-authored
-                // tweet text before appending the image marker, so
-                // ContentBlock.parse can't misinterpret the tweet body.
                 var text = ArticleMarker.escape(tweet.text)
                 if let imageURL = tweet.imageURL {
                     text += "\n\n{{IMG}}\(imageURL){{/IMG}}"

--- a/SakuraRSS/Views/Shared/Article Detail/ArticleDetailView+Extraction.swift
+++ b/SakuraRSS/Views/Shared/Article Detail/ArticleDetailView+Extraction.swift
@@ -122,7 +122,10 @@ extension ArticleDetailView {
            await XProfileScraper.hasXSession() {
             let scraper = XProfileScraper()
             if let tweet = await scraper.fetchSingleTweet(tweetID: tweetID) {
-                var text = tweet.text
+                // Escape any literal marker sequences in the user-authored
+                // tweet text before appending the image marker, so
+                // ContentBlock.parse can't misinterpret the tweet body.
+                var text = ArticleMarker.escape(tweet.text)
                 if let imageURL = tweet.imageURL {
                     text += "\n\n{{IMG}}\(imageURL){{/IMG}}"
                 }

--- a/Shared/Article Extractor/ArticleExtractor+TextContent.swift
+++ b/Shared/Article Extractor/ArticleExtractor+TextContent.swift
@@ -64,12 +64,7 @@ extension ArticleExtractor {
         text = escapeBracketsInLinkText(text,
                                         open: linkOpenPlaceholder,
                                         mid: linkMidPlaceholder)
-        // Escape any pre-existing marker sequences (e.g. `{{IMG}}` in a
-        // Mustache/Handlebars tutorial) that came through SwiftSoup's
-        // `.text()` call BEFORE the SAKURA placeholders below are converted
-        // into real `{{IMG}}`/`{{CODE}}`/etc. markers. Otherwise
-        // `ContentBlock.parse` would later misinterpret the article's own
-        // text as image/code/video markers.
+        // Escape literal markers before SAKURA placeholders become real ones.
         text = ArticleMarker.escape(text)
         text = convertPlaceholdersToMarkdown(text)
         text = stripInvalidURLSupSub(text)

--- a/Shared/Article Extractor/ArticleExtractor+TextContent.swift
+++ b/Shared/Article Extractor/ArticleExtractor+TextContent.swift
@@ -64,6 +64,13 @@ extension ArticleExtractor {
         text = escapeBracketsInLinkText(text,
                                         open: linkOpenPlaceholder,
                                         mid: linkMidPlaceholder)
+        // Escape any pre-existing marker sequences (e.g. `{{IMG}}` in a
+        // Mustache/Handlebars tutorial) that came through SwiftSoup's
+        // `.text()` call BEFORE the SAKURA placeholders below are converted
+        // into real `{{IMG}}`/`{{CODE}}`/etc. markers. Otherwise
+        // `ContentBlock.parse` would later misinterpret the article's own
+        // text as image/code/video markers.
+        text = ArticleMarker.escape(text)
         text = convertPlaceholdersToMarkdown(text)
         text = stripInvalidURLSupSub(text)
         text = stripRemainingHTMLTags(text)

--- a/Shared/Article Extractor/ArticleExtractor.swift
+++ b/Shared/Article Extractor/ArticleExtractor.swift
@@ -63,6 +63,7 @@ struct ArticleExtractor { // swiftlint:disable:this type_body_length
         if !html.contains("<") {
             var trimmed = html.trimmingCharacters(in: .whitespacesAndNewlines)
             trimmed = resolveMarkdownLinks(in: trimmed, baseURL: baseURL)
+            trimmed = ArticleMarker.escape(trimmed)
             #if DEBUG
             debugPrint("[Extract] extractText: no HTML tags, plain text (\(trimmed.count) chars)")
             #endif
@@ -81,8 +82,9 @@ struct ArticleExtractor { // swiftlint:disable:this type_body_length
             #if DEBUG
             debugPrint("[Extract] extractText: wrapped plain text/Markdown (\(tagCount) tags, \(stripped.count) chars), using directly")
             #endif
-            let cleaned = stripRemainingHTMLTags(html)
-            return resolveMarkdownLinks(in: cleaned, baseURL: baseURL)
+            var cleaned = stripRemainingHTMLTags(html)
+            cleaned = resolveMarkdownLinks(in: cleaned, baseURL: baseURL)
+            return ArticleMarker.escape(cleaned)
         }
 
         #if DEBUG
@@ -409,8 +411,9 @@ struct ArticleExtractor { // swiftlint:disable:this type_body_length
         if directDivs.count > 1 {
             let lines = try directDivs.map { try $0.text() }
             let text = lines.joined(separator: "\n")
-            return decodeCodeEntities(text)
+            let decoded = decodeCodeEntities(text)
                 .trimmingCharacters(in: CharacterSet(charactersIn: "\n"))
+            return ArticleMarker.escape(decoded)
         }
 
         // Standard <pre>/<pre><code> — use inner HTML
@@ -421,8 +424,12 @@ struct ArticleExtractor { // swiftlint:disable:this type_body_length
         html = html.replacingOccurrences(
             of: "<[^>]+>", with: "", options: .regularExpression
         )
-        return decodeCodeEntities(html)
+        let decoded = decodeCodeEntities(html)
             .trimmingCharacters(in: CharacterSet(charactersIn: "\n"))
+        // Code samples that legitimately contain `{{/CODE}}` or other
+        // marker tokens (templating tutorials) would otherwise prematurely
+        // terminate the wrapping `{{CODE}}…{{/CODE}}` block at parse time.
+        return ArticleMarker.escape(decoded)
     }
 
     private static func decodeCodeEntities(_ text: String) -> String {

--- a/Shared/Article Extractor/ArticleExtractor.swift
+++ b/Shared/Article Extractor/ArticleExtractor.swift
@@ -426,9 +426,6 @@ struct ArticleExtractor { // swiftlint:disable:this type_body_length
         )
         let decoded = decodeCodeEntities(html)
             .trimmingCharacters(in: CharacterSet(charactersIn: "\n"))
-        // Code samples that legitimately contain `{{/CODE}}` or other
-        // marker tokens (templating tutorials) would otherwise prematurely
-        // terminate the wrapping `{{CODE}}…{{/CODE}}` block at parse time.
         return ArticleMarker.escape(decoded)
     }
 

--- a/Shared/Article Extractor/ArticleMarker.swift
+++ b/Shared/Article Extractor/ArticleMarker.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+/// Marker token escaping shared between `ArticleExtractor` (which produces
+/// `{{IMG}}`/`{{CODE}}`/`{{VIDEO}}`/etc. markers from HTML) and consumers
+/// like `ContentBlock.parse` (which split on those markers).
+///
+/// If an article legitimately contains the literal sequence `{{IMG}}` —
+/// e.g. a Mustache or Handlebars tutorial, templating documentation — it
+/// must be escaped before being emitted as paragraph text, otherwise
+/// downstream parsers will misinterpret it as an extractor marker and
+/// corrupt the rendered output.
+///
+/// Lives in its own file (rather than as an extension on `ArticleExtractor`)
+/// because some targets (Add Feed, WidgetsExtension) compile
+/// `RedditPostScraper` — a producer of marker strings — but exclude
+/// `ArticleExtractor.swift` due to its SwiftSoup dependency. This helper
+/// has no dependencies beyond Foundation and is therefore safe to include
+/// everywhere.
+nonisolated enum ArticleMarker {
+
+    /// All marker tokens emitted by the extractor and friends. The escaped
+    /// form uses U+E000 / U+E001 from the Unicode Private Use Area as
+    /// delimiters: those characters cannot occur in real article text, and
+    /// crucially the escaped form does not contain the original `{{TOKEN}}`
+    /// substring, so callers checking `text.contains("{{IMG}}")` won't get
+    /// false positives from escaped literals.
+    private static let table: [(literal: String, escaped: String)] = [
+        ("{{IMG}}",      "\u{E000}IMG\u{E001}"),
+        ("{{/IMG}}",     "\u{E000}/IMG\u{E001}"),
+        ("{{IMGLINK}}",  "\u{E000}IMGLINK\u{E001}"),
+        ("{{/IMGLINK}}", "\u{E000}/IMGLINK\u{E001}"),
+        ("{{CODE}}",     "\u{E000}CODE\u{E001}"),
+        ("{{/CODE}}",    "\u{E000}/CODE\u{E001}"),
+        ("{{VIDEO}}",    "\u{E000}VIDEO\u{E001}"),
+        ("{{/VIDEO}}",   "\u{E000}/VIDEO\u{E001}"),
+        ("{{SUP}}",      "\u{E000}SUP\u{E001}"),
+        ("{{/SUP}}",     "\u{E000}/SUP\u{E001}"),
+        ("{{SUB}}",      "\u{E000}SUB\u{E001}"),
+        ("{{/SUB}}",     "\u{E000}/SUB\u{E001}")
+    ]
+
+    /// Escapes literal marker sequences in `text` so they don't collide
+    /// with markers injected by the extractor. Call `unescape(_:)` at every
+    /// rendering or text-export boundary to reverse this.
+    static func escape(_ text: String) -> String {
+        guard text.contains("{{") else { return text }
+        var result = text
+        for (literal, escaped) in table where result.contains(literal) {
+            result = result.replacingOccurrences(of: literal, with: escaped)
+        }
+        return result
+    }
+
+    /// Reverses `escape(_:)`. Safe to call on any string — strings without
+    /// escape characters return unchanged.
+    static func unescape(_ text: String) -> String {
+        guard text.contains("\u{E000}") else { return text }
+        var result = text
+        for (literal, escaped) in table where result.contains(escaped) {
+            result = result.replacingOccurrences(of: escaped, with: literal)
+        }
+        return result
+    }
+}

--- a/Shared/Article Extractor/ArticleMarker.swift
+++ b/Shared/Article Extractor/ArticleMarker.swift
@@ -1,29 +1,12 @@
 import Foundation
 
-/// Marker token escaping shared between `ArticleExtractor` (which produces
-/// `{{IMG}}`/`{{CODE}}`/`{{VIDEO}}`/etc. markers from HTML) and consumers
-/// like `ContentBlock.parse` (which split on those markers).
-///
-/// If an article legitimately contains the literal sequence `{{IMG}}` —
-/// e.g. a Mustache or Handlebars tutorial, templating documentation — it
-/// must be escaped before being emitted as paragraph text, otherwise
-/// downstream parsers will misinterpret it as an extractor marker and
-/// corrupt the rendered output.
-///
-/// Lives in its own file (rather than as an extension on `ArticleExtractor`)
-/// because some targets (Add Feed, WidgetsExtension) compile
-/// `RedditPostScraper` — a producer of marker strings — but exclude
-/// `ArticleExtractor.swift` due to its SwiftSoup dependency. This helper
-/// has no dependencies beyond Foundation and is therefore safe to include
-/// everywhere.
+/// Escapes literal `{{IMG}}`/`{{CODE}}`/etc. sequences in article text so
+/// `ContentBlock.parse` doesn't misinterpret them as extractor markers.
+/// Escaped form uses U+E000/U+E001 as delimiters so it contains no
+/// `{{TOKEN}}` substring — callers checking `text.contains("{{IMG}}")`
+/// keep matching only real markers.
 nonisolated enum ArticleMarker {
 
-    /// All marker tokens emitted by the extractor and friends. The escaped
-    /// form uses U+E000 / U+E001 from the Unicode Private Use Area as
-    /// delimiters: those characters cannot occur in real article text, and
-    /// crucially the escaped form does not contain the original `{{TOKEN}}`
-    /// substring, so callers checking `text.contains("{{IMG}}")` won't get
-    /// false positives from escaped literals.
     private static let table: [(literal: String, escaped: String)] = [
         ("{{IMG}}",      "\u{E000}IMG\u{E001}"),
         ("{{/IMG}}",     "\u{E000}/IMG\u{E001}"),
@@ -39,9 +22,6 @@ nonisolated enum ArticleMarker {
         ("{{/SUB}}",     "\u{E000}/SUB\u{E001}")
     ]
 
-    /// Escapes literal marker sequences in `text` so they don't collide
-    /// with markers injected by the extractor. Call `unescape(_:)` at every
-    /// rendering or text-export boundary to reverse this.
     static func escape(_ text: String) -> String {
         guard text.contains("{{") else { return text }
         var result = text
@@ -51,8 +31,6 @@ nonisolated enum ArticleMarker {
         return result
     }
 
-    /// Reverses `escape(_:)`. Safe to call on any string — strings without
-    /// escape characters return unchanged.
     static func unescape(_ text: String) -> String {
         guard text.contains("\u{E000}") else { return text }
         var result = text

--- a/Shared/RSS Parser/ParserVersion.swift
+++ b/Shared/RSS Parser/ParserVersion.swift
@@ -3,5 +3,5 @@ import Foundation
 nonisolated enum ParserVersion {
     /// Bump this integer whenever ArticleExtractor logic changes
     /// to invalidate all cached article content on next launch.
-    static let articleExtractor = 7
+    static let articleExtractor = 8
 }

--- a/Shared/Reddit Integration/RedditPostScraper+Extraction.swift
+++ b/Shared/Reddit Integration/RedditPostScraper+Extraction.swift
@@ -27,10 +27,6 @@ extension RedditPostScraper {
 
         let selftext: String = {
             guard let raw = post["selftext"] as? String else { return "" }
-            // Reddit selftext is user-authored Markdown that may legitimately
-            // contain `{{IMG}}`, `{{CODE}}`, etc. (templating discussions).
-            // Escape these so `ContentBlock.parse` doesn't misinterpret them
-            // as markers when the cached marker string is rendered later.
             let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
             return ArticleMarker.escape(trimmed)
         }()

--- a/Shared/Reddit Integration/RedditPostScraper+Extraction.swift
+++ b/Shared/Reddit Integration/RedditPostScraper+Extraction.swift
@@ -27,7 +27,12 @@ extension RedditPostScraper {
 
         let selftext: String = {
             guard let raw = post["selftext"] as? String else { return "" }
-            return raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            // Reddit selftext is user-authored Markdown that may legitimately
+            // contain `{{IMG}}`, `{{CODE}}`, etc. (templating discussions).
+            // Escape these so `ContentBlock.parse` doesn't misinterpret them
+            // as markers when the cached marker string is rendered later.
+            let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            return ArticleMarker.escape(trimmed)
         }()
 
         var markerLines: [String] = []


### PR DESCRIPTION
## Summary

Bare `{{IMG}}`, `{{CODE}}`, `{{VIDEO}}` (and friends) were injected directly into extracted article text. Articles that legitimately contained those sequences — Mustache/Handlebars tutorials, templating documentation, Reddit/X posts about `{{IMG}}` — were corrupted by `ContentBlock.parse`, which couldn't distinguish literal text from extractor markers.

## Approach

New `ArticleMarker` helper (`Shared/Article Extractor/ArticleMarker.swift`) provides `escape(_:)` / `unescape(_:)`. Escaped form uses `U+E000` / `U+E001` (Unicode Private Use Area) as delimiters, so:

- The escape glyphs cannot occur in real article text.
- The escaped form contains **no** `{{TOKEN}}` substring, so existing checks like `extractedText.contains("{{IMG}}")` and the regex in `refreshArticleContent` keep matching only real markers.

`ArticleMarker` lives in its own file rather than as an extension on `ArticleExtractor` because `RedditPostScraper` (a producer) compiles in the Add Feed and WidgetsExtension targets, but `ArticleExtractor.swift` is excluded from those targets due to its SwiftSoup dependency. The helper is Foundation-only.

### Producers escape

- `ArticleExtractor.extractText`: plain-text branch and wrapped-text branch.
- `ArticleExtractor.codeContent(of:)`: both line-oriented and standard `<pre>` branches — code samples that legitimately contain `{{/CODE}}` would otherwise prematurely terminate the wrapping `{{CODE}}…{{/CODE}}` block.
- `ArticleExtractor.textContent(of:)`: between `escapeBracketsInLinkText` and `convertPlaceholdersToMarkdown`, so the SAKURA placeholders that become real markers aren't escaped while literal source text is.
- `RedditPostScraper+Extraction`: Reddit `selftext` (user-authored Markdown).
- `ArticleDetailView+Extraction`: X/Twitter tweet body before the image marker is appended.

### Consumers unescape (`ContentBlock`)

- `parse(_:)` unescapes every `.text(...)` and `.code(...)` payload it constructs (including the no-marker-found early returns).
- `plainText(from:)` and `stripMarkdown(_:)` unescape after stripping markers, so translation/summarization sources and feed-cell previews see the article's original text.

### Cache invalidation

`ParserVersion.articleExtractor` bumps `7 → 8`, forcing every cached v7 article to be re-extracted on next launch. There's no mixed state between escaped and non-escaped cached content.

### Spotlight

No change needed: `SpotlightIndexer.stripMarkup` / `stripHTML` operate on `article.summary` and `article.content`, which are RSS-provided fields that never carry the PUA escape glyph.

## Test plan

- [ ] Build the Sakura, Add Feed, and WidgetsExtension targets — ensure `ArticleMarker.swift` is picked up by all three (synchronized file group, no exclusions).
- [ ] Open an article whose body contains literal `{{IMG}}` / `{{CODE}}` text (e.g. a Mustache or Handlebars tutorial); confirm the literal renders correctly and isn't swallowed as an image marker.
- [ ] Open an article with real inline images and code blocks; confirm images and code blocks still render (no regression on the happy path).
- [ ] Trigger Translate and Summarize on an article containing literal `{{IMG}}` text; confirm the source passed to the model contains the original text, not the PUA glyph.
- [ ] Open a Reddit self-post whose `selftext` contains `{{IMG}}`; confirm correct rendering.
- [ ] Open an X tweet whose body contains `{{IMG}}` plus an image; confirm the tweet text and the image both render.
- [ ] First launch after upgrade: confirm v7 cached articles re-extract automatically (ParserVersion bump).

https://claude.ai/code/session_017gTM1mXHLsp7DHiQq4p8rZ