### PR TITLE
Preserve sheet input across app backgrounding

### DIFF
--- a/SakuraRSS/Structs/SheetInputCache.swift
+++ b/SakuraRSS/Structs/SheetInputCache.swift
@@ -1,0 +1,123 @@
+import Foundation
+
+/// Process-scoped cache for preserving in-progress user input in sheets
+/// across view recreation.  SwiftUI @State on a sheet view can be torn
+/// down and rebuilt when the app is backgrounded and returns to the
+/// foreground (iOS may invalidate the sheet's snapshot, and subsequent
+/// feedManager mutations re-run the view body).  Without this cache,
+/// any half-typed URL / name / rules input is lost on every app switch.
+///
+/// Sheets read their initial @State from this cache in `init` via
+/// `State(initialValue:)` and write back on every change.  The cache
+/// entry is cleared on explicit save or cancel.
+@MainActor
+enum SheetInputCache {
+
+    // MARK: - Add Feed
+
+    static var addFeedURLInput: String = ""
+
+    static func clearAddFeed() {
+        addFeedURLInput = ""
+    }
+
+    // MARK: - Feed Edit
+
+    struct FeedEditSnapshot {
+        var name: String
+        var url: String
+        var iconURLInput: String
+        var openModeRaw: String?
+        var articleSourceRaw: String?
+        var useDefaultIcon: Bool
+    }
+
+    private static var feedEdit: [Int64: FeedEditSnapshot] = [:]
+
+    static func feedEditSnapshot(for feedID: Int64) -> FeedEditSnapshot? {
+        feedEdit[feedID]
+    }
+
+    static func setFeedEditSnapshot(_ snapshot: FeedEditSnapshot, for feedID: Int64) {
+        feedEdit[feedID] = snapshot
+    }
+
+    static func clearFeedEdit(for feedID: Int64) {
+        feedEdit.removeValue(forKey: feedID)
+    }
+
+    // MARK: - Feed Rules
+
+    struct FeedRulesSnapshot {
+        var allowedKeywords: [String]
+        var mutedKeywords: [String]
+        var mutedAuthors: [String]
+        var allowedKeywordInput: String
+        var keywordInput: String
+        var authorInput: String
+    }
+
+    private static var feedRules: [Int64: FeedRulesSnapshot] = [:]
+
+    static func feedRulesSnapshot(for feedID: Int64) -> FeedRulesSnapshot? {
+        feedRules[feedID]
+    }
+
+    static func setFeedRulesSnapshot(_ snapshot: FeedRulesSnapshot, for feedID: Int64) {
+        feedRules[feedID] = snapshot
+    }
+
+    static func clearFeedRules(for feedID: Int64) {
+        feedRules.removeValue(forKey: feedID)
+    }
+
+    // MARK: - List Edit
+
+    struct ListEditSnapshot {
+        var name: String
+        var selectedIcon: String
+        var selectedDisplayStyle: String?
+        var selectedFeedIDs: Set<Int64>
+    }
+
+    /// Keyed by list id for edits of existing lists; `nil` key is used
+    /// for a new (unsaved) list.
+    private static var listEdit: [Int64?: ListEditSnapshot] = [:]
+
+    static func listEditSnapshot(for listID: Int64?) -> ListEditSnapshot? {
+        listEdit[listID]
+    }
+
+    static func setListEditSnapshot(_ snapshot: ListEditSnapshot, for listID: Int64?) {
+        listEdit[listID] = snapshot
+    }
+
+    static func clearListEdit(for listID: Int64?) {
+        listEdit.removeValue(forKey: listID)
+    }
+
+    // MARK: - List Rules
+
+    struct ListRulesSnapshot {
+        var allowedKeywords: [String]
+        var mutedKeywords: [String]
+        var mutedAuthors: [String]
+        var allowedKeywordInput: String
+        var keywordInput: String
+        var authorInput: String
+    }
+
+    private static var listRules: [Int64: ListRulesSnapshot] = [:]
+
+    static func listRulesSnapshot(for listID: Int64) -> ListRulesSnapshot? {
+        listRules[listID]
+    }
+
+    static func setListRulesSnapshot(_ snapshot: ListRulesSnapshot, for listID: Int64) {
+        listRules[listID] = snapshot
+    }
+
+    static func clearListRules(for listID: Int64) {
+        listRules.removeValue(forKey: listID)
+    }
+}

