### PR TITLE
Split Localizable.xcstrings into per-feature catalogs

### DIFF
--- a/Widgets/ListWidget/ListWidgetIntent.swift
+++ b/Widgets/ListWidget/ListWidgetIntent.swift
@@ -3,7 +3,7 @@ import WidgetKit
 
 struct ListWidgetIntent: WidgetConfigurationIntent {
     static var title: LocalizedStringResource = LocalizedStringResource("ListWidget.IntentTitle", table: "Widget")
-    static var description: IntentDescription = LocalizedStringResource("ListWidget.IntentDescription", table: "Widget")
+    static var description: IntentDescription = IntentDescription(LocalizedStringResource("ListWidget.IntentDescription", table: "Widget"))
 
     @Parameter(title: LocalizedStringResource("ListWidget.Parameter.List", table: "Widget"))
     var list: ListEntity?

--- a/Widgets/SingleFeedWidget/SingleFeedIntent.swift
+++ b/Widgets/SingleFeedWidget/SingleFeedIntent.swift
@@ -3,7 +3,7 @@ import WidgetKit
 
 struct SingleFeedIntent: WidgetConfigurationIntent {
     static var title: LocalizedStringResource = LocalizedStringResource("SingleFeedWidget.IntentTitle", table: "Widget")
-    static var description: IntentDescription = LocalizedStringResource("SingleFeedWidget.IntentDescription", table: "Widget")
+    static var description: IntentDescription = IntentDescription(LocalizedStringResource("SingleFeedWidget.IntentDescription", table: "Widget"))
 
     @Parameter(title: LocalizedStringResource("SingleFeedWidget.Parameter.Feed", table: "Widget"))
     var feed: FeedEntity?


### PR DESCRIPTION
The single Localizable.xcstrings file had grown to ~31k lines and 541 keys
with everything intermingled. This splits it into thirteen focused
catalogs grouped by feature area (Articles, Feeds, Lists, Settings,
Onboarding, Petal, Podcast, Widget, Labs, etc.) and removes the
redundant catalog-name prefix from keys whose prefix matched their
catalog. Swift call sites were rewritten to reference the new tables.