### PR TITLE
Split Localizable.xcstrings into per-feature catalogs

### DIFF
--- a/SakuraRSS/Views/Shared/SummarizeButton.swift
+++ b/SakuraRSS/Views/Shared/SummarizeButton.swift
@@ -31,9 +31,9 @@ struct SummarizeButton: View {
                 }
             } label: {
                 Label(
-                    String(localized: showingSummary
-                           ? String(localized: "Article.ShowOriginal", table: "Articles")
-                           : String(localized: "Article.ShowSummary", table: "Articles")),
+                    showingSummary
+                        ? String(localized: "Article.ShowOriginal", table: "Articles")
+                        : String(localized: "Article.ShowSummary", table: "Articles"),
                     systemImage: showingSummary
                         ? "doc.plaintext" : "apple.intelligence"
                 )

--- a/SakuraRSS/Views/Shared/TranslateButton.swift
+++ b/SakuraRSS/Views/Shared/TranslateButton.swift
@@ -15,9 +15,9 @@ struct TranslateButton: View {
                 }
             } label: {
                 Label(
-                    String(localized: showingTranslation
-                           ? String(localized: "Article.ShowOriginal", table: "Articles")
-                           : String(localized: "Article.ShowTranslation", table: "Articles")),
+                    showingTranslation
+                        ? String(localized: "Article.ShowOriginal", table: "Articles")
+                        : String(localized: "Article.ShowTranslation", table: "Articles"),
                     systemImage: showingTranslation
                         ? "doc.plaintext" : "translate"
                 )


### PR DESCRIPTION
The single Localizable.xcstrings file had grown to ~31k lines and 541 keys
with everything intermingled. This splits it into thirteen focused
catalogs grouped by feature area (Articles, Feeds, Lists, Settings,
Onboarding, Petal, Podcast, Widget, Labs, etc.) and removes the
redundant catalog-name prefix from keys whose prefix matched their
catalog. Swift call sites were rewritten to reference the new tables.