--- a/SakuraRSS/Views/Feeds/FeedEditSheet.swift
+++ b/SakuraRSS/Views/Feeds/FeedEditSheet.swift
@@ -8,19 +8,52 @@ struct FeedEditSheet: View {
 
     let feed: Feed
 
-    @State private var name: String = ""
-    @State private var url: String = ""
-    @State var iconURLInput: String = ""
-    @State private var openMode: FeedOpenMode = .inAppViewer
-    @State private var articleSource: ArticleSource = .automatic
+    @State private var name: String
+    @State private var url: String
+    @State var iconURLInput: String
+    @State private var openMode: FeedOpenMode
+    @State private var articleSource: ArticleSource
     @State var selectedPhoto: PhotosPickerItem?
     @State var customIconImage: UIImage?
     @State var currentFavicon: UIImage?
     @State var isFetchingIcon = false
     @State var showIconFetchError = false
-    @State var useDefaultIcon = false
-    @State private var hasInitialized = false
+    @State var useDefaultIcon: Bool
     @State private var showPetalBuilder = false
+
+    init(feed: Feed) {
+        self.feed = feed
+        // Restore any in-progress edits preserved from an earlier
+        // background→foreground cycle; fall back to the feed's current
+        // persisted values otherwise.
+        let cached = SheetInputCache.feedEditSnapshot(for: feed.id)
+        let defaultName = feed.title
+        let defaultURL: String = (feed.isXFeed || feed.isInstagramFeed || feed.isYouTubePlaylistFeed)
+            ? feed.siteURL : feed.url
+        let existingIconURL = feed.customIconURL
+        let defaultIconURLInput = (
+            existingIconURL == "photo" || existingIconURL == "none"
+        ) ? "" : (existingIconURL ?? "")
+        let defaultUseDefaultIcon = existingIconURL == "none"
+        let defaultOpenMode: FeedOpenMode = {
+            let raw = UserDefaults.standard.string(forKey: "openMode-\(feed.id)")
+            return raw.flatMap(FeedOpenMode.init(rawValue:)) ?? .inAppViewer
+        }()
+        let defaultArticleSource: ArticleSource = {
+            let raw = UserDefaults.standard.string(forKey: "articleSource-\(feed.id)")
+            return raw.flatMap(ArticleSource.init(rawValue:)) ?? .automatic
+        }()
+
+        let cachedOpenMode = (cached?.openModeRaw).flatMap(FeedOpenMode.init(rawValue:))
+        let cachedArticleSource = (cached?.articleSourceRaw).flatMap(ArticleSource.init(rawValue:))
+
+        _name = State(initialValue: cached?.name ?? defaultName)
+        _url = State(initialValue: cached?.url ?? defaultURL)
+        _iconURLInput = State(initialValue: cached?.iconURLInput ?? defaultIconURLInput)
+        _useDefaultIcon = State(initialValue: cached?.useDefaultIcon ?? defaultUseDefaultIcon)
+        _openMode = State(initialValue: cachedOpenMode ?? defaultOpenMode)
+        _articleSource = State(initialValue: cachedArticleSource ?? defaultArticleSource)
+    }
 
     var body: some View {
         NavigationStack {
@@ -202,6 +235,7 @@ struct FeedEditSheet: View {
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
                     Button(role: .cancel) {
+                        SheetInputCache.clearFeedEdit(for: feed.id)
                         dismiss()
                     }
                 }
@@ -212,25 +246,12 @@ struct FeedEditSheet: View {
                     .disabled(name.isEmpty || url.isEmpty)
                 }
             }
-            .onAppear {
-                guard !hasInitialized else { return }
-                hasInitialized = true
-                name = feed.title
-                if feed.isXFeed || feed.isInstagramFeed || feed.isYouTubePlaylistFeed {
-                    url = feed.siteURL
-                } else {
-                    url = feed.url
-                }
-                let existingIconURL = feed.customIconURL
-                iconURLInput = (
-                    existingIconURL == "photo" || existingIconURL == "none"
-                ) ? "" : (existingIconURL ?? "")
-                useDefaultIcon = existingIconURL == "none"
-                let raw = UserDefaults.standard.string(forKey: "openMode-\(feed.id)")
-                openMode = raw.flatMap(FeedOpenMode.init(rawValue:)) ?? .inAppViewer
-                let sourceRaw = UserDefaults.standard.string(forKey: "articleSource-\(feed.id)")
-                articleSource = sourceRaw.flatMap(ArticleSource.init(rawValue:)) ?? .automatic
-            }
+            .onChange(of: name) { persistInputSnapshot() }
+            .onChange(of: url) { persistInputSnapshot() }
+            .onChange(of: iconURLInput) { persistInputSnapshot() }
+            .onChange(of: useDefaultIcon) { persistInputSnapshot() }
+            .onChange(of: openMode) { persistInputSnapshot() }
+            .onChange(of: articleSource) { persistInputSnapshot() }
             .task {
                 currentFavicon = await loadCurrentFavicon()
             }
@@ -318,7 +339,22 @@ struct FeedEditSheet: View {
         } else {
             UserDefaults.standard.set(articleSource.rawValue, forKey: "articleSource-\(feed.id)")
         }
+        SheetInputCache.clearFeedEdit(for: feed.id)
         dismiss()
+    }
+
+    private func persistInputSnapshot() {
+        SheetInputCache.setFeedEditSnapshot(
+            SheetInputCache.FeedEditSnapshot(
+                name: name,
+                url: url,
+                iconURLInput: iconURLInput,
+                openModeRaw: openMode.rawValue,
+                articleSourceRaw: articleSource.rawValue,
+                useDefaultIcon: useDefaultIcon
+            ),
+            for: feed.id
+        )
     }
 
 }

