### PR TITLE
Fix YouTube feeds not refreshing due to concatenated Atom dates

### DIFF
--- a/Shared/RSS Parser/RSSParser.swift
+++ b/Shared/RSS Parser/RSSParser.swift
@@ -9,6 +9,7 @@ nonisolated final class RSSParser: NSObject, XMLParserDelegate, @unchecked Senda
     private var currentAuthor = ""
     private var currentContent = ""
     private var currentPubDate = ""
+    private var currentUpdatedDate = ""
     private var currentImageURL = ""
     private var currentAudioURL = ""
     private var currentDuration = ""
@@ -49,6 +50,7 @@ nonisolated final class RSSParser: NSObject, XMLParserDelegate, @unchecked Senda
         currentAuthor = ""
         currentContent = ""
         currentPubDate = ""
+        currentUpdatedDate = ""
         currentImageURL = ""
         currentAudioURL = ""
         currentDuration = ""
@@ -110,6 +112,7 @@ nonisolated final class RSSParser: NSObject, XMLParserDelegate, @unchecked Senda
         currentAuthor = ""
         currentContent = ""
         currentPubDate = ""
+        currentUpdatedDate = ""
         currentImageURL = ""
         currentAudioURL = ""
         currentDuration = ""
@@ -161,7 +164,8 @@ nonisolated final class RSSParser: NSObject, XMLParserDelegate, @unchecked Senda
         case "description", "summary", "subtitle", "media:description": currentDescription += string
         case "dc:creator", "author", "name": currentAuthor += string
         case "content:encoded", "content": currentContent += string
-        case "pubDate", "published", "updated", "dc:date": currentPubDate += string
+        case "pubDate", "published", "dc:date": currentPubDate += string
+        case "updated": currentUpdatedDate += string
         case "itunes:duration": currentDuration += string
         default: break
         }
@@ -187,6 +191,10 @@ nonisolated final class RSSParser: NSObject, XMLParserDelegate, @unchecked Senda
             let trimmedAudioURL = currentAudioURL.trimmingCharacters(in: .whitespacesAndNewlines)
             let trimmedLink = currentLink.trimmingCharacters(in: .whitespacesAndNewlines)
             let articleURL = trimmedLink.isEmpty ? trimmedAudioURL : trimmedLink
+            let trimmedPubDate = currentPubDate.trimmingCharacters(in: .whitespacesAndNewlines)
+            let dateString = trimmedPubDate.isEmpty
+                ? currentUpdatedDate.trimmingCharacters(in: .whitespacesAndNewlines)
+                : trimmedPubDate
             let article = ParsedArticle(
                 title: decodeHTMLEntities(currentTitle.trimmingCharacters(in: .whitespacesAndNewlines)),
                 url: articleURL,
@@ -199,7 +207,7 @@ nonisolated final class RSSParser: NSObject, XMLParserDelegate, @unchecked Senda
                 ),
                 content: trimmedContent.isEmpty ? nil : trimmedContent,
                 imageURL: resolveImageURL(),
-                publishedDate: parseDate(currentPubDate.trimmingCharacters(in: .whitespacesAndNewlines)),
+                publishedDate: parseDate(dateString),
                 audioURL: trimmedAudioURL.isEmpty ? nil : trimmedAudioURL,
                 duration: parseDuration(currentDuration.trimmingCharacters(in: .whitespacesAndNewlines))
             )


### PR DESCRIPTION
## Summary

YouTube channel Atom feeds (`feeds/videos.xml?channel_id=...`) include both `<published>` and `<updated>` in every entry. `RSSParser` routed both element bodies to a single `currentPubDate` buffer using `+=`, producing a concatenated string like `2024-01-15T18:30:00+00:002024-01-15T18:35:00+00:00` that no `DateFormatter` or `ISO8601DateFormatter` could parse.

The result: every YouTube video was inserted with `publishedDate == nil`, so refreshed videos sank to the bottom of the timeline instead of appearing at the top — looked exactly like "feeds aren't refreshing."

## Fix

`Shared/RSS Parser/RSSParser.swift`

- Added a separate `currentUpdatedDate` buffer for `<updated>`.
- `<published>`, `<pubDate>`, and `<dc:date>` continue to feed `currentPubDate`.
- At entry close, prefer the trimmed `currentPubDate`; fall back to `currentUpdatedDate` only when no original publish date was provided.
- Both buffers are reset in `resetState` and `resetItemState`.

This is also semantically correct for Atom: `<published>` is the original publish time, `<updated>` is the most recent modification — we should prefer the former when both exist.

## Test plan

- [ ] Add a YouTube channel feed (e.g. via `youtube.com/@channelname` — discovery picks up the Atom feed link tag) and refresh; new videos should appear at the top of the timeline with correct dates.
- [ ] Verify other Atom feeds that only carry `<updated>` still get a date (fallback path).
- [ ] Verify RSS feeds with `<pubDate>` still parse correctly.
- [ ] Verify Atom feeds with both `<published>` and `<updated>` (e.g. GitHub release feeds) prefer the publish date.

Note: pre-existing YouTube videos already in the database remain undated since `insertArticles` uses `insert(or: .ignore)`. Newly fetched videos from any subsequent refresh will sort correctly.

https://claude.ai/code/session_01UX4wkNoGMKPkaaHaXadwRi