### PR TITLE
claude/move-button-to-bottom-3E86u

### DIFF
--- a/SakuraRSS/Views/Petal/PetalBuilderSelectorsSection.swift
+++ b/SakuraRSS/Views/Petal/PetalBuilderSelectorsSection.swift
@@ -13,7 +13,9 @@ struct PetalBuilderSelectorsSection: View {
 
     @Binding var recipe: PetalRecipe
     let canAutoDetect: Bool
+    let isFetching: Bool
     let onAutoDetect: () -> Void
+    let onFetch: () -> Void
     let onSelectorChanged: () -> Void
 
     var body: some View {
@@ -56,6 +58,19 @@ struct PetalBuilderSelectorsSection: View {
                 optional: $recipe.dateSelector,
                 placeholder: "time, .published"
             )
+
+            Button {
+                onFetch()
+            } label: {
+                HStack {
+                    Text(String(localized: "Builder.Fetch", table: "Petal"))
+                    if isFetching {
+                        Spacer()
+                        ProgressView()
+                    }
+                }
+            }
+            .disabled(recipe.siteURL.isEmpty || isFetching)
         } header: {
             Text(String(localized: "Builder.Section.Selectors", table: "Petal"))
         } footer: {

--- a/SakuraRSS/Views/Petal/PetalBuilderSourceSection.swift
+++ b/SakuraRSS/Views/Petal/PetalBuilderSourceSection.swift
@@ -1,17 +1,15 @@
 import SwiftUI
 
 /// "Source" section of the Web Feed builder: feed name, page
-/// URL, fetch mode picker, and the Fetch & Preview button.
+/// URL, and fetch mode picker.
 ///
 /// Owns no state of its own — the parent `PetalBuilderView` holds
-/// the recipe and toggles `isFetching`, and passes bindings down.
+/// the recipe and passes bindings down.
 struct PetalBuilderSourceSection: View {
 
     @Binding var name: String
     @Binding var siteURL: String
     @Binding var fetchMode: PetalRecipe.FetchMode
-    let isFetching: Bool
-    let onFetch: () -> Void
 
     var body: some View {
         Section {
@@ -28,18 +26,6 @@ struct PetalBuilderSourceSection: View {
                 Text(String(localized: "Builder.FetchMode.Rendered", table: "Petal"))
                     .tag(PetalRecipe.FetchMode.rendered)
             }
-            Button {
-                onFetch()
-            } label: {
-                HStack {
-                    Text(String(localized: "Builder.Fetch", table: "Petal"))
-                    if isFetching {
-                        Spacer()
-                        ProgressView()
-                    }
-                }
-            }
-            .disabled(siteURL.isEmpty || isFetching)
         } header: {
             Text(String(localized: "Builder.Section.Source", table: "Petal"))
         } footer: {

--- a/SakuraRSS/Views/Petal/PetalBuilderView.swift
+++ b/SakuraRSS/Views/Petal/PetalBuilderView.swift
@@ -61,14 +61,14 @@ struct PetalBuilderView: View {
                 PetalBuilderSourceSection(
                     name: $recipe.name,
                     siteURL: $recipe.siteURL,
-                    fetchMode: $recipe.fetchMode,
-                    isFetching: isFetching,
-                    onFetch: { Task { await fetchAndPreview(force: true) } }
+                    fetchMode: $recipe.fetchMode
                 )
                 PetalBuilderSelectorsSection(
                     recipe: $recipe,
                     canAutoDetect: fetchedHTML != nil && !isFetching,
+                    isFetching: isFetching,
                     onAutoDetect: runAutoDetect,
+                    onFetch: { Task { await fetchAndPreview(force: true) } },
                     onSelectorChanged: schedulePreview
                 )
                 PetalBuilderPreviewSection(


### PR DESCRIPTION
Relocates the Fetch & Preview action from the Source section to
the bottom of the Selectors section so it sits adjacent to the
selectors it previews.