--- a/SakuraRSS/Views/Feeds/FeedRulesSheet.swift
+++ b/SakuraRSS/Views/Feeds/FeedRulesSheet.swift
@@ -10,20 +10,28 @@ struct FeedRulesSheet: View {
     @State private var allowedKeywords: [String]
     @State private var mutedKeywords: [String]
     @State private var mutedAuthors: [String]
-    @State private var allowedKeywordInput: String = ""
-    @State private var keywordInput: String = ""
-    @State private var authorInput: String = ""
+    @State private var allowedKeywordInput: String
+    @State private var keywordInput: String
+    @State private var authorInput: String
     @State private var availableAuthors: [String] = []
-    @State private var hasInitialized = false
+    @State private var hasInitialized: Bool
     @FocusState private var isAllowedKeywordFieldFocused: Bool
     @FocusState private var isKeywordFieldFocused: Bool
     @FocusState private var isAuthorFieldFocused: Bool
 
     init(feed: Feed) {
         self.feed = feed
-        _allowedKeywords = State(initialValue: [])
-        _mutedKeywords = State(initialValue: [])
-        _mutedAuthors = State(initialValue: [])
+        // Restore any in-progress edits preserved from an earlier
+        // background→foreground cycle; the list bodies default to empty
+        // and are filled from feedManager in `.onAppear` on first show.
+        let cached = SheetInputCache.feedRulesSnapshot(for: feed.id)
+        _allowedKeywords = State(initialValue: cached?.allowedKeywords ?? [])
+        _mutedKeywords = State(initialValue: cached?.mutedKeywords ?? [])
+        _mutedAuthors = State(initialValue: cached?.mutedAuthors ?? [])
+        _allowedKeywordInput = State(initialValue: cached?.allowedKeywordInput ?? "")
+        _keywordInput = State(initialValue: cached?.keywordInput ?? "")
+        _authorInput = State(initialValue: cached?.authorInput ?? "")
+        _hasInitialized = State(initialValue: cached != nil)
     }
 
     var suggestedAuthors: [String] {
@@ -169,6 +177,7 @@ struct FeedRulesSheet: View {
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
                     Button(role: .cancel) {
+                        SheetInputCache.clearFeedRules(for: feed.id)
                         dismiss()
                     }
                 }
@@ -179,13 +188,22 @@ struct FeedRulesSheet: View {
                 }
             }
             .onAppear {
-                guard !hasInitialized else { return }
-                hasInitialized = true
-                allowedKeywords = feedManager.allowedKeywords(for: feed)
-                mutedKeywords = feedManager.mutedKeywords(for: feed)
-                mutedAuthors = feedManager.mutedAuthors(for: feed)
-                availableAuthors = feedManager.uniqueAuthors(for: feed)
+                if !hasInitialized {
+                    hasInitialized = true
+                    allowedKeywords = feedManager.allowedKeywords(for: feed)
+                    mutedKeywords = feedManager.mutedKeywords(for: feed)
+                    mutedAuthors = feedManager.mutedAuthors(for: feed)
+                }
+                if availableAuthors.isEmpty {
+                    availableAuthors = feedManager.uniqueAuthors(for: feed)
+                }
             }
+            .onChange(of: allowedKeywords) { persistInputSnapshot() }
+            .onChange(of: mutedKeywords) { persistInputSnapshot() }
+            .onChange(of: mutedAuthors) { persistInputSnapshot() }
+            .onChange(of: allowedKeywordInput) { persistInputSnapshot() }
+            .onChange(of: keywordInput) { persistInputSnapshot() }
+            .onChange(of: authorInput) { persistInputSnapshot() }
         }
     }
 
