### PR TITLE
Suppress all empty overlays in scroll display style

### DIFF
--- a/SakuraRSS/Views/Shared/Articles/ArticlesView.swift
+++ b/SakuraRSS/Views/Shared/Articles/ArticlesView.swift
@@ -209,19 +209,21 @@ struct ArticlesView: View {
             displayStyle = raw.flatMap(FeedDisplayStyle.init(rawValue:)) ?? fallback
         }
         .overlay {
-            if articles.isEmpty && effectiveStyle != .scroll {
-                ContentUnavailableView {
-                    Label("Articles.Empty.Title",
-                          systemImage: "doc.text")
-                } description: {
-                    Text("Articles.Empty.Description")
-                }
-            } else if visibleArticles.isEmpty && hideRead {
-                ContentUnavailableView {
-                    Label("Articles.AllRead.Title",
-                          systemImage: "checkmark.circle")
-                } description: {
-                    Text("Articles.AllRead.Description")
+            if effectiveStyle != .scroll {
+                if articles.isEmpty {
+                    ContentUnavailableView {
+                        Label("Articles.Empty.Title",
+                              systemImage: "doc.text")
+                    } description: {
+                        Text("Articles.Empty.Description")
+                    }
+                } else if visibleArticles.isEmpty && hideRead {
+                    ContentUnavailableView {
+                        Label("Articles.AllRead.Title",
+                              systemImage: "checkmark.circle")
+                    } description: {
+                        Text("Articles.AllRead.Description")
+                    }
                 }
             }
         }


### PR DESCRIPTION
The scroll display style renders its own end-of-feed content
unavailable view, but the 'all read' variant of the ArticlesView
overlay was still rendering behind it whenever the Articles.HideRead
AppStorage happened to be on from another feed. Skip the entire
overlay branch when the effective style is scroll so its own empty
state is the only one visible.