### PR TITLE
Freeze feed metadata after first refresh; fix edit-sheet icon stale read

### DIFF
--- a/SakuraRSS/Classes/Feed Manager/FeedManager+CRUD.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+CRUD.swift
@@ -82,6 +82,11 @@ extension FeedManager {
                     isTitleCustomized: feed.isTitleCustomized
                 )
             }.value
+            // Visible rows cache their favicon in @State; bump the
+            // revision so the newly-installed profile photo replaces
+            // the acronym fallback on the very first refresh without
+            // waiting for the row to scroll off-screen and back.
+            await MainActor.run { self.notifyFaviconChange() }
         } else if feed.title != effectiveTitle {
             try? await Task.detached {
                 try database.updateFeedDetails(
@@ -109,6 +114,15 @@ extension FeedManager {
             generateAcronymIcon(feedID: feed.id, title: title)
         }
         loadFromDatabase()
+        // Feed rows cache their favicon in @State from a one-shot
+        // `.task`, so without a revision bump they keep showing the
+        // pre-edit icon until they scroll off-screen and back.  Users
+        // see the stale image after pull-to-refresh and conclude the
+        // refresh clobbered their override, when really the edit just
+        // never propagated.  Bump the revision so every visible row
+        // re-queries `FaviconCache.favicon(for: feed)` and picks up
+        // the newly-saved custom icon.
+        notifyFaviconChange()
     }
 
 }

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+CRUD.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+CRUD.swift
@@ -1,5 +1,4 @@
 import Foundation
-import UIKit
 
 extension FeedManager {
 
@@ -56,46 +55,32 @@ extension FeedManager {
         loadFromDatabase()
     }
 
-    /// Applies a title/icon update from a social-feed scraper (X,
-    /// Instagram, YouTube playlist).  Each scraper fetches a display
-    /// name and optionally a profile photo; this helper centralizes
-    /// the "install the photo on first fetch, honour user-customized
-    /// titles, otherwise just sync the scraped title" logic the three
-    /// paths share so the title-customization rule lives in exactly
-    /// one place.
+    /// Applies a title update from a social-feed scraper (X, Instagram,
+    /// YouTube playlist).  Each scraper fetches a display name; this
+    /// helper centralizes the "honour user-customized titles, otherwise
+    /// sync the scraped title" rule the three paths share so the
+    /// title-customization logic lives in exactly one place.
+    ///
+    /// Icons are intentionally *not* touched here.  Auto-installing a
+    /// profile photo on the first post-add refresh races with any icon
+    /// the user picks from the edit sheet in the interim, and the
+    /// stale-snapshot check would overwrite their choice.  Users who
+    /// want the scraped avatar can pull it in explicitly via
+    /// `FeedEditSheet`'s "Fetch icon from feed" action.
     func applyScraperMetadataRefresh(
         feed: Feed,
-        scrapedTitle: String,
-        profileImage: UIImage?
+        scrapedTitle: String
     ) async {
         let effectiveTitle = feed.isTitleCustomized ? feed.title : scrapedTitle
-        let shouldInstallProfilePhoto = profileImage != nil && feed.customIconURL == nil
+        guard feed.title != effectiveTitle else { return }
         let database = database
-        if shouldInstallProfilePhoto, let image = profileImage {
-            await FaviconCache.shared.setCustomFavicon(
-                image, feedID: feed.id, skipTrimming: true
+        try? await Task.detached {
+            try database.updateFeedDetails(
+                id: feed.id, title: effectiveTitle, url: feed.url,
+                customIconURL: feed.customIconURL,
+                isTitleCustomized: feed.isTitleCustomized
             )
-            try? await Task.detached {
-                try database.updateFeedDetails(
-                    id: feed.id, title: effectiveTitle, url: feed.url,
-                    customIconURL: "photo",
-                    isTitleCustomized: feed.isTitleCustomized
-                )
-            }.value
-            // Visible rows cache their favicon in @State; bump the
-            // revision so the newly-installed profile photo replaces
-            // the acronym fallback on the very first refresh without
-            // waiting for the row to scroll off-screen and back.
-            await MainActor.run { self.notifyFaviconChange() }
-        } else if feed.title != effectiveTitle {
-            try? await Task.detached {
-                try database.updateFeedDetails(
-                    id: feed.id, title: effectiveTitle, url: feed.url,
-                    customIconURL: feed.customIconURL,
-                    isTitleCustomized: feed.isTitleCustomized
-                )
-            }.value
-        }
+        }.value
     }
 
     func updateFeedDetails(_ feed: Feed, title: String, url: String,

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+CRUD.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+CRUD.swift
@@ -11,11 +11,6 @@ extension FeedManager {
         guard !database.feedExists(url: url) else {
             throw FeedError.alreadyExists
         }
-        // Enforce per-host follow caps for authenticated scraper feeds
-        // (X, Instagram).  Unbounded follows on these hosts translate
-        // into rate-limit / account-lock pressure at refresh time, so
-        // the cap is applied at insert to keep the fleet small enough
-        // for the 30-minute refresh cadence to stay safe.
         let newHost = URL(string: siteURL)?.host
             ?? URL(string: url)?.host
             ?? ""
@@ -35,7 +30,6 @@ extension FeedManager {
         )
         generateAcronymIcon(feedID: feedID, title: title)
         loadFromDatabase()
-        // Fetch the feed's articles in the background
         if let feed = feedsByID[feedID] {
             Task {
                 try? await refreshFeed(feed)
@@ -56,12 +50,8 @@ extension FeedManager {
         loadFromDatabase()
     }
 
-    /// Applies the title + profile photo fetched by a social-feed
-    /// scraper (X, Instagram, YouTube playlist) on the *first* refresh
-    /// of a freshly-added feed.  Once `feed.lastFetched != nil` this
-    /// helper is a no-op: every subsequent refresh leaves the title
-    /// and icon alone, so user edits from the edit sheet are the sole
-    /// source of truth after add.
+    /// Installs the scraped title + profile photo on the first refresh
+    /// after add.  No-op once `feed.lastFetched != nil`.
     func applyScraperMetadataRefresh(
         feed: Feed,
         scrapedTitle: String,
@@ -96,12 +86,6 @@ extension FeedManager {
 
     func updateFeedDetails(_ feed: Feed, title: String, url: String,
                            customIconURL: String?) {
-        // A user-driven title change (from the edit sheet) flips the
-        // `isTitleCustomized` flag so future refreshes won't overwrite
-        // it.  If the user never touched the title we leave the existing
-        // flag alone — that way a user who previously customized and is
-        // now only editing the URL or icon doesn't accidentally clear
-        // their override.
         let titleIsCustomized = feed.isTitleCustomized || title != feed.title
         try? database.updateFeedDetails(id: feed.id, title: title, url: url,
                                         customIconURL: customIconURL,
@@ -110,14 +94,6 @@ extension FeedManager {
             generateAcronymIcon(feedID: feed.id, title: title)
         }
         loadFromDatabase()
-        // Feed rows cache their favicon in @State from a one-shot
-        // `.task`, so without a revision bump they keep showing the
-        // pre-edit icon until they scroll off-screen and back.  Users
-        // see the stale image after pull-to-refresh and conclude the
-        // refresh clobbered their override, when really the edit just
-        // never propagated.  Bump the revision so every visible row
-        // re-queries `FaviconCache.favicon(for: feed)` and picks up
-        // the newly-saved custom icon.
         notifyFaviconChange()
     }
 

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+CRUD.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+CRUD.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 
 extension FeedManager {
 
@@ -55,32 +56,42 @@ extension FeedManager {
         loadFromDatabase()
     }
 
-    /// Applies a title update from a social-feed scraper (X, Instagram,
-    /// YouTube playlist).  Each scraper fetches a display name; this
-    /// helper centralizes the "honour user-customized titles, otherwise
-    /// sync the scraped title" rule the three paths share so the
-    /// title-customization logic lives in exactly one place.
-    ///
-    /// Icons are intentionally *not* touched here.  Auto-installing a
-    /// profile photo on the first post-add refresh races with any icon
-    /// the user picks from the edit sheet in the interim, and the
-    /// stale-snapshot check would overwrite their choice.  Users who
-    /// want the scraped avatar can pull it in explicitly via
-    /// `FeedEditSheet`'s "Fetch icon from feed" action.
+    /// Applies the title + profile photo fetched by a social-feed
+    /// scraper (X, Instagram, YouTube playlist) on the *first* refresh
+    /// of a freshly-added feed.  Once `feed.lastFetched != nil` this
+    /// helper is a no-op: every subsequent refresh leaves the title
+    /// and icon alone, so user edits from the edit sheet are the sole
+    /// source of truth after add.
     func applyScraperMetadataRefresh(
         feed: Feed,
-        scrapedTitle: String
+        scrapedTitle: String,
+        profileImage: UIImage?
     ) async {
+        guard feed.lastFetched == nil else { return }
         let effectiveTitle = feed.isTitleCustomized ? feed.title : scrapedTitle
-        guard feed.title != effectiveTitle else { return }
+        let shouldInstallProfilePhoto = profileImage != nil && feed.customIconURL == nil
         let database = database
-        try? await Task.detached {
-            try database.updateFeedDetails(
-                id: feed.id, title: effectiveTitle, url: feed.url,
-                customIconURL: feed.customIconURL,
-                isTitleCustomized: feed.isTitleCustomized
+        if shouldInstallProfilePhoto, let image = profileImage {
+            await FaviconCache.shared.setCustomFavicon(
+                image, feedID: feed.id, skipTrimming: true
             )
-        }.value
+            try? await Task.detached {
+                try database.updateFeedDetails(
+                    id: feed.id, title: effectiveTitle, url: feed.url,
+                    customIconURL: "photo",
+                    isTitleCustomized: feed.isTitleCustomized
+                )
+            }.value
+            await MainActor.run { self.notifyFaviconChange() }
+        } else if feed.title != effectiveTitle {
+            try? await Task.detached {
+                try database.updateFeedDetails(
+                    id: feed.id, title: effectiveTitle, url: feed.url,
+                    customIconURL: feed.customIconURL,
+                    isTitleCustomized: feed.isTitleCustomized
+                )
+            }.value
+        }
     }
 
     func updateFeedDetails(_ feed: Feed, title: String, url: String,

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+InstagramProfile.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+InstagramProfile.swift
@@ -6,22 +6,16 @@ extension FeedManager {
     // MARK: - Instagram Profile Feeds
 
     /// Minimum interval between Instagram API calls per feed (30 minutes).
-    /// Also used by `FaviconProgressBadge` to size the cooldown pie.
     static let instagramRefreshInterval: TimeInterval = 30 * 60
 
-    /// Returns a jittered effective refresh interval.  A hard 30-minute
-    /// cadence is a strong automation signal on its own — real users do
-    /// not open the same profile on the tick.  We keep 30 min as the
-    /// floor and add up to ~10 min of upward jitter so consecutive
-    /// refreshes never fall on a fixed schedule.
+    /// Jittered effective refresh interval — the 30-minute floor plus up
+    /// to ~10 minutes so consecutive refreshes don't fall on a fixed
+    /// schedule (a strong automation signal on its own).
     private static func jitteredRefreshInterval() -> TimeInterval {
         instagramRefreshInterval + TimeInterval.random(in: 0...(10 * 60))
     }
 
     func refreshInstagramFeed(_ feed: Feed, reloadData: Bool = true) async throws {
-        // Skip if this feed was fetched too recently to avoid rate limits.
-        // The cutoff is randomised on each check to avoid a perfectly
-        // periodic fetch cadence.
         let effectiveInterval = Self.jitteredRefreshInterval()
         if let lastFetched = feed.lastFetched,
            Date().timeIntervalSince(lastFetched) < effectiveInterval {
@@ -39,7 +33,6 @@ extension FeedManager {
         let scraper = InstagramProfileScraper()
         let result = await scraper.scrapeProfile(profileURL: profileURL)
 
-        // Prepare post data for batch insert
         let postTuples = result.posts.map { post in
             let title = post.text.isEmpty
                 ? "Post by @\(post.authorHandle)"
@@ -59,9 +52,6 @@ extension FeedManager {
 
         let feedTitle = result.displayName ?? feed.title
 
-        // Download the profile photo only on the first-ever refresh of
-        // this feed.  After that, metadata is frozen and user edits
-        // from the edit sheet are authoritative.
         var profileImage: UIImage?
         if feed.lastFetched == nil,
            let imageURLString = result.profileImageURL,
@@ -70,7 +60,6 @@ extension FeedManager {
             profileImage = UIImage(data: imageData)
         }
 
-        // Run all DB writes off the main thread
         let database = database
         try await Task.detached {
             try database.insertArticles(feedID: feed.id, articles: postTuples)
@@ -79,8 +68,6 @@ extension FeedManager {
             SpotlightIndexer.indexArticles(articlesToIndex, feedTitle: feedTitle)
         }.value
 
-        // Install title + profile photo only on the first-ever fetch.
-        // The helper itself no-ops on subsequent refreshes.
         await applyScraperMetadataRefresh(
             feed: feed, scrapedTitle: feedTitle, profileImage: profileImage
         )
@@ -90,7 +77,6 @@ extension FeedManager {
         }
     }
 
-    /// Whether the user has any Instagram profile feeds.
     var hasInstagramFeeds: Bool {
         feeds.contains { InstagramProfileScraper.isInstagramFeedURL($0.url) }
     }

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+InstagramProfile.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+InstagramProfile.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 
 extension FeedManager {
 
@@ -58,6 +59,17 @@ extension FeedManager {
 
         let feedTitle = result.displayName ?? feed.title
 
+        // Download the profile photo only on the first-ever refresh of
+        // this feed.  After that, metadata is frozen and user edits
+        // from the edit sheet are authoritative.
+        var profileImage: UIImage?
+        if feed.lastFetched == nil,
+           let imageURLString = result.profileImageURL,
+           let imageURL = URL(string: imageURLString),
+           let (imageData, _) = try? await FaviconCache.urlSession.data(from: imageURL) {
+            profileImage = UIImage(data: imageData)
+        }
+
         // Run all DB writes off the main thread
         let database = database
         try await Task.detached {
@@ -67,11 +79,11 @@ extension FeedManager {
             SpotlightIndexer.indexArticles(articlesToIndex, feedTitle: feedTitle)
         }.value
 
-        // Sync the scraped display name if the user hasn't customized
-        // the title.  Icons are deliberately left alone here — the user
-        // can pull the profile photo via `FeedEditSheet`'s "Fetch icon
-        // from feed" action if they want it.
-        await applyScraperMetadataRefresh(feed: feed, scrapedTitle: feedTitle)
+        // Install title + profile photo only on the first-ever fetch.
+        // The helper itself no-ops on subsequent refreshes.
+        await applyScraperMetadataRefresh(
+            feed: feed, scrapedTitle: feedTitle, profileImage: profileImage
+        )
 
         if reloadData {
             await loadFromDatabaseInBackground()

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+InstagramProfile.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+InstagramProfile.swift
@@ -1,5 +1,4 @@
 import Foundation
-import UIKit
 
 extension FeedManager {
 
@@ -59,16 +58,6 @@ extension FeedManager {
 
         let feedTitle = result.displayName ?? feed.title
 
-        // Download profile photo if available. This fetch is effectively
-        // a favicon fetch and therefore uses the favicon cache's dedicated
-        // URLSession, which bypasses the normal request timeout.
-        var profileImage: UIImage?
-        if let imageURLString = result.profileImageURL,
-           let imageURL = URL(string: imageURLString),
-           let (imageData, _) = try? await FaviconCache.urlSession.data(from: imageURL) {
-            profileImage = UIImage(data: imageData)
-        }
-
         // Run all DB writes off the main thread
         let database = database
         try await Task.detached {
@@ -78,13 +67,11 @@ extension FeedManager {
             SpotlightIndexer.indexArticles(articlesToIndex, feedTitle: feedTitle)
         }.value
 
-        // Cache favicon and update feed details.  The shared helper
-        // honours `isTitleCustomized` and only installs the downloaded
-        // profile photo when `customIconURL == nil`, so a user-assigned
-        // icon or title survives every refresh.
-        await applyScraperMetadataRefresh(
-            feed: feed, scrapedTitle: feedTitle, profileImage: profileImage
-        )
+        // Sync the scraped display name if the user hasn't customized
+        // the title.  Icons are deliberately left alone here — the user
+        // can pull the profile photo via `FeedEditSheet`'s "Fetch icon
+        // from feed" action if they want it.
+        await applyScraperMetadataRefresh(feed: feed, scrapedTitle: feedTitle)
 
         if reloadData {
             await loadFromDatabaseInBackground()

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+Refresh.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+Refresh.swift
@@ -36,10 +36,6 @@ extension FeedManager {
             let parser = RSSParser()
             guard let parsed = parser.parse(data: data) else { return }
 
-            // Fall back to HTML metadata (og:image, twitter:image, etc.)
-            // for new items the feed itself didn't tag with an image.
-            // Existing items are skipped so we don't re-probe pages we've
-            // already ingested on every refresh.
             let existingURLs = (try? database.existingArticleURLs(forFeedID: feed.id)) ?? []
             let imageBackfills = await FeedManager.backfillMetadataImages(
                 for: parsed.articles, skippingURLs: existingURLs
@@ -64,20 +60,12 @@ extension FeedManager {
 
             try database.insertArticles(feedID: feed.id, articles: articleTuples)
 
-            // Skip Spotlight indexing under Low Power Mode so feeds still
-            // refresh while deferring the CoreSpotlight writes until LPM
-            // turns off.  The next successful refresh outside LPM will
-            // re-index the same articles.
             if !ProcessInfo.processInfo.isLowPowerModeEnabled {
                 let feedTitleForIndex = parsed.title.isEmpty ? feed.title : parsed.title
                 let articlesToIndex = try database.articles(forFeedID: feed.id, limit: articleTuples.count)
                 SpotlightIndexer.indexArticles(articlesToIndex, feedTitle: feedTitleForIndex)
             }
 
-            // Feed metadata (title, isPodcast) is fetched exactly once,
-            // on the first refresh after add.  Subsequent refreshes
-            // never touch these fields — edits from the edit sheet are
-            // the sole source of truth after add.
             if feed.lastFetched == nil {
                 if parsed.isPodcast && !feed.isPodcast {
                     try database.updateFeedIsPodcast(id: feed.id, isPodcast: true)
@@ -98,10 +86,6 @@ extension FeedManager {
         }
     }
 
-    /// Returns `[articleURL: imageURL]` for parsed items missing an
-    /// image, by scraping each article page's HTML metadata.  Skips
-    /// articles already in `skippingURLs` and caps concurrency so a
-    /// feed with many imageless items doesn't flood a single host.
     nonisolated static func backfillMetadataImages(
         for articles: [ParsedArticle],
         skippingURLs existingURLs: Set<String>
@@ -180,27 +164,11 @@ extension FeedManager {
         await loadFromDatabaseInBackground()
     }
 
-    /// Refreshes every feed.
-    ///
-    /// - Parameters:
-    ///   - skipAuthenticatedScrapers: When `true`, X and Instagram
-    ///     profile feeds are skipped entirely.  Pass this from background
-    ///     refresh tasks.  Both scrapers' cookies now live in Keychain and
-    ///     so are technically available in the background, but hitting the
-    ///     Instagram/X APIs from a locked device at a fixed scheduler
-    ///     cadence is itself a strong bot-like signal — a stronger signal
-    ///     than anything else in the request fingerprint — so those
-    ///     scrapes are reserved for foreground use.  X additionally still
-    ///     depends on a JS-bundle query-ID fetch that is unreliable in a
-    ///     `BGAppRefreshTask`.
-    ///   - respectCooldown: When `true`, feeds whose `lastFetched` is
-    ///     within the user-configured `BackgroundRefresh.Cooldown`
-    ///     window are skipped.  Feeds that have never been fetched
-    ///     (`lastFetched == nil`) always refresh.  Pass this from
-    ///     automatic triggers (background refresh, app startup,
-    ///     foreground re-enter).  Leave `false` for explicit user
-    ///     actions like pull-to-refresh, which should always refresh
-    ///     everything.
+    /// Refreshes every feed.  `skipAuthenticatedScrapers` omits X and
+    /// Instagram profile feeds (pass from background refresh tasks).
+    /// `respectCooldown` skips feeds whose `lastFetched` is within the
+    /// `BackgroundRefresh.Cooldown` window; feeds with nil `lastFetched`
+    /// always refresh.
     func refreshAllFeeds(
         skipAuthenticatedScrapers: Bool = false,
         respectCooldown: Bool = false
@@ -225,9 +193,6 @@ extension FeedManager {
                 if let cooldownSeconds,
                    let lastFetched = feed.lastFetched,
                    now.timeIntervalSince(lastFetched) < cooldownSeconds {
-                    // Inside the cooldown window.  A nil lastFetched
-                    // means the feed has never been refreshed (new or
-                    // freshly imported), so it always proceeds.
                     continue
                 }
                 group.addTask {
@@ -238,25 +203,16 @@ extension FeedManager {
         await loadFromDatabaseInBackground()
     }
 
-    /// Refreshes feeds that have never been fetched (e.g. added by the share
-    /// extension while the main app was in the background).  Also generates
-    /// acronym icons for those feeds.
-    ///
-    /// Icons are deliberately not refreshed here.  Forcing a favicon
-    /// reload after add races with any icon the user has meanwhile
-    /// picked from the edit sheet, which reads as the refresh
-    /// clobbering their custom icon.  Rows pick up whatever is already
-    /// in `FaviconCache` lazily the first time they render.
+    /// Refreshes feeds that have never been fetched (e.g. added by the
+    /// share extension while the main app was in the background).
     func refreshUnfetchedFeeds() async {
         let unfetched = feeds.filter { $0.lastFetched == nil }
         guard !unfetched.isEmpty else { return }
 
-        // Generate acronym icons the share extension doesn't create.
         for feed in unfetched {
             generateAcronymIcon(feedID: feed.id, title: feed.title)
         }
 
-        // Fetch articles for the new feeds.
         await withTaskGroup(of: Void.self) { group in
             for feed in unfetched {
                 group.addTask {

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+Refresh.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+Refresh.swift
@@ -236,7 +236,13 @@ extension FeedManager {
 
     /// Refreshes feeds that have never been fetched (e.g. added by the share
     /// extension while the main app was in the background).  Also generates
-    /// acronym icons and fetches favicons for those feeds.
+    /// acronym icons for those feeds.
+    ///
+    /// Icons are deliberately not refreshed here.  Forcing a favicon
+    /// reload after add races with any icon the user has meanwhile
+    /// picked from the edit sheet, which reads as the refresh
+    /// clobbering their custom icon.  Rows pick up whatever is already
+    /// in `FaviconCache` lazily the first time they render.
     func refreshUnfetchedFeeds() async {
         let unfetched = feeds.filter { $0.lastFetched == nil }
         guard !unfetched.isEmpty else { return }
@@ -255,12 +261,6 @@ extension FeedManager {
             }
         }
         await loadFromDatabaseInBackground()
-
-        // Clear any stale favicon failures and notify the UI so
-        // FeedRowViews re-fetch their icons.
-        let entries = unfetched.map { ($0.domain, $0.siteURL as String?) }
-        await FaviconCache.shared.clearFailedLookups(for: entries)
-        notifyFaviconChange()
     }
 
     func refreshAllFeedsAndFavicons() async {

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+Refresh.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+Refresh.swift
@@ -74,18 +74,22 @@ extension FeedManager {
                 SpotlightIndexer.indexArticles(articlesToIndex, feedTitle: feedTitleForIndex)
             }
 
-            if parsed.isPodcast && !feed.isPodcast {
-                try database.updateFeedIsPodcast(id: feed.id, isPodcast: true)
-            } else if !parsed.isPodcast && feed.isPodcast {
-                try database.updateFeedIsPodcast(id: feed.id, isPodcast: false)
-            }
-            // Respect user-customized titles: when the user has edited the
-            // title via the edit sheet, the refresh should never silently
-            // overwrite that override with whatever the remote feed
-            // currently advertises.
-            if updateTitle, !feed.isTitleCustomized,
-               !parsed.title.isEmpty, parsed.title != feed.title {
-                try database.updateFeed(id: feed.id, title: parsed.title, category: feed.category)
+            // Feed metadata (title, isPodcast) is fetched exactly once,
+            // on the first refresh after add.  Subsequent refreshes
+            // never touch these fields — edits from the edit sheet are
+            // the sole source of truth after add.
+            if feed.lastFetched == nil {
+                if parsed.isPodcast && !feed.isPodcast {
+                    try database.updateFeedIsPodcast(id: feed.id, isPodcast: true)
+                } else if !parsed.isPodcast && feed.isPodcast {
+                    try database.updateFeedIsPodcast(id: feed.id, isPodcast: false)
+                }
+                if updateTitle, !feed.isTitleCustomized,
+                   !parsed.title.isEmpty, parsed.title != feed.title {
+                    try database.updateFeed(
+                        id: feed.id, title: parsed.title, category: feed.category
+                    )
+                }
             }
             try database.updateFeedLastFetched(id: feed.id, date: Date())
         }.value

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+XProfile.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+XProfile.swift
@@ -1,5 +1,4 @@
 import Foundation
-import UIKit
 
 extension FeedManager {
 
@@ -47,16 +46,6 @@ extension FeedManager {
 
         let feedTitle = result.displayName ?? feed.title
 
-        // Download profile photo if available. This fetch is effectively
-        // a favicon fetch and therefore uses the favicon cache's dedicated
-        // URLSession, which bypasses the normal request timeout.
-        var profileImage: UIImage?
-        if let imageURLString = result.profileImageURL,
-           let imageURL = URL(string: imageURLString),
-           let (imageData, _) = try? await FaviconCache.urlSession.data(from: imageURL) {
-            profileImage = UIImage(data: imageData)
-        }
-
         // Run all DB writes off the main thread
         let database = database
         try await Task.detached {
@@ -66,13 +55,11 @@ extension FeedManager {
             SpotlightIndexer.indexArticles(articlesToIndex, feedTitle: feedTitle)
         }.value
 
-        // Cache favicon and update feed details.  The shared helper
-        // honours `isTitleCustomized` and only installs the downloaded
-        // profile photo when `customIconURL == nil`, so a user-assigned
-        // icon or title survives every refresh.
-        await applyScraperMetadataRefresh(
-            feed: feed, scrapedTitle: feedTitle, profileImage: profileImage
-        )
+        // Sync the scraped display name if the user hasn't customized
+        // the title.  Icons are deliberately left alone here — the user
+        // can pull the profile photo via `FeedEditSheet`'s "Fetch icon
+        // from feed" action if they want it.
+        await applyScraperMetadataRefresh(feed: feed, scrapedTitle: feedTitle)
 
         if reloadData {
             await loadFromDatabaseInBackground()

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+XProfile.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+XProfile.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 
 extension FeedManager {
 
@@ -46,6 +47,17 @@ extension FeedManager {
 
         let feedTitle = result.displayName ?? feed.title
 
+        // Download the profile photo only on the first-ever refresh of
+        // this feed.  After that, metadata is frozen and user edits
+        // from the edit sheet are authoritative.
+        var profileImage: UIImage?
+        if feed.lastFetched == nil,
+           let imageURLString = result.profileImageURL,
+           let imageURL = URL(string: imageURLString),
+           let (imageData, _) = try? await FaviconCache.urlSession.data(from: imageURL) {
+            profileImage = UIImage(data: imageData)
+        }
+
         // Run all DB writes off the main thread
         let database = database
         try await Task.detached {
@@ -55,11 +67,11 @@ extension FeedManager {
             SpotlightIndexer.indexArticles(articlesToIndex, feedTitle: feedTitle)
         }.value
 
-        // Sync the scraped display name if the user hasn't customized
-        // the title.  Icons are deliberately left alone here — the user
-        // can pull the profile photo via `FeedEditSheet`'s "Fetch icon
-        // from feed" action if they want it.
-        await applyScraperMetadataRefresh(feed: feed, scrapedTitle: feedTitle)
+        // Install title + profile photo only on the first-ever fetch.
+        // The helper itself no-ops on subsequent refreshes.
+        await applyScraperMetadataRefresh(
+            feed: feed, scrapedTitle: feedTitle, profileImage: profileImage
+        )
 
         if reloadData {
             await loadFromDatabaseInBackground()

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+XProfile.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+XProfile.swift
@@ -6,11 +6,9 @@ extension FeedManager {
     // MARK: - X Profile Feeds
 
     /// Minimum interval between X API calls per feed (30 minutes).
-    /// Also used by `FaviconProgressBadge` to size the cooldown pie.
     static let xRefreshInterval: TimeInterval = 30 * 60
 
     func refreshXFeed(_ feed: Feed, reloadData: Bool = true) async throws {
-        // Skip if this feed was fetched less than 30 minutes ago to avoid rate limits
         if let lastFetched = feed.lastFetched,
            Date().timeIntervalSince(lastFetched) < Self.xRefreshInterval {
             #if DEBUG
@@ -27,7 +25,6 @@ extension FeedManager {
         let scraper = XProfileScraper()
         let result = await scraper.scrapeProfile(profileURL: profileURL)
 
-        // Prepare tweet data for batch insert
         let tweetTuples = result.tweets.map { tweet in
             let title = tweet.text.isEmpty
                 ? "Post by @\(tweet.authorHandle)"
@@ -47,9 +44,6 @@ extension FeedManager {
 
         let feedTitle = result.displayName ?? feed.title
 
-        // Download the profile photo only on the first-ever refresh of
-        // this feed.  After that, metadata is frozen and user edits
-        // from the edit sheet are authoritative.
         var profileImage: UIImage?
         if feed.lastFetched == nil,
            let imageURLString = result.profileImageURL,
@@ -58,7 +52,6 @@ extension FeedManager {
             profileImage = UIImage(data: imageData)
         }
 
-        // Run all DB writes off the main thread
         let database = database
         try await Task.detached {
             try database.insertArticles(feedID: feed.id, articles: tweetTuples)
@@ -67,8 +60,6 @@ extension FeedManager {
             SpotlightIndexer.indexArticles(articlesToIndex, feedTitle: feedTitle)
         }.value
 
-        // Install title + profile photo only on the first-ever fetch.
-        // The helper itself no-ops on subsequent refreshes.
         await applyScraperMetadataRefresh(
             feed: feed, scrapedTitle: feedTitle, profileImage: profileImage
         )
@@ -78,7 +69,6 @@ extension FeedManager {
         }
     }
 
-    /// Whether the user has any X profile feeds.
     var hasXFeeds: Bool {
         feeds.contains { XProfileScraper.isXFeedURL($0.url) }
     }

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+YouTubePlaylist.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+YouTubePlaylist.swift
@@ -1,5 +1,4 @@
 import Foundation
-import UIKit
 
 extension FeedManager {
 
@@ -42,16 +41,6 @@ extension FeedManager {
 
         let feedTitle = result.playlistTitle ?? feed.title
 
-        // Download the playlist creator's channel avatar if available.
-        // Uses the favicon cache's dedicated URLSession so the request
-        // bypasses the normal timeout — same as X / Instagram feeds.
-        var avatarImage: UIImage?
-        if let avatarURLString = result.channelAvatarURL,
-           let avatarURL = URL(string: avatarURLString),
-           let (imageData, _) = try? await FaviconCache.urlSession.data(from: avatarURL) {
-            avatarImage = UIImage(data: imageData)
-        }
-
         // Run all DB writes off the main thread
         let database = database
         try await Task.detached {
@@ -63,13 +52,11 @@ extension FeedManager {
             SpotlightIndexer.indexArticles(articlesToIndex, feedTitle: feedTitle)
         }.value
 
-        // Cache favicon and update feed details.  The shared helper
-        // honours `isTitleCustomized` and only installs the downloaded
-        // channel avatar when `customIconURL == nil`, so a user-assigned
-        // icon or title survives every refresh.
-        await applyScraperMetadataRefresh(
-            feed: feed, scrapedTitle: feedTitle, profileImage: avatarImage
-        )
+        // Sync the scraped playlist title if the user hasn't customized
+        // it.  Icons are deliberately left alone here — the user can
+        // pull the channel avatar via `FeedEditSheet`'s "Fetch icon
+        // from feed" action if they want it.
+        await applyScraperMetadataRefresh(feed: feed, scrapedTitle: feedTitle)
 
         if reloadData {
             await loadFromDatabaseInBackground()

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+YouTubePlaylist.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+YouTubePlaylist.swift
@@ -9,7 +9,6 @@ extension FeedManager {
     private static let youTubePlaylistRefreshInterval: TimeInterval = 30 * 60
 
     func refreshYouTubePlaylistFeed(_ feed: Feed, reloadData: Bool = true) async throws {
-        // Skip if this feed was fetched less than 30 minutes ago
         if let lastFetched = feed.lastFetched,
            Date().timeIntervalSince(lastFetched) < Self.youTubePlaylistRefreshInterval {
             #if DEBUG
@@ -28,7 +27,6 @@ extension FeedManager {
         let scraper = YouTubePlaylistScraper()
         let result = await scraper.scrapePlaylist(playlistID: playlistID)
 
-        // Convert playlist videos to article insert items
         let articleTuples = result.videos.map { video in
             ArticleInsertItem(
                 title: video.title,
@@ -42,9 +40,6 @@ extension FeedManager {
 
         let feedTitle = result.playlistTitle ?? feed.title
 
-        // Download the channel avatar only on the first-ever refresh of
-        // this feed.  After that, metadata is frozen and user edits
-        // from the edit sheet are authoritative.
         var avatarImage: UIImage?
         if feed.lastFetched == nil,
            let avatarURLString = result.channelAvatarURL,
@@ -53,7 +48,6 @@ extension FeedManager {
             avatarImage = UIImage(data: imageData)
         }
 
-        // Run all DB writes off the main thread
         let database = database
         try await Task.detached {
             try database.insertArticles(feedID: feed.id, articles: articleTuples)
@@ -64,8 +58,6 @@ extension FeedManager {
             SpotlightIndexer.indexArticles(articlesToIndex, feedTitle: feedTitle)
         }.value
 
-        // Install title + channel avatar only on the first-ever fetch.
-        // The helper itself no-ops on subsequent refreshes.
         await applyScraperMetadataRefresh(
             feed: feed, scrapedTitle: feedTitle, profileImage: avatarImage
         )
@@ -75,7 +67,6 @@ extension FeedManager {
         }
     }
 
-    /// Whether the user has any YouTube playlist feeds.
     var hasYouTubePlaylistFeeds: Bool {
         feeds.contains { YouTubePlaylistScraper.isYouTubePlaylistFeedURL($0.url) }
     }

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+YouTubePlaylist.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+YouTubePlaylist.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 
 extension FeedManager {
 
@@ -41,6 +42,17 @@ extension FeedManager {
 
         let feedTitle = result.playlistTitle ?? feed.title
 
+        // Download the channel avatar only on the first-ever refresh of
+        // this feed.  After that, metadata is frozen and user edits
+        // from the edit sheet are authoritative.
+        var avatarImage: UIImage?
+        if feed.lastFetched == nil,
+           let avatarURLString = result.channelAvatarURL,
+           let avatarURL = URL(string: avatarURLString),
+           let (imageData, _) = try? await FaviconCache.urlSession.data(from: avatarURL) {
+            avatarImage = UIImage(data: imageData)
+        }
+
         // Run all DB writes off the main thread
         let database = database
         try await Task.detached {
@@ -52,11 +64,11 @@ extension FeedManager {
             SpotlightIndexer.indexArticles(articlesToIndex, feedTitle: feedTitle)
         }.value
 
-        // Sync the scraped playlist title if the user hasn't customized
-        // it.  Icons are deliberately left alone here — the user can
-        // pull the channel avatar via `FeedEditSheet`'s "Fetch icon
-        // from feed" action if they want it.
-        await applyScraperMetadataRefresh(feed: feed, scrapedTitle: feedTitle)
+        // Install title + channel avatar only on the first-ever fetch.
+        // The helper itself no-ops on subsequent refreshes.
+        await applyScraperMetadataRefresh(
+            feed: feed, scrapedTitle: feedTitle, profileImage: avatarImage
+        )
 
         if reloadData {
             await loadFromDatabaseInBackground()

--- a/SakuraRSS/Views/Feeds/FeedGridCell.swift
+++ b/SakuraRSS/Views/Feeds/FeedGridCell.swift
@@ -94,6 +94,7 @@ struct FeedGridCell: View {
     }
 
     private func loadFavicon() async -> UIImage? {
-        await FaviconCache.shared.favicon(for: feed)
+        let currentFeed = feedManager.feedsByID[feed.id] ?? feed
+        return await FaviconCache.shared.favicon(for: currentFeed)
     }
 }

--- a/SakuraRSS/Views/Feeds/FeedRowView.swift
+++ b/SakuraRSS/Views/Feeds/FeedRowView.swift
@@ -91,6 +91,7 @@ struct FeedRowView: View {
     }
 
     private func loadFavicon() async -> UIImage? {
-        await FaviconCache.shared.favicon(for: feed)
+        let currentFeed = feedManager.feedsByID[feed.id] ?? feed
+        return await FaviconCache.shared.favicon(for: currentFeed)
     }
 }


### PR DESCRIPTION
## Summary

Fixes two related bugs where user-customized feed titles and icons could be clobbered or fail to appear after an edit.

### 1. Freeze feed metadata after first refresh

Feed title, icon, and `isPodcast` are now fetched exactly once — on the very first refresh after add. Every subsequent refresh leaves these fields untouched, so edits from the edit sheet are the sole source of truth post-add.

- `refreshFeed` (RSS) gates `updateFeed` and `updateFeedIsPodcast` on `feed.lastFetched == nil`.
- X / Instagram / YouTube playlist scrapers only download the profile photo on the first fetch and pass it through `applyScraperMetadataRefresh`, which itself no-ops once `lastFetched` is set.
- `refreshUnfetchedFeeds` no longer forces a favicon revision bump after catching up share-extension feeds.

This prevents background refreshes from racing with user edits and silently clobbering a custom icon or title.

### 2. Fix stale feed prop in row favicon reload

`FeedRowView` and `FeedGridCell` now re-query the current `Feed` from `feedManager.feedsByID[feed.id]` inside `loadFavicon()` instead of reading `self.feed` directly.

When `updateFeedDetails` commits, `loadFromDatabase()` and `notifyFaviconChange()` both write observable state in the same tick. The `.onChange(of: faviconRevision)` closure can fire with a struct prop snapshot whose `customIconURL` is still the pre-edit value, causing `FaviconCache.favicon(for:)` to skip the custom-icon branch and return the stale domain favicon. Looking up by ID guarantees the closure reads the freshest `customIconURL`.

## Test plan

- [ ] Add a new RSS feed, verify title and favicon populate on first refresh.
- [ ] Pull-to-refresh an existing feed, confirm its title/icon stay unchanged.
- [ ] Open edit sheet → change custom icon → tap Done → verify the Following view row updates immediately without scrolling.
- [ ] Open edit sheet → change title → tap Done → verify the row reflects the new title and that a subsequent refresh does not revert it.
- [ ] Add an X / Instagram / YouTube playlist feed; confirm the profile avatar and display name populate on first refresh only.
- [ ] After first fetch, refresh again and confirm the avatar and title remain untouched.

https://claude.ai/code/session_01F5coEhMdmz3y1bdTNc1Vhx