@@ -217,6 +235,21 @@ struct FeedRulesSheet: View {
         feedManager.saveAllowedKeywords(allowedKeywords, for: feed)
         feedManager.saveMutedKeywords(mutedKeywords, for: feed)
         feedManager.saveMutedAuthors(mutedAuthors, for: feed)
+        SheetInputCache.clearFeedRules(for: feed.id)
         dismiss()
+    }
+
+    private func persistInputSnapshot() {
+        SheetInputCache.setFeedRulesSnapshot(
+            SheetInputCache.FeedRulesSnapshot(
+                allowedKeywords: allowedKeywords,
+                mutedKeywords: mutedKeywords,
+                mutedAuthors: mutedAuthors,
+                allowedKeywordInput: allowedKeywordInput,
+                keywordInput: keywordInput,
+                authorInput: authorInput
+            ),
+            for: feed.id
+        )
     }
 }

--- a/SakuraRSS/Views/Home/AddFeedView.swift
+++ b/SakuraRSS/Views/Home/AddFeedView.swift
@@ -6,7 +6,7 @@ struct AddFeedView: View {
     @Environment(\.dismiss) var dismiss
 
     var initialURL: String = ""
-    @State private var urlInput = ""
+    @State private var urlInput: String
     @State private var discoveredFeeds: [DiscoveredFeed] = []
     @State private var isSearching = false
     @State private var errorMessage: String?
@@ -21,6 +21,21 @@ struct AddFeedView: View {
     @State private var showPetalBuilder = false
     @AppStorage("Labs.PetalRecipes") private var petalRecipesEnabled: Bool = false
     @FocusState private var isURLFieldFocused: Bool
+
+    /// Tracks whether `urlInput` came from the cache (user was mid-edit
+    /// when the sheet was rebuilt) so we don't re-trigger `searchFeeds`
+    /// on every background→foreground cycle.
+    private let restoredFromCache: Bool
+
+    init(initialURL: String = "") {
+        self.initialURL = initialURL
+        // Prefer cached in-progress input (user was mid-edit when the
+        // view was torn down by a background→foreground cycle) over
+        // the seed URL passed in from outside.
+        let cached = SheetInputCache.addFeedURLInput
+        self.restoredFromCache = !cached.isEmpty
+        _urlInput = State(initialValue: cached.isEmpty ? initialURL : cached)
+    }
 
     /// The URL to seed the Petal builder with when the user taps
     /// "Generate with Petal" after a failed search.  Prefers the
@@ -204,11 +219,15 @@ struct AddFeedView: View {
             .toolbar {
                 ToolbarItem(placement: .confirmationAction) {
                     Button(role: .confirm) {
+                        SheetInputCache.clearAddFeed()
                         dismiss()
                     }
                 }
             }
             .interactiveDismissDisabled()
+            .onChange(of: urlInput) {
+                SheetInputCache.addFeedURLInput = urlInput
+            }
             .sheet(isPresented: $showXLogin) {
                 if let pending = pendingXFeed {
                     addFeedAfterXLogin(pending)
@@ -231,10 +250,9 @@ struct AddFeedView: View {
                 guard !hasInitialized else { return }
                 hasInitialized = true
                 suggestedTopics = SuggestedFeedsLoader.topicsForCurrentRegion()
-                if !initialURL.isEmpty {
-                    urlInput = initialURL
+                if !urlInput.isEmpty && !restoredFromCache {
                     searchFeeds()
-                } else {
+                } else if urlInput.isEmpty {
                     isURLFieldFocused = true
                 }
             }

--- a/SakuraRSS/Views/Lists/ListEditSheet.swift
+++ b/SakuraRSS/Views/Lists/ListEditSheet.swift
@@ -11,7 +11,7 @@ struct ListEditSheet: View {
     @State private var selectedIcon: String
     @State private var selectedDisplayStyle: String?
     @State private var selectedFeedIDs: Set<Int64>
-    @State private var hasInitialized = false
+    @State private var hasInitialized: Bool
 
     private var isEditing: Bool { list != nil }
 
@@ -30,10 +30,22 @@ struct ListEditSheet: View {
 
     init(list: FeedList?) {
         self.list = list
-        _name = State(initialValue: list?.name ?? "")
-        _selectedIcon = State(initialValue: list?.icon ?? ListIcon.newspaper.rawValue)
-        _selectedDisplayStyle = State(initialValue: list?.displayStyle)
-        _selectedFeedIDs = State(initialValue: [])
+        // Restore any in-progress edits preserved from an earlier
+        // background→foreground cycle.  Feed membership is loaded from
+        // feedManager in `.onAppear` on first show.
+        if let cached = SheetInputCache.listEditSnapshot(for: list?.id) {
+            _name = State(initialValue: cached.name)
+            _selectedIcon = State(initialValue: cached.selectedIcon)
+            _selectedDisplayStyle = State(initialValue: cached.selectedDisplayStyle)
+            _selectedFeedIDs = State(initialValue: cached.selectedFeedIDs)
+            _hasInitialized = State(initialValue: true)
+        } else {
+            _name = State(initialValue: list?.name ?? "")
+            _selectedIcon = State(initialValue: list?.icon ?? ListIcon.newspaper.rawValue)
+            _selectedDisplayStyle = State(initialValue: list?.displayStyle)
+            _selectedFeedIDs = State(initialValue: [])
+            _hasInitialized = State(initialValue: false)
+        }
     }
 
     var body: some View {
@@ -129,6 +141,7 @@ struct ListEditSheet: View {
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
                     Button(role: .cancel) {
+                        SheetInputCache.clearListEdit(for: list?.id)
                         dismiss()
                     }
                 }
@@ -146,7 +159,23 @@ struct ListEditSheet: View {
                     selectedFeedIDs = feedManager.feedIDs(for: list)
                 }
             }
+            .onChange(of: name) { persistInputSnapshot() }
+            .onChange(of: selectedIcon) { persistInputSnapshot() }
+            .onChange(of: selectedDisplayStyle) { persistInputSnapshot() }
+            .onChange(of: selectedFeedIDs) { persistInputSnapshot() }
         }
+    }
+
+    private func persistInputSnapshot() {
+        SheetInputCache.setListEditSnapshot(
+            SheetInputCache.ListEditSnapshot(
+                name: name,
+                selectedIcon: selectedIcon,
+                selectedDisplayStyle: selectedDisplayStyle,
+                selectedFeedIDs: selectedFeedIDs
+            ),
+            for: list?.id
+        )
     }
 
     private func save() {
@@ -182,6 +211,7 @@ struct ListEditSheet: View {
                 }
             }
         }
+        SheetInputCache.clearListEdit(for: list?.id)
         dismiss()
     }
 }

--- a/SakuraRSS/Views/Lists/ListRulesSheet.swift
+++ b/SakuraRSS/Views/Lists/ListRulesSheet.swift
@@ -7,17 +7,31 @@ struct ListRulesSheet: View {
 
     let list: FeedList
 
-    @State private var allowedKeywords: [String] = []
-    @State private var mutedKeywords: [String] = []
-    @State private var mutedAuthors: [String] = []
-    @State private var allowedKeywordInput: String = ""
-    @State private var keywordInput: String = ""
-    @State private var authorInput: String = ""
+    @State private var allowedKeywords: [String]
+    @State private var mutedKeywords: [String]
+    @State private var mutedAuthors: [String]
+    @State private var allowedKeywordInput: String
+    @State private var keywordInput: String
+    @State private var authorInput: String
     @State private var availableAuthors: [String] = []
-    @State private var hasInitialized = false
+    @State private var hasInitialized: Bool
     @FocusState private var isAllowedKeywordFieldFocused: Bool
     @FocusState private var isKeywordFieldFocused: Bool
     @FocusState private var isAuthorFieldFocused: Bool
+
+    init(list: FeedList) {
+        self.list = list
+        // Restore any in-progress edits preserved from an earlier
+        // background→foreground cycle.
+        let cached = SheetInputCache.listRulesSnapshot(for: list.id)
+        _allowedKeywords = State(initialValue: cached?.allowedKeywords ?? [])
+        _mutedKeywords = State(initialValue: cached?.mutedKeywords ?? [])
+        _mutedAuthors = State(initialValue: cached?.mutedAuthors ?? [])
+        _allowedKeywordInput = State(initialValue: cached?.allowedKeywordInput ?? "")
+        _keywordInput = State(initialValue: cached?.keywordInput ?? "")
+        _authorInput = State(initialValue: cached?.authorInput ?? "")
+        _hasInitialized = State(initialValue: cached != nil)
+    }
 
     var suggestedAuthors: [String] {
         let existing = Set(mutedAuthors)
@@ -162,6 +176,7 @@ struct ListRulesSheet: View {
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
                     Button(role: .cancel) {
+                        SheetInputCache.clearListRules(for: list.id)
                         dismiss()
                     }
                 }
@@ -172,14 +187,37 @@ struct ListRulesSheet: View {
                 }
             }
             .onAppear {
-                guard !hasInitialized else { return }
-                hasInitialized = true
-                allowedKeywords = feedManager.allowedKeywords(for: list)
-                mutedKeywords = feedManager.mutedKeywords(for: list)
-                mutedAuthors = feedManager.mutedAuthors(for: list)
-                availableAuthors = feedManager.uniqueAuthorsInList(list)
+                if !hasInitialized {
+                    hasInitialized = true
+                    allowedKeywords = feedManager.allowedKeywords(for: list)
+                    mutedKeywords = feedManager.mutedKeywords(for: list)
+                    mutedAuthors = feedManager.mutedAuthors(for: list)
+                }
+                if availableAuthors.isEmpty {
+                    availableAuthors = feedManager.uniqueAuthorsInList(list)
+                }
             }
+            .onChange(of: allowedKeywords) { persistInputSnapshot() }
+            .onChange(of: mutedKeywords) { persistInputSnapshot() }
+            .onChange(of: mutedAuthors) { persistInputSnapshot() }
+            .onChange(of: allowedKeywordInput) { persistInputSnapshot() }
+            .onChange(of: keywordInput) { persistInputSnapshot() }
+            .onChange(of: authorInput) { persistInputSnapshot() }
         }
+    }
+
+    private func persistInputSnapshot() {
+        SheetInputCache.setListRulesSnapshot(
+            SheetInputCache.ListRulesSnapshot(
+                allowedKeywords: allowedKeywords,
+                mutedKeywords: mutedKeywords,
+                mutedAuthors: mutedAuthors,
+                allowedKeywordInput: allowedKeywordInput,
+                keywordInput: keywordInput,
+                authorInput: authorInput
+            ),
+            for: list.id
+        )
     }
 
     private func addAllowedKeyword() {
@@ -210,6 +248,7 @@ struct ListRulesSheet: View {
         feedManager.saveAllowedKeywords(allowedKeywords, for: list)
         feedManager.saveMutedKeywords(mutedKeywords, for: list)
         feedManager.saveMutedAuthors(mutedAuthors, for: list)
+        SheetInputCache.clearListRules(for: list.id)
         dismiss()
     }
 }


### PR DESCRIPTION
## Summary

Fixes a bug where switching apps (or otherwise backgrounding Sakura) while a sheet such as **Add Feed** or **Edit Feed** is open would wipe any in-progress input — the URL you had typed, the name you were editing, the keywords you were adding, etc. — as soon as you returned to the app.

### Root cause

When the app returns to the foreground, `FeedManager.loadFromDatabase()` mutates the `@Observable` feed manager, which re-runs the surrounding view bodies. SwiftUI can tear down and rebuild the active sheet's view tree as part of that pass, and any sheet-local `@State` is reinitialized from scratch — losing whatever the user had typed.

### Fix

Introduce a process-scoped `SheetInputCache` that survives view recreation within the same process lifetime. Each affected sheet:

- Reads its initial `@State` from the cache in `init` via `State(initialValue:)`, falling back to the underlying model values when no cached snapshot exists.
- Writes a fresh snapshot via `.onChange` whenever any tracked field mutates.
- Clears its cache entry on explicit **Cancel** or **Save**, so dismissing the sheet legitimately doesn't leak input into the next presentation.

Sheets updated:

- `AddFeedView` — URL field input
- `FeedEditSheet` — name, URL, icon URL, open mode, article source, default-icon flag
- `FeedRulesSheet` — allowed/muted keywords, muted authors, in-progress text fields
- `ListEditSheet` — name, icon, display style, selected feed IDs
- `ListRulesSheet` — allowed/muted keywords, muted authors, in-progress text fields

`AddFeedView` additionally tracks whether `urlInput` was restored from cache so it doesn't re-trigger an automatic `searchFeeds()` on every background→foreground cycle.

## Test plan

- [ ] Open **Add Feed**, type a partial URL, switch to another app, return — URL is preserved.
- [ ] Open **Edit Feed**, change the title and icon URL, background the app, return — both edits are preserved.
- [ ] Open **Feed Rules**, type a keyword without tapping Add, background and return — the in-progress text remains.
- [ ] Open **List Edit** for an existing list, toggle several feeds, background and return — selection is preserved.
- [ ] Open **New List**, fill in name + icon, background and return — values are preserved.
- [ ] Tap **Cancel** on each sheet, reopen it — fields show the underlying model values, not stale cache.
- [ ] Tap **Save** on each sheet, reopen it — fields show the freshly-saved values, not stale cache.