### PR TITLE
Add interactive element picker for Petal recipe builder

### DIFF
--- a/SakuraRSS/Views/Petal/PetalElementAssignMenu.swift
+++ b/SakuraRSS/Views/Petal/PetalElementAssignMenu.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+
+/// Replacement for the old chip row — a single "Assign to…" button
+/// that expands into a menu listing every recipe field the picked
+/// element can be bound to.  Rows are checkmarked when the currently
+/// picked selector already populates that field, and rows that are
+/// filled with a different selector show it as secondary text.
+struct PetalElementAssignMenu: View {
+
+    @Binding var recipe: PetalRecipe
+    let picked: PetalElementPickerWebView.PickedElement?
+
+    var body: some View {
+        Menu {
+            ForEach(PetalRecipeField.allCases, id: \.self) { field in
+                row(for: field)
+            }
+        } label: {
+            HStack(spacing: 6) {
+                Text(String(localized: "Picker.AssignTo", table: "Petal"))
+                    .font(.subheadline.weight(.semibold))
+                Image(systemName: "chevron.up.chevron.down")
+                    .font(.caption2.weight(.bold))
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 10)
+        }
+        .buttonStyle(.borderedProminent)
+        .buttonBorderShape(.capsule)
+        .disabled(picked == nil)
+    }
+
+    @ViewBuilder
+    private func row(for field: PetalRecipeField) -> some View {
+        let current = field.selector(in: recipe)
+        let pickedSelector = picked?.selected.selector
+        let isAssignedToPicked = current != nil && current == pickedSelector
+        Button {
+            guard let pickedSelector else { return }
+            field.assign(pickedSelector, to: &recipe)
+        } label: {
+            if isAssignedToPicked {
+                Label(field.localizedLabel, systemImage: "checkmark")
+            } else if let current {
+                Text(verbatim: "\(field.localizedLabel) — \(current)")
+            } else {
+                Text(field.localizedLabel)
+            }
+        }
+    }
+}

--- a/SakuraRSS/Views/Petal/PetalElementBreadcrumb.swift
+++ b/SakuraRSS/Views/Petal/PetalElementBreadcrumb.swift
@@ -1,0 +1,112 @@
+import SwiftUI
+
+/// Horizontal breadcrumb trail showing the ancestor chain from the
+/// document root down to the currently-selected element, with a
+/// trailing drill-in control that exposes the selected element's
+/// direct visible children as menu items.
+///
+/// Tapping an ancestor segment drills *out* (selects that ancestor);
+/// picking a child from the trailing menu drills *in*.
+struct PetalElementBreadcrumb: View {
+
+    typealias Info = PetalElementPickerWebView.ElementInfo
+
+    let ancestors: [Info]           // immediate parent first
+    let selected: Info
+    let children: [Info]
+    let onSelectAncestor: (Int) -> Void   // levels up (1 = parent)
+    let onSelectChild: (Int) -> Void
+
+    var body: some View {
+        HStack(spacing: 6) {
+            trail
+            drillInControl
+                .padding(.trailing, 16)
+        }
+    }
+
+    private var trail: some View {
+        ScrollViewReader { proxy in
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 4) {
+                    ForEach(orderedAncestors.indices, id: \.self) { idx in
+                        segment(orderedAncestors[idx].tag, isCurrent: false) {
+                            let levelsUp = orderedAncestors.count - idx
+                            onSelectAncestor(levelsUp)
+                        }
+                        Image(systemName: "chevron.right")
+                            .font(.caption2.weight(.semibold))
+                            .foregroundStyle(.tertiary)
+                    }
+                    segment(selected.tag, isCurrent: true) {}
+                        .id("selected-segment")
+                }
+                .padding(.horizontal, 16)
+            }
+            .onChange(of: selected.selector) { _, _ in
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    proxy.scrollTo("selected-segment", anchor: .trailing)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var drillInControl: some View {
+        if children.isEmpty {
+            Image(systemName: "chevron.down.circle")
+                .font(.title3)
+                .foregroundStyle(.quaternary)
+        } else {
+            Menu {
+                Section(String(localized: "Picker.Children.Menu", table: "Petal")) {
+                    ForEach(children.indices, id: \.self) { idx in
+                        Button {
+                            onSelectChild(idx)
+                        } label: {
+                            childLabel(children[idx])
+                        }
+                    }
+                }
+            } label: {
+                Image(systemName: "chevron.down.circle.fill")
+                    .font(.title3)
+                    .foregroundStyle(.tint)
+            }
+            .accessibilityLabel(String(localized: "Picker.Children.A11y", table: "Petal"))
+        }
+    }
+
+    @ViewBuilder
+    private func childLabel(_ info: Info) -> some View {
+        if info.text.isEmpty {
+            Text(verbatim: "<\(info.tag)>")
+        } else {
+            Text(verbatim: "<\(info.tag)>  \(info.text)")
+        }
+    }
+
+    private var orderedAncestors: [Info] {
+        Array(ancestors.reversed())   // outermost first
+    }
+
+    @ViewBuilder
+    private func segment(_ tag: String, isCurrent: Bool, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(tag)
+                .font(.footnote.monospaced().weight(isCurrent ? .semibold : .regular))
+                .foregroundStyle(isCurrent ? Color.primary : Color.secondary)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 5)
+                .background(
+                    Capsule().fill(
+                        isCurrent
+                            ? Color.accentColor.opacity(0.18)
+                            : Color.secondary.opacity(0.08)
+                    )
+                )
+        }
+        .buttonStyle(.plain)
+        .disabled(isCurrent)
+    }
+}

--- a/SakuraRSS/Views/Petal/PetalElementPickerBottomBar.swift
+++ b/SakuraRSS/Views/Petal/PetalElementPickerBottomBar.swift
@@ -1,0 +1,64 @@
+import SwiftUI
+
+/// Picker chrome pinned to the bottom of the sheet:
+/// breadcrumb trail on top, picked-element summary + "Assign to…"
+/// menu on the bottom.  Shows a placeholder until the user taps
+/// an element in the web view.
+struct PetalElementPickerBottomBar: View {
+
+    @Binding var recipe: PetalRecipe
+    let picked: PetalElementPickerWebView.PickedElement?
+    let onSelectAncestor: (Int) -> Void
+    let onSelectChild: (Int) -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            if let picked {
+                PetalElementBreadcrumb(
+                    ancestors: picked.ancestors,
+                    selected: picked.selected,
+                    children: picked.children,
+                    onSelectAncestor: onSelectAncestor,
+                    onSelectChild: onSelectChild
+                )
+                .padding(.vertical, 8)
+                Divider()
+            }
+            actionRow
+        }
+        .background(.ultraThinMaterial)
+        .safeAreaPadding(.bottom)
+    }
+
+    private var actionRow: some View {
+        HStack(alignment: .center, spacing: 12) {
+            summary
+            Spacer(minLength: 8)
+            PetalElementAssignMenu(recipe: $recipe, picked: picked)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+    }
+
+    @ViewBuilder
+    private var summary: some View {
+        if let picked {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(verbatim: "<\(picked.selected.tag)>")
+                    .font(.caption.monospaced().weight(.semibold))
+                    .foregroundStyle(.primary)
+                if !picked.selected.text.isEmpty {
+                    Text(picked.selected.text)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                }
+            }
+        } else {
+            Text(String(localized: "Picker.NoSelection", table: "Petal"))
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+    }
+}

--- a/SakuraRSS/Views/Petal/PetalElementPickerController.swift
+++ b/SakuraRSS/Views/Petal/PetalElementPickerController.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+import WebKit
+
+/// Bridges Swift → JS calls so the breadcrumb can drive the
+/// in-page selection (drilling up to an ancestor or into a
+/// direct child of the currently-selected element).
+final class PetalElementPickerController: ObservableObject {
+
+    weak var webView: WKWebView?
+
+    /// Selects the ancestor `levelsUp` steps above the current
+    /// selection.  `1` is the immediate parent, `2` the
+    /// grandparent, and so on.
+    func selectAncestor(levelsUp: Int) {
+        webView?.evaluateJavaScript("window.petalSelectAncestor(\(levelsUp))")
+    }
+
+    /// Selects the direct child of the current selection at the
+    /// given index in the visible-child list sent to Swift.
+    func selectChild(atIndex index: Int) {
+        webView?.evaluateJavaScript("window.petalSelectChild(\(index))")
+    }
+}

--- a/SakuraRSS/Views/Petal/PetalElementPickerView.swift
+++ b/SakuraRSS/Views/Petal/PetalElementPickerView.swift
@@ -1,10 +1,10 @@
 import SwiftUI
 
 /// Full-screen sheet that renders fetched HTML in a web view and
-/// lets the user tap elements to assign them to recipe fields.
-///
-/// The picker modifies the recipe binding directly — changes are
-/// visible in the builder as soon as the sheet is dismissed.
+/// lets the user tap elements, navigate the DOM via a breadcrumb,
+/// and assign the current selection to a recipe field via the
+/// "Assign to…" menu.  Recipe mutations flow through the binding
+/// so the builder sees them as soon as the sheet is dismissed.
 struct PetalElementPickerView: View {
 
     @Binding var recipe: PetalRecipe
@@ -12,6 +12,7 @@ struct PetalElementPickerView: View {
     @Environment(\.dismiss) private var dismiss
 
     @State private var pickedElement: PetalElementPickerWebView.PickedElement?
+    @StateObject private var controller = PetalElementPickerController()
 
     private var baseURL: URL? {
         URL(string: recipe.baseURL ?? recipe.siteURL)
@@ -22,6 +23,7 @@ struct PetalElementPickerView: View {
             PetalElementPickerWebView(
                 html: html,
                 baseURL: baseURL,
+                controller: controller,
                 onElementPicked: { pickedElement = $0 }
             )
             .ignoresSafeArea()
@@ -33,83 +35,13 @@ struct PetalElementPickerView: View {
                 }
             }
             .safeAreaInset(edge: .bottom) {
-                statusBar
+                PetalElementPickerBottomBar(
+                    recipe: $recipe,
+                    picked: pickedElement,
+                    onSelectAncestor: controller.selectAncestor(levelsUp:),
+                    onSelectChild: controller.selectChild(atIndex:)
+                )
             }
         }
     }
-
-    // MARK: - Assignment
-
-    private func assign(field: PetalRecipeField, selector: String) {
-        switch field {
-        case .item:    recipe.itemSelector = selector
-        case .title:   recipe.titleSelector = selector
-        case .link:    recipe.linkSelector = selector
-        case .date:    recipe.dateSelector = selector
-        case .author:  recipe.authorSelector = selector
-        case .summary: recipe.summarySelector = selector
-        case .image:   recipe.imageSelector = selector
-        }
-    }
-
-    // MARK: - Status bar
-
-    private var statusBar: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            GlassEffectContainer(spacing: 8) {
-                HStack(spacing: 8) {
-                    chip(field: .item)
-                    chip(field: .title)
-                    chip(field: .link)
-                    chip(field: .date)
-                    chip(field: .author)
-                    chip(field: .summary)
-                    chip(field: .image)
-                }
-            }
-            .padding(.horizontal, 16)
-            .padding(.vertical, 10)
-        }
-        .safeAreaPadding(.bottom)
-    }
-
-    @ViewBuilder
-    private func chip(field: PetalRecipeField) -> some View {
-        let currentSelector = selector(for: field)
-        let isSet = !currentSelector.isEmpty
-        let canAssign = pickedElement != nil
-        Button {
-            if let el = pickedElement {
-                assign(field: field, selector: el.selector)
-            }
-        } label: {
-            HStack(spacing: 6) {
-                Image(systemName: isSet ? "checkmark.circle.fill" : "circle")
-                    .font(.subheadline.weight(.medium))
-                    .foregroundStyle(isSet ? Color.green : Color.secondary)
-                Text(field.localizedLabel)
-                    .font(.subheadline)
-                    .foregroundStyle(isSet ? Color.primary : Color.secondary)
-            }
-            .padding(.horizontal, 16)
-            .padding(.vertical, 10)
-        }
-        .buttonStyle(.plain)
-        .glassEffect(.regular.interactive(), in: .capsule)
-        .disabled(!canAssign)
-    }
-
-    private func selector(for field: PetalRecipeField) -> String {
-        switch field {
-        case .item:    recipe.itemSelector
-        case .title:   recipe.titleSelector ?? ""
-        case .link:    recipe.linkSelector ?? ""
-        case .date:    recipe.dateSelector ?? ""
-        case .author:  recipe.authorSelector ?? ""
-        case .summary: recipe.summarySelector ?? ""
-        case .image:   recipe.imageSelector ?? ""
-        }
-    }
-
 }
-

--- a/SakuraRSS/Views/Petal/PetalElementPickerWebView+Coordinator.swift
+++ b/SakuraRSS/Views/Petal/PetalElementPickerWebView+Coordinator.swift
@@ -1,0 +1,51 @@
+import WebKit
+
+extension PetalElementPickerWebView {
+
+    final class Coordinator: NSObject, WKScriptMessageHandler, WKNavigationDelegate {
+
+        let onElementPicked: (PickedElement) -> Void
+
+        init(onElementPicked: @escaping (PickedElement) -> Void) {
+            self.onElementPicked = onElementPicked
+        }
+
+        func userContentController(
+            _ userContentController: WKUserContentController,
+            didReceive message: WKScriptMessage
+        ) {
+            guard message.name == "elementPicked",
+                  let body = message.body as? [String: Any],
+                  let selected = Self.element(from: body["selected"])
+            else { return }
+            let ancestors = (body["ancestors"] as? [Any] ?? []).compactMap(Self.element(from:))
+            let children = (body["children"] as? [Any] ?? []).compactMap(Self.element(from:))
+            let picked = PickedElement(
+                selected: selected,
+                ancestors: ancestors,
+                children: children
+            )
+            DispatchQueue.main.async { self.onElementPicked(picked) }
+        }
+
+        private static func element(from raw: Any?) -> ElementInfo? {
+            guard let dict = raw as? [String: Any],
+                  let selector = dict["selector"] as? String,
+                  !selector.isEmpty
+            else { return nil }
+            return ElementInfo(
+                selector: selector,
+                text: dict["text"] as? String ?? "",
+                tag: dict["tag"] as? String ?? ""
+            )
+        }
+
+        func webView(
+            _ webView: WKWebView,
+            decidePolicyFor action: WKNavigationAction,
+            decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+        ) {
+            decisionHandler(action.navigationType == .linkActivated ? .cancel : .allow)
+        }
+    }
+}

--- a/SakuraRSS/Views/Petal/PetalElementPickerWebView+JS.swift
+++ b/SakuraRSS/Views/Petal/PetalElementPickerWebView+JS.swift
@@ -1,0 +1,134 @@
+extension PetalElementPickerWebView {
+
+    /// JavaScript injected at document-end.  Adds a touch-highlight,
+    /// posts the current selection (plus ancestors and visible
+    /// children) back to Swift on every tap, and exposes
+    /// `window.petalSelectAncestor` / `window.petalSelectChild` so
+    /// the breadcrumb can drive the selection from Swift.
+    static let injectionJS = #"""
+    (function () {
+      var style = document.createElement('style');
+      style.textContent =
+        '*, *::before, *::after {' +
+        '  -webkit-tap-highlight-color: transparent !important;' +
+        '  -webkit-touch-callout: none !important;' +
+        '  -webkit-user-select: none !important;' +
+        '  user-select: none !important;' +
+        '  pointer-events: auto !important;' +
+        '}' +
+        '.petal-tap { outline: 3px solid rgba(255,59,48,0.8) !important; outline-offset: 1px !important; }';
+      document.head.appendChild(style);
+
+      document.addEventListener('contextmenu', function (e) {
+        e.preventDefault();
+      }, true);
+
+      function cssEscape(v) {
+        return (typeof CSS !== 'undefined' && CSS.escape)
+          ? CSS.escape(v) : v.replace(/([^\w-])/g, '\\$1');
+      }
+
+      function compact(el) {
+        var tag = el.tagName.toLowerCase();
+        var id = el.getAttribute('id');
+        if (id) return '#' + cssEscape(id);
+        var cls = null;
+        el.classList.forEach(function (c) {
+          if (!cls && c.indexOf('petal-') !== 0) cls = c;
+        });
+        return cls ? tag + '.' + cls : tag;
+      }
+
+      function isInvisibleOverlay(el) {
+        if (!el || el === document.body || el === document.documentElement) return true;
+        var textContent = (el.textContent || '').trim();
+        var innerText = (el.innerText || '').trim();
+        if (textContent.length > 0 && innerText.length === 0) return true;
+        if (!textContent && !el.querySelector('img, svg, video, canvas, picture')) {
+          return true;
+        }
+        return false;
+      }
+
+      function pickThroughOverlays(x, y, startEl) {
+        if (!isInvisibleOverlay(startEl)) return startEl;
+        var stack = document.elementsFromPoint(x, y);
+        for (var i = 0; i < stack.length; i++) {
+          if (!isInvisibleOverlay(stack[i])) return stack[i];
+        }
+        return startEl;
+      }
+
+      function summarize(el) {
+        var text = (el.innerText || el.textContent || '').trim()
+          .replace(/\s+/g, ' ').substring(0, 80);
+        return {
+          selector: compact(el),
+          text: text,
+          tag: el.tagName.toLowerCase()
+        };
+      }
+
+      function ancestorsOf(el) {
+        var out = [];
+        var cur = el.parentElement;
+        while (cur && cur !== document.body && cur !== document.documentElement) {
+          out.push(summarize(cur));
+          cur = cur.parentElement;
+        }
+        return out;
+      }
+
+      function visibleChildren(el) {
+        var out = [];
+        var kids = el.children;
+        for (var i = 0; i < kids.length; i++) {
+          if (!isInvisibleOverlay(kids[i])) out.push(kids[i]);
+        }
+        return out;
+      }
+
+      var selected = null;
+
+      function select(el) {
+        if (!el || el === document.body || el === document.documentElement) return;
+        if (selected) selected.classList.remove('petal-tap');
+        selected = el;
+        el.classList.add('petal-tap');
+        try {
+          el.scrollIntoView({ block: 'nearest', inline: 'nearest', behavior: 'smooth' });
+        } catch (_) { /* older WebKit */ }
+        window.webkit.messageHandlers.elementPicked.postMessage({
+          selected: summarize(el),
+          ancestors: ancestorsOf(el),
+          children: visibleChildren(el).map(summarize)
+        });
+      }
+
+      document.addEventListener('click', function (e) {
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        var el = pickThroughOverlays(e.clientX, e.clientY, e.target);
+        select(el);
+      }, true);
+
+      window.petalSelectAncestor = function (levelsUp) {
+        if (!selected) return;
+        var el = selected;
+        for (var i = 0; i < levelsUp; i++) {
+          if (!el.parentElement) return;
+          el = el.parentElement;
+        }
+        if (el === document.body || el === document.documentElement) return;
+        select(el);
+      };
+
+      window.petalSelectChild = function (index) {
+        if (!selected) return;
+        var kids = visibleChildren(selected);
+        if (index < 0 || index >= kids.length) return;
+        select(kids[index]);
+      };
+    })();
+    """#
+}

--- a/SakuraRSS/Views/Petal/PetalElementPickerWebView.swift
+++ b/SakuraRSS/Views/Petal/PetalElementPickerWebView.swift
@@ -4,20 +4,32 @@ import WebKit
 /// `UIViewRepresentable` wrapping a `WKWebView` that injects a
 /// tap-to-identify overlay into fetched HTML.
 ///
-/// Every element tap produces a `PickedElement` sent back via
-/// `onElementPicked`.  Navigation is blocked so tapping links
-/// doesn't leave the picker.
+/// Every element tap produces a `PickedElement` (the selected
+/// element plus its ancestor chain and visible direct children)
+/// sent back via `onElementPicked`.  Navigation is blocked so
+/// tapping links doesn't leave the picker.
 struct PetalElementPickerWebView: UIViewRepresentable {
 
     let html: String
     let baseURL: URL?
+    let controller: PetalElementPickerController
     let onElementPicked: (PickedElement) -> Void
 
-    /// Metadata the JS overlay sends back when the user taps.
-    struct PickedElement {
+    /// A single element's summary (selector + preview text + tag).
+    struct ElementInfo: Hashable, Sendable {
         let selector: String
         let text: String
         let tag: String
+    }
+
+    /// The full payload the JS overlay sends back when a tap or
+    /// breadcrumb/child navigation changes the selection.
+    struct PickedElement {
+        let selected: ElementInfo
+        /// Immediate parent first, root-most ancestor last.
+        let ancestors: [ElementInfo]
+        /// Direct visible children of `selected`, in DOM order.
+        let children: [ElementInfo]
     }
 
     func makeCoordinator() -> Coordinator {
@@ -25,165 +37,28 @@ struct PetalElementPickerWebView: UIViewRepresentable {
     }
 
     func makeUIView(context: Context) -> WKWebView {
-        let controller = WKUserContentController()
-        controller.add(context.coordinator, name: "elementPicked")
-        controller.addUserScript(WKUserScript(
+        let userController = WKUserContentController()
+        userController.add(context.coordinator, name: "elementPicked")
+        userController.addUserScript(WKUserScript(
             source: Self.injectionJS,
             injectionTime: .atDocumentEnd,
             forMainFrameOnly: true
         ))
         let config = WKWebViewConfiguration()
-        config.userContentController = controller
+        config.userContentController = userController
         let webView = WKWebView(frame: .zero, configuration: config)
         webView.navigationDelegate = context.coordinator
         webView.allowsLinkPreview = false
         webView.loadHTMLString(html, baseURL: baseURL)
+        controller.webView = webView
         return webView
     }
 
-    func updateUIView(_ uiView: WKWebView, context: Context) {}
+    func updateUIView(_ uiView: WKWebView, context: Context) {
+        controller.webView = uiView
+    }
 
     static func dismantleUIView(_ uiView: WKWebView, coordinator: Coordinator) {
         uiView.configuration.userContentController.removeScriptMessageHandler(forName: "elementPicked")
     }
-}
-
-// MARK: - Coordinator
-
-extension PetalElementPickerWebView {
-
-    final class Coordinator: NSObject, WKScriptMessageHandler, WKNavigationDelegate {
-
-        let onElementPicked: (PickedElement) -> Void
-
-        init(onElementPicked: @escaping (PickedElement) -> Void) {
-            self.onElementPicked = onElementPicked
-        }
-
-        func userContentController(
-            _ userContentController: WKUserContentController,
-            didReceive message: WKScriptMessage
-        ) {
-            guard message.name == "elementPicked",
-                  let body = message.body as? [String: Any],
-                  let selector = body["selector"] as? String,
-                  !selector.isEmpty else { return }
-            let element = PickedElement(
-                selector: selector,
-                text: body["text"] as? String ?? "",
-                tag: body["tag"] as? String ?? ""
-            )
-            DispatchQueue.main.async { self.onElementPicked(element) }
-        }
-
-        func webView(
-            _ webView: WKWebView,
-            decidePolicyFor action: WKNavigationAction,
-            decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
-        ) {
-            decisionHandler(action.navigationType == .linkActivated ? .cancel : .allow)
-        }
-    }
-}
-
-// MARK: - Injection script
-
-private extension PetalElementPickerWebView {
-
-    /// JavaScript injected at document-end.  Adds a touch-highlight
-    /// and sends a compact CSS selector back to Swift when the user
-    /// taps any element.
-    static let injectionJS = #"""
-    (function () {
-      var style = document.createElement('style');
-      style.textContent =
-        '*, *::before, *::after {' +
-        '  -webkit-tap-highlight-color: transparent !important;' +
-        '  -webkit-touch-callout: none !important;' +
-        '  -webkit-user-select: none !important;' +
-        '  user-select: none !important;' +
-        '  pointer-events: auto !important;' +
-        '}' +
-        '.petal-tap { outline: 3px solid rgba(255,59,48,0.8) !important; }';
-      document.head.appendChild(style);
-
-      document.addEventListener('contextmenu', function (e) {
-        e.preventDefault();
-      }, true);
-
-      function cssEscape(v) {
-        return (typeof CSS !== 'undefined' && CSS.escape)
-          ? CSS.escape(v) : v.replace(/([^\w-])/g, '\\$1');
-      }
-
-      function compact(el) {
-        var tag = el.tagName.toLowerCase();
-        var id = el.getAttribute('id');
-        if (id) return '#' + cssEscape(id);
-        var cls = null;
-        el.classList.forEach(function (c) {
-          if (!cls && c.indexOf('petal-') !== 0) cls = c;
-        });
-        return cls ? tag + '.' + cls : tag;
-      }
-
-      var selected = null;
-
-      // Elements whose only rendered content is visually hidden
-      // (e.g. `.sr-only` link overlays that Webflow and similar CMSes
-      // use to make a whole card clickable) are not pickable targets —
-      // the user can't see them, so the picker should treat them as
-      // transparent and drill through to the real content below.
-      function isInvisibleOverlay(el) {
-        if (!el || el === document.body || el === document.documentElement) return true;
-        var textContent = (el.textContent || '').trim();
-        var innerText = (el.innerText || '').trim();
-        if (textContent.length > 0 && innerText.length === 0) return true;
-        if (!textContent && !el.querySelector('img, svg, video, canvas, picture')) {
-          return true;
-        }
-        return false;
-      }
-
-      function pickThroughOverlays(x, y, startEl) {
-        if (!isInvisibleOverlay(startEl)) return startEl;
-        var stack = document.elementsFromPoint(x, y);
-        for (var i = 0; i < stack.length; i++) {
-          if (!isInvisibleOverlay(stack[i])) return stack[i];
-        }
-        return startEl;
-      }
-
-      document.addEventListener('click', function (e) {
-        e.preventDefault();
-        e.stopImmediatePropagation();
-        var el = pickThroughOverlays(e.clientX, e.clientY, e.target);
-        if (!el || el === document.body || el === document.documentElement) return;
-
-        // Drill into a child when tapping the already-selected element.
-        if (selected && el === selected) {
-          var stack = document.elementsFromPoint(e.clientX, e.clientY);
-          for (var i = 0; i < stack.length; i++) {
-            if (selected.contains(stack[i]) && stack[i] !== selected
-                && !isInvisibleOverlay(stack[i])) {
-              el = stack[i];
-              break;
-            }
-          }
-          if (el === selected) return;
-        }
-
-        if (selected) selected.classList.remove('petal-tap');
-        selected = el;
-        el.classList.add('petal-tap');
-        var text = (el.innerText || el.textContent || '').trim()
-          .replace(/\s+/g, ' ').substring(0, 100);
-        window.webkit.messageHandlers.elementPicked.postMessage({
-          selector: compact(el),
-          text: text,
-          tag: el.tagName.toLowerCase()
-        });
-      }, true);
-    })();
-    """#
 }

--- a/SakuraRSS/Views/Petal/PetalRecipeField.swift
+++ b/SakuraRSS/Views/Petal/PetalRecipeField.swift
@@ -1,9 +1,7 @@
 import Foundation
 
 /// Every recipe slot the element picker knows how to assign a
-/// selector to.  Shared between `PetalElementPickerView` (which
-/// renders chips + decides where to write) and
-/// `PetalElementAssignSheet` (which presents the menu).
+/// selector to.
 enum PetalRecipeField: CaseIterable {
     case item, title, link, date, author, summary, image
 
@@ -16,6 +14,35 @@ enum PetalRecipeField: CaseIterable {
         case .author:  String(localized: "Picker.Field.Author",  table: "Petal")
         case .summary: String(localized: "Picker.Field.Summary", table: "Petal")
         case .image:   String(localized: "Picker.Field.Image",   table: "Petal")
+        }
+    }
+
+    /// Current selector stored in the recipe for this field, if any.
+    func selector(in recipe: PetalRecipe) -> String? {
+        let value: String?
+        switch self {
+        case .item:    value = recipe.itemSelector
+        case .title:   value = recipe.titleSelector
+        case .link:    value = recipe.linkSelector
+        case .date:    value = recipe.dateSelector
+        case .author:  value = recipe.authorSelector
+        case .summary: value = recipe.summarySelector
+        case .image:   value = recipe.imageSelector
+        }
+        guard let value, !value.isEmpty else { return nil }
+        return value
+    }
+
+    /// Writes `selector` into this field on the recipe.
+    func assign(_ selector: String, to recipe: inout PetalRecipe) {
+        switch self {
+        case .item:    recipe.itemSelector = selector
+        case .title:   recipe.titleSelector = selector
+        case .link:    recipe.linkSelector = selector
+        case .date:    recipe.dateSelector = selector
+        case .author:  recipe.authorSelector = selector
+        case .summary: recipe.summarySelector = selector
+        case .image:   recipe.imageSelector = selector
         }
     }
 }

--- a/Shared/Strings/Petal.xcstrings
+++ b/Shared/Strings/Petal.xcstrings
@@ -1,3251 +1,3487 @@
 {
-  "sourceLanguage" : "en",
-  "strings" : {
-    "About.Body" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mit Web-Feeds kannst du eigene Feeds von jeder Webseite erstellen, auch ohne RSS."
+  "sourceLanguage": "en",
+  "strings": {
+    "About.Body": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mit Web-Feeds kannst du eigene Feeds von jeder Webseite erstellen, auch ohne RSS."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Web Feeds lets you create custom feeds from any website, even those without RSS."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Web Feeds lets you create custom feeds from any website, even those without RSS."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Web Feeds vous permet de créer des flux personnalisés depuis n'importe quel site web, même sans RSS."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Web Feeds vous permet de créer des flux personnalisés depuis n'importe quel site web, même sans RSS."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Web Feeds ti permette di creare feed personalizzati da qualsiasi sito web, anche senza RSS."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Web Feeds ti permette di creare feed personalizzati da qualsiasi sito web, anche senza RSS."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "WebフィードはRSSのないサイトからもカスタムフィードを作成できます。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WebフィードはRSSのないサイトからもカスタムフィードを作成できます。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "웹 피드를 사용하면 RSS가 없는 사이트에서도 맞춤 피드를 만들 수 있습니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "웹 피드를 사용하면 RSS가 없는 사이트에서도 맞춤 피드를 만들 수 있습니다."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Web Feeds cho phép bạn tạo nguồn cấp tùy chỉnh từ bất kỳ trang web nào, kể cả những trang không có RSS."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Web Feeds cho phép bạn tạo nguồn cấp tùy chỉnh từ bất kỳ trang web nào, kể cả những trang không có RSS."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "网页订阅源让你从任何网站创建自定义订阅源，即使没有 RSS 也可以。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "网页订阅源让你从任何网站创建自定义订阅源，即使没有 RSS 也可以。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "網頁訂閱源讓你從任何網站建立自訂訂閱源，即使沒有 RSS 也可以。"
-          }
-        }
-      }
-    },
-    "About.Header" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Über Web-Feeds"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "About Web Feeds"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "À propos des flux web"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Informazioni sui feed web"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Webフィードについて"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "웹 피드 정보"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Giới thiệu về Web Feeds"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "关于网页订阅源"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "關於網頁訂閱源"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "網頁訂閱源讓你從任何網站建立自訂訂閱源，即使沒有 RSS 也可以。"
           }
         }
       }
     },
-    "AddFeed.Generate" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Web-Feed generieren"
+    "About.Header": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Über Web-Feeds"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Generate Web Feed"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "About Web Feeds"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Générer un flux web"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "À propos des flux web"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Genera feed web"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Informazioni sui feed web"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Webフィードを生成"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Webフィードについて"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "웹 피드 생성"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "웹 피드 정보"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tạo nguồn cấp web"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giới thiệu về Web Feeds"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "生成网页订阅源"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关于网页订阅源"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "產生網頁訂閱源"
-          }
-        }
-      }
-    },
-    "AddFeed.GenerateFooter" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kein RSS-Feed gefunden. Mit von dir gewählten Selektoren kann direkt auf dem Gerät ein Feed aus der Seite erstellt werden."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No RSS feed was found. Web Feeds can build one on-device by scraping the page with selectors you choose."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aucun flux RSS trouvé. Web Feeds peut en créer un sur l’appareil en analysant la page avec les sélecteurs de votre choix."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nessun feed RSS trovato. Web Feeds può crearne uno sul dispositivo analizzando la pagina con i selettori che scegli."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "RSSフィードが見つかりませんでした。選択したセレクタでページをスクレイピングし、デバイス上でWebフィードを作成できます。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "RSS 피드를 찾을 수 없습니다. 선택한 선택자로 페이지를 스크레이핑하여 기기에서 웹 피드를 만들 수 있습니다."
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Không tìm thấy nguồn RSS. Web Feeds có thể tạo một nguồn ngay trên thiết bị bằng cách trích xuất trang với các bộ chọn bạn chọn."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "未找到 RSS 订阅源。可以使用你选择的选择器在设备上抓取该页面并生成网页订阅源。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "找不到 RSS 訂閱源。可以使用你選擇的選擇器在裝置上抓取該頁面並產生網頁訂閱源。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "關於網頁訂閱源"
           }
         }
       }
     },
-    "Builder.AutoDetect" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Automatisch erkennen"
+    "AddFeed.Generate": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Web-Feed generieren"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Auto-Detect"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Generate Web Feed"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Détection automatique"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Générer un flux web"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rilevamento automatico"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Genera feed web"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "自動検出"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Webフィードを生成"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "자동 감지"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "웹 피드 생성"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tự động phát hiện"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tạo nguồn cấp web"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "自动检测"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "生成网页订阅源"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "自動偵測"
-          }
-        }
-      }
-    },
-    "Builder.AutoDetect.Failed" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Selektoren konnten nicht automatisch erkannt werden. Bitte manuell eingeben."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Could not auto-detect selectors. Try entering them manually."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impossible de détecter automatiquement les sélecteurs. Essayez de les saisir manuellement."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impossibile rilevare automaticamente i selettori. Prova a inserirli manualmente."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "セレクタを自動検出できませんでした。手動で入力してください。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "선택자를 자동으로 감지할 수 없습니다. 직접 입력해 보세요."
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Không thể tự động phát hiện các bộ chọn. Hãy thử nhập thủ công."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "无法自动检测选择器，请尝试手动输入。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "無法自動偵測選擇器，請嘗試手動輸入。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "產生網頁訂閱源"
           }
         }
       }
     },
-    "Builder.DateSelector" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Datum-Selektor"
+    "AddFeed.GenerateFooter": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kein RSS-Feed gefunden. Mit von dir gewählten Selektoren kann direkt auf dem Gerät ein Feed aus der Seite erstellt werden."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Date selector"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No RSS feed was found. Web Feeds can build one on-device by scraping the page with selectors you choose."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sélecteur de date"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun flux RSS trouvé. Web Feeds peut en créer un sur l’appareil en analysant la page avec les sélecteurs de votre choix."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Selettore data"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nessun feed RSS trovato. Web Feeds può crearne uno sul dispositivo analizzando la pagina con i selettori che scegli."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "日付セレクタ"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RSSフィードが見つかりませんでした。選択したセレクタでページをスクレイピングし、デバイス上でWebフィードを作成できます。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "날짜 선택자"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RSS 피드를 찾을 수 없습니다. 선택한 선택자로 페이지를 스크레이핑하여 기기에서 웹 피드를 만들 수 있습니다."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bộ chọn ngày"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Không tìm thấy nguồn RSS. Web Feeds có thể tạo một nguồn ngay trên thiết bị bằng cách trích xuất trang với các bộ chọn bạn chọn."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "日期选择器"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未找到 RSS 订阅源。可以使用你选择的选择器在设备上抓取该页面并生成网页订阅源。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "日期選擇器"
-          }
-        }
-      }
-    },
-    "Builder.Delete" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Web-Feed löschen"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Delete Web Feed"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Supprimer le flux web"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Elimina feed web"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Webフィードを削除"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "웹 피드 삭제"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Xóa nguồn cấp web"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "删除网页订阅源"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "刪除網頁訂閱源"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "找不到 RSS 訂閱源。可以使用你選擇的選擇器在裝置上抓取該頁面並產生網頁訂閱源。"
           }
         }
       }
     },
-    "Builder.DeleteConfirm.Message" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Das Rezept und die abgerufenen Artikel werden entfernt. Dies kann nicht rückgängig gemacht werden."
+    "Builder.AutoDetect": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatisch erkennen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The recipe and its fetched articles will be removed. This cannot be undone."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auto-Detect"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La recette et les articles récupérés seront supprimés. Cette action est irréversible."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Détection automatique"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La ricetta e gli articoli recuperati verranno rimossi. L’operazione non può essere annullata."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rilevamento automatico"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "レシピと取得した記事が削除されます。この操作は取り消せません。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自動検出"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "레시피와 가져온 기사가 삭제됩니다. 이 작업은 취소할 수 없습니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "자동 감지"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Công thức và các bài viết đã tải sẽ bị xóa. Hành động này không thể hoàn tác."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tự động phát hiện"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "配方及其已抓取的文章将被移除。此操作无法撤销。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自动检测"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "配方及其已抓取的文章將被移除。此操作無法復原。"
-          }
-        }
-      }
-    },
-    "Builder.DeleteConfirm.Title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Diesen Web-Feed löschen?"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Delete this Web Feed?"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Supprimer ce flux web ?"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eliminare questo feed web?"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "このWebフィードを削除しますか？"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "이 웹 피드를 삭제하시겠습니까?"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Xóa nguồn cấp web này?"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "要删除此网页订阅源吗？"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "要刪除此網頁訂閱源嗎？"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自動偵測"
           }
         }
       }
     },
-    "Builder.Fetch" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abrufen und Vorschau"
+    "Builder.AutoDetect.Failed": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selektoren konnten nicht automatisch erkannt werden. Bitte manuell eingeben."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fetch & Preview"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not auto-detect selectors. Try entering them manually."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Récupérer et prévisualiser"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossible de détecter automatiquement les sélecteurs. Essayez de les saisir manuellement."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Recupera e anteprima"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossibile rilevare automaticamente i selettori. Prova a inserirli manualmente."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "取得してプレビュー"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "セレクタを自動検出できませんでした。手動で入力してください。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "가져와서 미리보기"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "선택자를 자동으로 감지할 수 없습니다. 직접 입력해 보세요."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tải và xem trước"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Không thể tự động phát hiện các bộ chọn. Hãy thử nhập thủ công."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "抓取并预览"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法自动检测选择器，请尝试手动输入。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "抓取並預覽"
-          }
-        }
-      }
-    },
-    "Builder.FetchMode" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abrufmodus"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fetch mode"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mode de récupération"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modalità di recupero"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "取得モード"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "가져오기 모드"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chế độ tải"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "抓取模式"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "抓取模式"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無法自動偵測選擇器，請嘗試手動輸入。"
           }
         }
       }
     },
-    "Builder.FetchMode.Rendered" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gerendert (für SPAs)"
+    "Builder.DateSelector": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Datum-Selektor"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rendered (for SPAs)"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Date selector"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rendu (pour les SPA)"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sélecteur de date"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Renderizzato (per SPA)"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selettore data"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "レンダリング済み（SPA向け）"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "日付セレクタ"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "렌더링됨(SPA용)"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "날짜 선택자"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Đã kết xuất (cho SPA)"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bộ chọn ngày"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "已渲染（适用于 SPA）"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "日期选择器"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "已渲染（適用於 SPA）"
-          }
-        }
-      }
-    },
-    "Builder.FetchMode.Static" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Statisches HTML"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Static HTML"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "HTML statique"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "HTML statico"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "静的HTML"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "정적 HTML"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "HTML tĩnh"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "静态 HTML"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "靜態 HTML"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "日期選擇器"
           }
         }
       }
     },
-    "Builder.ImageSelector" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bild-Selektor"
+    "Builder.Delete": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Web-Feed löschen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Image selector"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete Web Feed"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sélecteur d’image"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supprimer le flux web"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Selettore immagine"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elimina feed web"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "画像セレクタ"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Webフィードを削除"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "이미지 선택자"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "웹 피드 삭제"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bộ chọn ảnh"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Xóa nguồn cấp web"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "图片选择器"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "删除网页订阅源"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "圖片選擇器"
-          }
-        }
-      }
-    },
-    "Builder.ItemSelector" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Element-Selektor (erforderlich)"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Item selector (required)"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sélecteur d’élément (obligatoire)"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Selettore elemento (obbligatorio)"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "アイテムセレクタ（必須）"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "항목 선택자(필수)"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bộ chọn mục (bắt buộc)"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "条目选择器（必填）"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "條目選擇器（必填）"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "刪除網頁訂閱源"
           }
         }
       }
     },
-    "Builder.LinkSelector" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Link-Selektor"
+    "Builder.DeleteConfirm.Message": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das Rezept und die abgerufenen Artikel werden entfernt. Dies kann nicht rückgängig gemacht werden."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Link selector"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The recipe and its fetched articles will be removed. This cannot be undone."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sélecteur de lien"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La recette et les articles récupérés seront supprimés. Cette action est irréversible."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Selettore link"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La ricetta e gli articoli recuperati verranno rimossi. L’operazione non può essere annullata."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "リンクセレクタ"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "レシピと取得した記事が削除されます。この操作は取り消せません。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "링크 선택자"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "레시피와 가져온 기사가 삭제됩니다. 이 작업은 취소할 수 없습니다."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bộ chọn liên kết"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Công thức và các bài viết đã tải sẽ bị xóa. Hành động này không thể hoàn tác."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "链接选择器"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "配方及其已抓取的文章将被移除。此操作无法撤销。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "連結選擇器"
-          }
-        }
-      }
-    },
-    "Builder.Name.Placeholder" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Feed-Name"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Feed name"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nom du flux"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nome del feed"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "フィード名"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "피드 이름"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tên nguồn cấp"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "订阅源名称"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "訂閱源名稱"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "配方及其已抓取的文章將被移除。此操作無法復原。"
           }
         }
       }
     },
-    "Builder.PickElements" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Elemente auswählen"
+    "Builder.DeleteConfirm.Title": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diesen Web-Feed löschen?"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pick Elements"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete this Web Feed?"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Choisir des éléments"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supprimer ce flux web ?"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seleziona elementi"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminare questo feed web?"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "要素を選択"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このWebフィードを削除しますか？"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "요소 선택"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 웹 피드를 삭제하시겠습니까?"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chọn phần tử"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Xóa nguồn cấp web này?"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "选取元素"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "要删除此网页订阅源吗？"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "選取元素"
-          }
-        }
-      }
-    },
-    "Builder.Preview.Empty" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keine Einträge gefunden. Versuche einen allgemeineren Element-Selektor."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No items matched. Try a broader item selector."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aucun élément correspondant. Essayez un sélecteur d’élément plus large."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nessun elemento corrispondente. Prova un selettore di elemento più ampio."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "一致するアイテムがありません。より広いアイテムセレクタを試してください。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "일치하는 항목이 없습니다. 더 넓은 항목 선택자를 사용해 보세요."
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Không có mục nào khớp. Hãy thử bộ chọn mục rộng hơn."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "没有匹配到任何条目。请尝试更宽松的条目选择器。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "沒有比對到任何條目。請嘗試更寬鬆的條目選擇器。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "要刪除此網頁訂閱源嗎？"
           }
         }
       }
     },
-    "Builder.Preview.TapFetch" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tippe auf „Abrufen und Vorschau“, um die Seite zu laden."
+    "Builder.Fetch": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrufen und Vorschau"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tap Fetch & Preview to load the page."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fetch & Preview"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Touchez « Récupérer et prévisualiser » pour charger la page."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Récupérer et prévisualiser"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tocca «Recupera e anteprima» per caricare la pagina."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recupera e anteprima"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "「取得してプレビュー」をタップしてページを読み込みます。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取得してプレビュー"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "‘가져와서 미리보기’를 탭하여 페이지를 불러오세요."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "가져와서 미리보기"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chạm vào “Tải và xem trước” để tải trang."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tải và xem trước"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "点按“抓取并预览”以加载页面。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "抓取并预览"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "點一下「抓取並預覽」以載入頁面。"
-          }
-        }
-      }
-    },
-    "Builder.Section.Preview" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vorschau"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preview"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aperçu"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anteprima"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "プレビュー"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "미리보기"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Xem trước"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "预览"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "預覽"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "抓取並預覽"
           }
         }
       }
     },
-    "Builder.Section.Selectors" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Selektoren"
+    "Builder.FetchMode": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrufmodus"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Selectors"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fetch mode"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sélecteurs"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mode de récupération"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Selettori"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modalità di recupero"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "セレクタ"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取得モード"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "선택자"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "가져오기 모드"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bộ chọn"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chế độ tải"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "选择器"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "抓取模式"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "選擇器"
-          }
-        }
-      }
-    },
-    "Builder.Section.SelectorsFooter" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Jeder Selektor wird relativ zu einem Element ausgeführt. Lass ein Feld leer, damit der Wert automatisch aus dem Inhalt des Elements ermittelt wird."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Each selector runs relative to an item. Leave a field empty to auto-detect the value from the item's own content."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chaque sélecteur s’applique par rapport à un élément. Laissez un champ vide pour détecter automatiquement la valeur à partir du contenu de l’élément."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ogni selettore viene eseguito in relazione a un elemento. Lascia un campo vuoto per rilevare automaticamente il valore dal contenuto dell’elemento."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "各セレクタはアイテムを基準に実行されます。フィールドを空のままにすると、アイテム自体の内容から自動的に推測します。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "각 선택자는 항목을 기준으로 실행됩니다. 필드를 비워 두면 항목 자체의 콘텐츠에서 값을 자동으로 감지합니다."
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mỗi bộ chọn chạy tương đối với một mục. Để trống một trường để tự động phát hiện giá trị từ nội dung của chính mục đó."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "每个选择器都会相对于条目运行。留空某个字段可从条目自身的内容中自动推断。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "每個選擇器都會相對於條目執行。留空某個欄位可從條目自身的內容中自動推斷。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "抓取模式"
           }
         }
       }
     },
-    "Builder.Section.Source" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Quelle"
+    "Builder.FetchMode.Rendered": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gerendert (für SPAs)"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Source"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rendered (for SPAs)"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Source"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rendu (pour les SPA)"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Origine"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Renderizzato (per SPA)"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ソース"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "レンダリング済み（SPA向け）"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "소스"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "렌더링됨(SPA용)"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nguồn"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đã kết xuất (cho SPA)"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "来源"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已渲染（适用于 SPA）"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "來源"
-          }
-        }
-      }
-    },
-    "Builder.Section.SourceFooter" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Im gerenderten Modus wird die Seite in einer Webansicht geladen und auf die JavaScript-Ausführung gewartet. Verwende ihn für React oder andere Single-Page-Apps."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rendered mode loads the page in a web view and waits for JavaScript to run. Use it for React or other single-page apps."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le mode rendu charge la page dans une vue web et attend l’exécution du JavaScript. Utilisez-le pour React ou d’autres applications à page unique."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La modalità renderizzata carica la pagina in una vista web e attende l’esecuzione del JavaScript. Usala per React o altre app a pagina singola."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "レンダリングモードはページをWebビューで読み込み、JavaScriptの実行を待ちます。Reactなどのシングルページアプリに使用してください。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "렌더링 모드는 웹 뷰에서 페이지를 불러오고 JavaScript가 실행될 때까지 기다립니다. React 또는 기타 싱글 페이지 앱에 사용하세요."
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chế độ kết xuất tải trang trong một web view và chờ JavaScript chạy. Dùng cho React hoặc các ứng dụng một trang khác."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "渲染模式会在 Web 视图中加载页面并等待 JavaScript 执行。适用于 React 或其他单页应用。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "渲染模式會在 Web 檢視中載入頁面並等待 JavaScript 執行。適用於 React 或其他單頁應用。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已渲染（適用於 SPA）"
           }
         }
       }
     },
-    "Builder.SummarySelector" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zusammenfassung-Selektor"
+    "Builder.FetchMode.Static": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Statisches HTML"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Summary selector"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Static HTML"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sélecteur de résumé"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HTML statique"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Selettore riepilogo"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HTML statico"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "概要セレクタ"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "静的HTML"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "요약 선택자"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "정적 HTML"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bộ chọn tóm tắt"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HTML tĩnh"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "摘要选择器"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "静态 HTML"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "摘要選擇器"
-          }
-        }
-      }
-    },
-    "Builder.Title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Web-Feed"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Web Feed"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Flux web"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Feed web"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Webフィード"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "웹 피드"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nguồn cấp web"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "网页订阅源"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "網頁訂閱源"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "靜態 HTML"
           }
         }
       }
     },
-    "Builder.TitleSelector" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Titel-Selektor"
+    "Builder.ImageSelector": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bild-Selektor"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Title selector"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Image selector"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sélecteur de titre"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sélecteur d’image"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Selettore titolo"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selettore immagine"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "タイトルセレクタ"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "画像セレクタ"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "제목 선택자"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이미지 선택자"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bộ chọn tiêu đề"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bộ chọn ảnh"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "标题选择器"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "图片选择器"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "標題選擇器"
-          }
-        }
-      }
-    },
-    "Builder.URL.Placeholder" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "https://example.com/blog"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "https://example.com/blog"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "https://example.com/blog"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "https://example.com/blog"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "https://example.com/blog"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "https://example.com/blog"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "https://example.com/blog"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "https://example.com/blog"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "https://example.com/blog"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "圖片選擇器"
           }
         }
       }
     },
-    "Error.FetchFailed" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Die Seite konnte nicht geladen werden. Überprüfe die URL oder versuche den gerenderten Modus."
+    "Builder.ItemSelector": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Element-Selektor (erforderlich)"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couldn't load that page. Check the URL or try rendered mode."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Item selector (required)"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impossible de charger cette page. Vérifiez l’URL ou essayez le mode rendu."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sélecteur d’élément (obligatoire)"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impossibile caricare la pagina. Controlla l’URL o prova la modalità renderizzata."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selettore elemento (obbligatorio)"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ページを読み込めませんでした。URLを確認するか、レンダリングモードをお試しください。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アイテムセレクタ（必須）"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "해당 페이지를 불러올 수 없습니다. URL을 확인하거나 렌더링 모드를 사용해 보세요."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "항목 선택자(필수)"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Không thể tải trang đó. Hãy kiểm tra URL hoặc thử chế độ kết xuất."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bộ chọn mục (bắt buộc)"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "无法加载该页面。请检查网址或尝试渲染模式。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "条目选择器（必填）"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "無法載入該頁面。請檢查網址或嘗試渲染模式。"
-          }
-        }
-      }
-    },
-    "Error.ImportFailed" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Das Paket konnte nicht importiert werden."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couldn't import that package."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impossible d’importer ce paquet."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impossibile importare il pacchetto."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "パッケージを読み込めませんでした。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "해당 패키지를 가져올 수 없습니다."
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Không thể nhập gói đó."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "无法导入该包。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "無法匯入該套件。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "條目選擇器（必填）"
           }
         }
       }
     },
-    "Error.NoMatches" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keine Einträge mit den aktuellen Selektoren gefunden."
+    "Builder.LinkSelector": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Link-Selektor"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No items matched the current selectors."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Link selector"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aucun élément ne correspond aux sélecteurs actuels."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sélecteur de lien"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nessun elemento corrisponde ai selettori attuali."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selettore link"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "現在のセレクタに一致するアイテムはありません。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リンクセレクタ"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "현재 선택자와 일치하는 항목이 없습니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "링크 선택자"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Không có mục nào khớp với các bộ chọn hiện tại."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bộ chọn liên kết"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "当前选择器没有匹配到任何条目。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "链接选择器"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "目前的選擇器沒有比對到任何條目。"
-          }
-        }
-      }
-    },
-    "Error.PackageMalformed" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Das sieht nicht nach einem gültigen Sakura-RSS-Paket aus."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This doesn't look like a valid Sakura RSS package."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cela ne ressemble pas à un paquet Sakura RSS valide."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Non sembra un pacchetto Sakura RSS valido."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "有効なRSSパッケージではないようです。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "유효한 Sakura RSS 패키지가 아닌 것 같습니다."
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Đây không giống một gói Sakura RSS hợp lệ."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "这看起来不是有效的 Sakura RSS 包。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "這看起來不是有效的 Sakura RSS 套件。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "連結選擇器"
           }
         }
       }
     },
-    "Error.PackageMissingRecipe" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Im Paket fehlt die Rezeptdatei."
+    "Builder.Name.Placeholder": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Feed-Name"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The package is missing a recipe file."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Feed name"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Il manque un fichier de recette dans le paquet."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nom du flux"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Il pacchetto non contiene il file della ricetta."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nome del feed"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "パッケージにレシピファイルが含まれていません。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フィード名"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "패키지에 레시피 파일이 없습니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "피드 이름"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gói thiếu tệp công thức."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tên nguồn cấp"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "该包缺少配方文件。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "订阅源名称"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "該套件缺少配方檔案。"
-          }
-        }
-      }
-    },
-    "Error.PackageTooLarge" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dieses Paket ist größer, als Sakura importieren kann."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This package is larger than Sakura will import."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ce paquet est plus volumineux que ce que Sakura accepte d’importer."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Questo pacchetto è più grande di quanto Sakura possa importare."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "このパッケージはサクラリーダーが読み込める上限を超えています。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "이 패키지는 Sakura가 가져올 수 있는 크기보다 큽니다."
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gói này lớn hơn mức Sakura có thể nhập."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "此包超出了 Sakura 可导入的大小。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "此套件超出了 Sakura 可匯入的大小。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "訂閱源名稱"
           }
         }
       }
     },
-    "Error.PackageUnsupportedVersion" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dieses Paket wurde mit einer neueren Version von Sakura erstellt. Aktualisiere die App und versuche es erneut."
+    "Builder.PickElements": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elemente auswählen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This package was made with a newer version of Sakura. Update the app and try again."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pick Elements"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ce paquet a été créé avec une version plus récente de Sakura. Mettez l’application à jour et réessayez."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choisir des éléments"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Questo pacchetto è stato creato con una versione più recente di Sakura. Aggiorna l’app e riprova."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seleziona elementi"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "このパッケージはより新しいバージョンのサクラリーダーで作成されました。アプリを更新してからもう一度お試しください。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "要素を選択"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "이 패키지는 더 최신 버전의 Sakura에서 만들어졌습니다. 앱을 업데이트한 후 다시 시도하세요."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "요소 선택"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gói này được tạo bằng phiên bản Sakura mới hơn. Hãy cập nhật ứng dụng và thử lại."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chọn phần tử"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "此包是用更新版本的 Sakura 制作的。请更新应用后重试。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选取元素"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "此套件是用更新版本的 Sakura 製作的。請更新 App 後重試。"
-          }
-        }
-      }
-    },
-    "Error.Title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Web-Feeds"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Web Feeds"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Flux web"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Feed web"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Webフィード"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "웹 피드"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nguồn cấp web"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "网页订阅源"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "網頁訂閱源"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選取元素"
           }
         }
       }
     },
-    "FeedEdit.EditRecipe" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rezept bearbeiten"
+    "Builder.Preview.Empty": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Einträge gefunden. Versuche einen allgemeineren Element-Selektor."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Edit Recipe"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No items matched. Try a broader item selector."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modifier la recette"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun élément correspondant. Essayez un sélecteur d’élément plus large."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modifica ricetta"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nessun elemento corrispondente. Prova un selettore di elemento più ampio."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "レシピを編集"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一致するアイテムがありません。より広いアイテムセレクタを試してください。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "레시피 편집"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "일치하는 항목이 없습니다. 더 넓은 항목 선택자를 사용해 보세요."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chỉnh sửa công thức"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Không có mục nào khớp. Hãy thử bộ chọn mục rộng hơn."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "编辑配方"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有匹配到任何条目。请尝试更宽松的条目选择器。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "編輯配方"
-          }
-        }
-      }
-    },
-    "FeedEdit.Header" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Web-Feed"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Web Feed"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Flux web"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Feed web"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Webフィード"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "웹 피드"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nguồn cấp web"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "网页订阅源"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "網頁訂閱源"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "沒有比對到任何條目。請嘗試更寬鬆的條目選擇器。"
           }
         }
       }
     },
-    "FeedEdit.SourceURL" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Quell-URL"
+    "Builder.Preview.TapFetch": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tippe auf „Abrufen und Vorschau“, um die Seite zu laden."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Source URL"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tap Fetch & Preview to load the page."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "URL source"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Touchez « Récupérer et prévisualiser » pour charger la page."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "URL sorgente"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tocca «Recupera e anteprima» per caricare la pagina."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ソースURL"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "「取得してプレビュー」をタップしてページを読み込みます。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "소스 URL"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "‘가져와서 미리보기’를 탭하여 페이지를 불러오세요."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "URL nguồn"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chạm vào “Tải và xem trước” để tải trang."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "来源 URL"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "点按“抓取并预览”以加载页面。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "來源 URL"
-          }
-        }
-      }
-    },
-    "Manage.Empty" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Noch keine Web-Feeds. Erstelle einen im Bildschirm „Feed hinzufügen“ oder importiere ein .srss-Paket."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No Web Feeds yet. Create one from the Add Feed screen, or import a .srss package."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aucun flux web pour le moment. Créez-en un depuis l’écran Ajouter un flux, ou importez un paquet .srss."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ancora nessun feed web. Creane uno dalla schermata Aggiungi feed oppure importa un pacchetto .srss."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "まだWebフィードがありません。「フィードを追加」画面で作成するか、.srssパッケージを読み込んでください。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "아직 웹 피드가 없습니다. '피드 추가' 화면에서 만들거나 .srss 패키지를 가져오세요."
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chưa có nguồn cấp web nào. Hãy tạo một nguồn từ màn hình Thêm nguồn cấp, hoặc nhập một gói .srss."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "还没有网页订阅源。可在“添加订阅源”界面创建，或导入 .srss 包。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "還沒有網頁訂閱源。可在「加入訂閱源」畫面建立，或匯入 .srss 套件。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "點一下「抓取並預覽」以載入頁面。"
           }
         }
       }
     },
-    "Manage.Export" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Als .srss exportieren"
+    "Builder.Section.Preview": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vorschau"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Export as .srss"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preview"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Exporter en .srss"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aperçu"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Esporta come .srss"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anteprima"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : ".srssとして書き出す"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プレビュー"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : ".srss로 내보내기"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "미리보기"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Xuất dưới dạng .srss"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Xem trước"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "导出为 .srss"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "预览"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "匯出為 .srss"
-          }
-        }
-      }
-    },
-    "Manage.Import" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : ".srss-Paket importieren"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Import .srss package"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Importer un paquet .srss"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Importa pacchetto .srss"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : ".srssパッケージを読み込む"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : ".srss 패키지 가져오기"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nhập gói .srss"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "导入 .srss 包"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "匯入 .srss 套件"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "預覽"
           }
         }
       }
     },
-    "Manage.ImportFooter" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sakura-RSS-Pakete (.srss) enthalten ein Rezept und ein optionales Feed-Symbol. Es wird nichts hochgeladen – der Import erfolgt vollständig auf dem Gerät."
+    "Builder.Section.Selectors": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selektoren"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sakura RSS packages (.srss) contain a recipe and an optional feed icon. Nothing is uploaded — import runs entirely on device."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selectors"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Les paquets Sakura RSS (.srss) contiennent une recette et, facultativement, une icône de flux. Rien n’est envoyé en ligne : l’importation se fait entièrement sur l’appareil."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sélecteurs"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "I pacchetti Sakura RSS (.srss) contengono una ricetta e un’icona del feed facoltativa. Non viene caricato nulla: l’importazione avviene interamente sul dispositivo."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selettori"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "RSSパッケージ（.srss）にはレシピとオプションのフィードアイコンが含まれます。アップロードは行われず、読み込みはすべてデバイス上で完了します。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "セレクタ"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sakura RSS 패키지(.srss)에는 레시피와 선택 사항인 피드 아이콘이 포함됩니다. 업로드되는 항목은 없으며 가져오기는 전적으로 기기에서 수행됩니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "선택자"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gói Sakura RSS (.srss) chứa một công thức và tùy chọn biểu tượng nguồn cấp. Không có gì được tải lên — việc nhập diễn ra hoàn toàn trên thiết bị."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bộ chọn"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sakura RSS 包（.srss）包含一个配方和可选的订阅源图标。不会上传任何内容——导入完全在设备上进行。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择器"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sakura RSS 套件（.srss）包含一個配方和選用的訂閱源圖示。不會上傳任何內容——匯入完全在裝置上進行。"
-          }
-        }
-      }
-    },
-    "Manage.Section.Installed" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installiert"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installed"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installés"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installati"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "インストール済み"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "설치됨"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Đã cài đặt"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "已安装"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "已安裝"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選擇器"
           }
         }
       }
     },
-    "Manage.Title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Web-Feeds verwalten"
+    "Builder.Section.SelectorsFooter": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jeder Selektor wird relativ zu einem Element ausgeführt. Lass ein Feld leer, damit der Wert automatisch aus dem Inhalt des Elements ermittelt wird."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Manage Web Feeds"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Each selector runs relative to an item. Leave a field empty to auto-detect the value from the item's own content."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gérer les flux web"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chaque sélecteur s’applique par rapport à un élément. Laissez un champ vide pour détecter automatiquement la valeur à partir du contenu de l’élément."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gestisci feed web"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ogni selettore viene eseguito in relazione a un elemento. Lascia un campo vuoto per rilevare automaticamente il valore dal contenuto dell’elemento."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Webフィードを管理"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "各セレクタはアイテムを基準に実行されます。フィールドを空のままにすると、アイテム自体の内容から自動的に推測します。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "웹 피드 관리"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "각 선택자는 항목을 기준으로 실행됩니다. 필드를 비워 두면 항목 자체의 콘텐츠에서 값을 자동으로 감지합니다."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Quản lý nguồn cấp web"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mỗi bộ chọn chạy tương đối với một mục. Để trống một trường để tự động phát hiện giá trị từ nội dung của chính mục đó."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "管理网页订阅源"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "每个选择器都会相对于条目运行。留空某个字段可从条目自身的内容中自动推断。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "管理網頁訂閱源"
-          }
-        }
-      }
-    },
-    "Picker.Field.Author" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Autor"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Author"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Auteur"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Autore"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "著者"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "작성자"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tác giả"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "作者"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "作者"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "每個選擇器都會相對於條目執行。留空某個欄位可從條目自身的內容中自動推斷。"
           }
         }
       }
     },
-    "Picker.Field.Date" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Datum"
+    "Builder.Section.Source": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quelle"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Date"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Source"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Date"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Source"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Data"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Origine"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "日付"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ソース"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "날짜"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "소스"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ngày"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nguồn"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "日期"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "来源"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "日期"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "來源"
           }
         }
       }
     },
-    "Picker.Field.Image" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bild"
+    "Builder.Section.SourceFooter": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Im gerenderten Modus wird die Seite in einer Webansicht geladen und auf die JavaScript-Ausführung gewartet. Verwende ihn für React oder andere Single-Page-Apps."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Image"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rendered mode loads the page in a web view and waits for JavaScript to run. Use it for React or other single-page apps."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Image"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le mode rendu charge la page dans une vue web et attend l’exécution du JavaScript. Utilisez-le pour React ou d’autres applications à page unique."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Immagine"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La modalità renderizzata carica la pagina in una vista web e attende l’esecuzione del JavaScript. Usala per React o altre app a pagina singola."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "画像"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "レンダリングモードはページをWebビューで読み込み、JavaScriptの実行を待ちます。Reactなどのシングルページアプリに使用してください。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "이미지"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "렌더링 모드는 웹 뷰에서 페이지를 불러오고 JavaScript가 실행될 때까지 기다립니다. React 또는 기타 싱글 페이지 앱에 사용하세요."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ảnh"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chế độ kết xuất tải trang trong một web view và chờ JavaScript chạy. Dùng cho React hoặc các ứng dụng một trang khác."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "图片"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "渲染模式会在 Web 视图中加载页面并等待 JavaScript 执行。适用于 React 或其他单页应用。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "圖片"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "渲染模式會在 Web 檢視中載入頁面並等待 JavaScript 執行。適用於 React 或其他單頁應用。"
           }
         }
       }
     },
-    "Picker.Field.Item" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Element-Container"
+    "Builder.SummarySelector": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zusammenfassung-Selektor"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Item Container"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Summary selector"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Conteneur d'élément"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sélecteur de résumé"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Contenitore elemento"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selettore riepilogo"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "アイテムコンテナ"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "概要セレクタ"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "항목 컨테이너"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "요약 선택자"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vùng chứa mục"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bộ chọn tóm tắt"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "条目容器"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "摘要选择器"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "條目容器"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "摘要選擇器"
           }
         }
       }
     },
-    "Picker.Field.Link" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Link"
+    "Builder.Title": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Web-Feed"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Link"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Web Feed"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lien"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Flux web"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Link"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Feed web"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "リンク"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Webフィード"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "링크"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "웹 피드"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Liên kết"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nguồn cấp web"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "链接"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "网页订阅源"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "連結"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "網頁訂閱源"
           }
         }
       }
     },
-    "Picker.Field.Summary" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zusammenfassung"
+    "Builder.TitleSelector": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Titel-Selektor"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Summary"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Title selector"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Résumé"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sélecteur de titre"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Riepilogo"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selettore titolo"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "概要"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タイトルセレクタ"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "요약"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "제목 선택자"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tóm tắt"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bộ chọn tiêu đề"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "摘要"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "标题选择器"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "摘要"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "標題選擇器"
           }
         }
       }
     },
-    "Picker.Field.Title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Titel"
+    "Builder.URL.Placeholder": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "https://example.com/blog"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Title"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "https://example.com/blog"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Titre"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "https://example.com/blog"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Titolo"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "https://example.com/blog"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "タイトル"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "https://example.com/blog"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "제목"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "https://example.com/blog"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tiêu đề"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "https://example.com/blog"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "标题"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "https://example.com/blog"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "標題"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "https://example.com/blog"
           }
         }
       }
     },
-    "Picker.Title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Elementauswahl"
+    "Error.FetchFailed": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Seite konnte nicht geladen werden. Überprüfe die URL oder versuche den gerenderten Modus."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Element Picker"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn't load that page. Check the URL or try rendered mode."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sélecteur d'éléments"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossible de charger cette page. Vérifiez l’URL ou essayez le mode rendu."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Selettore elementi"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossibile caricare la pagina. Controlla l’URL o prova la modalità renderizzata."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "要素を選択"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ページを読み込めませんでした。URLを確認するか、レンダリングモードをお試しください。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "요소 선택기"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "해당 페이지를 불러올 수 없습니다. URL을 확인하거나 렌더링 모드를 사용해 보세요."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Trình chọn phần tử"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Không thể tải trang đó. Hãy kiểm tra URL hoặc thử chế độ kết xuất."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "元素选取器"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法加载该页面。请检查网址或尝试渲染模式。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "元素選取器"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無法載入該頁面。請檢查網址或嘗試渲染模式。"
+          }
+        }
+      }
+    },
+    "Error.ImportFailed": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das Paket konnte nicht importiert werden."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn't import that package."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossible d’importer ce paquet."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossibile importare il pacchetto."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "パッケージを読み込めませんでした。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "해당 패키지를 가져올 수 없습니다."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Không thể nhập gói đó."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法导入该包。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無法匯入該套件。"
+          }
+        }
+      }
+    },
+    "Error.NoMatches": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Einträge mit den aktuellen Selektoren gefunden."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No items matched the current selectors."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun élément ne correspond aux sélecteurs actuels."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nessun elemento corrisponde ai selettori attuali."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "現在のセレクタに一致するアイテムはありません。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "현재 선택자와 일치하는 항목이 없습니다."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Không có mục nào khớp với các bộ chọn hiện tại."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "当前选择器没有匹配到任何条目。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "目前的選擇器沒有比對到任何條目。"
+          }
+        }
+      }
+    },
+    "Error.PackageMalformed": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das sieht nicht nach einem gültigen Sakura-RSS-Paket aus."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This doesn't look like a valid Sakura RSS package."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cela ne ressemble pas à un paquet Sakura RSS valide."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Non sembra un pacchetto Sakura RSS valido."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有効なRSSパッケージではないようです。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "유효한 Sakura RSS 패키지가 아닌 것 같습니다."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đây không giống một gói Sakura RSS hợp lệ."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "这看起来不是有效的 Sakura RSS 包。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "這看起來不是有效的 Sakura RSS 套件。"
+          }
+        }
+      }
+    },
+    "Error.PackageMissingRecipe": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Im Paket fehlt die Rezeptdatei."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The package is missing a recipe file."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Il manque un fichier de recette dans le paquet."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Il pacchetto non contiene il file della ricetta."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "パッケージにレシピファイルが含まれていません。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "패키지에 레시피 파일이 없습니다."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gói thiếu tệp công thức."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "该包缺少配方文件。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "該套件缺少配方檔案。"
+          }
+        }
+      }
+    },
+    "Error.PackageTooLarge": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dieses Paket ist größer, als Sakura importieren kann."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This package is larger than Sakura will import."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ce paquet est plus volumineux que ce que Sakura accepte d’importer."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Questo pacchetto è più grande di quanto Sakura possa importare."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このパッケージはサクラリーダーが読み込める上限を超えています。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 패키지는 Sakura가 가져올 수 있는 크기보다 큽니다."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gói này lớn hơn mức Sakura có thể nhập."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此包超出了 Sakura 可导入的大小。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此套件超出了 Sakura 可匯入的大小。"
+          }
+        }
+      }
+    },
+    "Error.PackageUnsupportedVersion": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dieses Paket wurde mit einer neueren Version von Sakura erstellt. Aktualisiere die App und versuche es erneut."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This package was made with a newer version of Sakura. Update the app and try again."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ce paquet a été créé avec une version plus récente de Sakura. Mettez l’application à jour et réessayez."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Questo pacchetto è stato creato con una versione più recente di Sakura. Aggiorna l’app e riprova."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このパッケージはより新しいバージョンのサクラリーダーで作成されました。アプリを更新してからもう一度お試しください。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 패키지는 더 최신 버전의 Sakura에서 만들어졌습니다. 앱을 업데이트한 후 다시 시도하세요."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gói này được tạo bằng phiên bản Sakura mới hơn. Hãy cập nhật ứng dụng và thử lại."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此包是用更新版本的 Sakura 制作的。请更新应用后重试。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此套件是用更新版本的 Sakura 製作的。請更新 App 後重試。"
+          }
+        }
+      }
+    },
+    "Error.Title": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Web-Feeds"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Web Feeds"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Flux web"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Feed web"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Webフィード"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "웹 피드"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nguồn cấp web"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "网页订阅源"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "網頁訂閱源"
+          }
+        }
+      }
+    },
+    "FeedEdit.EditRecipe": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rezept bearbeiten"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edit Recipe"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modifier la recette"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modifica ricetta"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "レシピを編集"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "레시피 편집"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chỉnh sửa công thức"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "编辑配方"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "編輯配方"
+          }
+        }
+      }
+    },
+    "FeedEdit.Header": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Web-Feed"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Web Feed"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Flux web"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Feed web"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Webフィード"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "웹 피드"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nguồn cấp web"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "网页订阅源"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "網頁訂閱源"
+          }
+        }
+      }
+    },
+    "FeedEdit.SourceURL": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quell-URL"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Source URL"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL source"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL sorgente"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ソースURL"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "소스 URL"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL nguồn"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "来源 URL"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "來源 URL"
+          }
+        }
+      }
+    },
+    "Manage.Empty": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Noch keine Web-Feeds. Erstelle einen im Bildschirm „Feed hinzufügen“ oder importiere ein .srss-Paket."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Web Feeds yet. Create one from the Add Feed screen, or import a .srss package."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun flux web pour le moment. Créez-en un depuis l’écran Ajouter un flux, ou importez un paquet .srss."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ancora nessun feed web. Creane uno dalla schermata Aggiungi feed oppure importa un pacchetto .srss."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "まだWebフィードがありません。「フィードを追加」画面で作成するか、.srssパッケージを読み込んでください。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "아직 웹 피드가 없습니다. '피드 추가' 화면에서 만들거나 .srss 패키지를 가져오세요."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chưa có nguồn cấp web nào. Hãy tạo một nguồn từ màn hình Thêm nguồn cấp, hoặc nhập một gói .srss."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "还没有网页订阅源。可在“添加订阅源”界面创建，或导入 .srss 包。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "還沒有網頁訂閱源。可在「加入訂閱源」畫面建立，或匯入 .srss 套件。"
+          }
+        }
+      }
+    },
+    "Manage.Export": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Als .srss exportieren"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Export as .srss"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exporter en .srss"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esporta come .srss"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": ".srssとして書き出す"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": ".srss로 내보내기"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Xuất dưới dạng .srss"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "导出为 .srss"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "匯出為 .srss"
+          }
+        }
+      }
+    },
+    "Manage.Import": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": ".srss-Paket importieren"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Import .srss package"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importer un paquet .srss"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importa pacchetto .srss"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": ".srssパッケージを読み込む"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": ".srss 패키지 가져오기"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nhập gói .srss"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "导入 .srss 包"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "匯入 .srss 套件"
+          }
+        }
+      }
+    },
+    "Manage.ImportFooter": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sakura-RSS-Pakete (.srss) enthalten ein Rezept und ein optionales Feed-Symbol. Es wird nichts hochgeladen – der Import erfolgt vollständig auf dem Gerät."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sakura RSS packages (.srss) contain a recipe and an optional feed icon. Nothing is uploaded — import runs entirely on device."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les paquets Sakura RSS (.srss) contiennent une recette et, facultativement, une icône de flux. Rien n’est envoyé en ligne : l’importation se fait entièrement sur l’appareil."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I pacchetti Sakura RSS (.srss) contengono una ricetta e un’icona del feed facoltativa. Non viene caricato nulla: l’importazione avviene interamente sul dispositivo."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RSSパッケージ（.srss）にはレシピとオプションのフィードアイコンが含まれます。アップロードは行われず、読み込みはすべてデバイス上で完了します。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sakura RSS 패키지(.srss)에는 레시피와 선택 사항인 피드 아이콘이 포함됩니다. 업로드되는 항목은 없으며 가져오기는 전적으로 기기에서 수행됩니다."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gói Sakura RSS (.srss) chứa một công thức và tùy chọn biểu tượng nguồn cấp. Không có gì được tải lên — việc nhập diễn ra hoàn toàn trên thiết bị."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sakura RSS 包（.srss）包含一个配方和可选的订阅源图标。不会上传任何内容——导入完全在设备上进行。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sakura RSS 套件（.srss）包含一個配方和選用的訂閱源圖示。不會上傳任何內容——匯入完全在裝置上進行。"
+          }
+        }
+      }
+    },
+    "Manage.Section.Installed": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installiert"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installed"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installés"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installati"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インストール済み"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "설치됨"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đã cài đặt"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已安装"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已安裝"
+          }
+        }
+      }
+    },
+    "Manage.Title": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Web-Feeds verwalten"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Manage Web Feeds"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gérer les flux web"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gestisci feed web"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Webフィードを管理"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "웹 피드 관리"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quản lý nguồn cấp web"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "管理网页订阅源"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "管理網頁訂閱源"
+          }
+        }
+      }
+    },
+    "Picker.Field.Author": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Autor"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Author"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auteur"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Autore"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "著者"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "작성자"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tác giả"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "作者"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "作者"
+          }
+        }
+      }
+    },
+    "Picker.Field.Date": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Datum"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Date"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Date"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Data"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "日付"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "날짜"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ngày"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "日期"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "日期"
+          }
+        }
+      }
+    },
+    "Picker.Field.Image": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bild"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Image"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Image"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Immagine"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "画像"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이미지"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ảnh"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "图片"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "圖片"
+          }
+        }
+      }
+    },
+    "Picker.Field.Item": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Element-Container"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Item Container"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conteneur d'élément"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contenitore elemento"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アイテムコンテナ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "항목 컨테이너"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vùng chứa mục"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "条目容器"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "條目容器"
+          }
+        }
+      }
+    },
+    "Picker.Field.Link": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Link"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Link"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lien"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Link"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リンク"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "링크"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liên kết"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "链接"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "連結"
+          }
+        }
+      }
+    },
+    "Picker.Field.Summary": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zusammenfassung"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Summary"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Résumé"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Riepilogo"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "概要"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "요약"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tóm tắt"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "摘要"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "摘要"
+          }
+        }
+      }
+    },
+    "Picker.Field.Title": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Titel"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Title"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Titre"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Titolo"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タイトル"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "제목"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tiêu đề"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "标题"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "標題"
+          }
+        }
+      }
+    },
+    "Picker.Title": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elementauswahl"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Element Picker"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sélecteur d'éléments"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selettore elementi"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "要素を選択"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "요소 선택기"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trình chọn phần tử"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "元素选取器"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "元素選取器"
+          }
+        }
+      }
+    },
+    "Picker.AssignTo": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zuweisen zu…"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Assign to…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Attribuer à…"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Assegna a…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "割り当て先…"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "할당 대상…"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gán cho…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "分配到…"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "指派給…"
+          }
+        }
+      }
+    },
+    "Picker.Children.A11y": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unterelemente anzeigen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show children"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afficher les enfants"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostra elementi figli"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "子要素を表示"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "하위 요소 표시"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hiển thị phần tử con"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示子元素"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顯示子元素"
+          }
+        }
+      }
+    },
+    "Picker.Children.Menu": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unterelemente"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Children"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enfants"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elementi figli"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "子要素"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "하위 요소"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Phần tử con"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "子元素"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "子元素"
+          }
+        }
+      }
+    },
+    "Picker.NoSelection": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tippe ein Element an, um es auszuwählen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tap an element to pick it"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Touchez un élément pour le sélectionner"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tocca un elemento per selezionarlo"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "要素をタップして選択"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "요소를 탭해서 선택하세요"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chạm vào một phần tử để chọn"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "轻点元素以选取"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "輕點元素以選取"
           }
         }
       }
     }
   },
-  "version" : "1.1"
+  "version": "1.1"
 }

--- a/Shared/Strings/Petal.xcstrings
+++ b/Shared/Strings/Petal.xcstrings
@@ -1,3487 +1,3487 @@
 {
-  "sourceLanguage": "en",
-  "strings": {
-    "About.Body": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mit Web-Feeds kannst du eigene Feeds von jeder Webseite erstellen, auch ohne RSS."
+  "sourceLanguage" : "en",
+  "strings" : {
+    "About.Body" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mit Web-Feeds kannst du eigene Feeds von jeder Webseite erstellen, auch ohne RSS."
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Web Feeds lets you create custom feeds from any website, even those without RSS."
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Web Feeds lets you create custom feeds from any website, even those without RSS."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Web Feeds vous permet de créer des flux personnalisés depuis n'importe quel site web, même sans RSS."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Web Feeds vous permet de créer des flux personnalisés depuis n'importe quel site web, même sans RSS."
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Web Feeds ti permette di creare feed personalizzati da qualsiasi sito web, anche senza RSS."
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Web Feeds ti permette di creare feed personalizzati da qualsiasi sito web, anche senza RSS."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "WebフィードはRSSのないサイトからもカスタムフィードを作成できます。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "WebフィードはRSSのないサイトからもカスタムフィードを作成できます。"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "웹 피드를 사용하면 RSS가 없는 사이트에서도 맞춤 피드를 만들 수 있습니다."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "웹 피드를 사용하면 RSS가 없는 사이트에서도 맞춤 피드를 만들 수 있습니다."
           }
         },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Web Feeds cho phép bạn tạo nguồn cấp tùy chỉnh từ bất kỳ trang web nào, kể cả những trang không có RSS."
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Web Feeds cho phép bạn tạo nguồn cấp tùy chỉnh từ bất kỳ trang web nào, kể cả những trang không có RSS."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "网页订阅源让你从任何网站创建自定义订阅源，即使没有 RSS 也可以。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "网页订阅源让你从任何网站创建自定义订阅源，即使没有 RSS 也可以。"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "網頁訂閱源讓你從任何網站建立自訂訂閱源，即使沒有 RSS 也可以。"
-          }
-        }
-      }
-    },
-    "About.Header": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Über Web-Feeds"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "About Web Feeds"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "À propos des flux web"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Informazioni sui feed web"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Webフィードについて"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "웹 피드 정보"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Giới thiệu về Web Feeds"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "关于网页订阅源"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "關於網頁訂閱源"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "網頁訂閱源讓你從任何網站建立自訂訂閱源，即使沒有 RSS 也可以。"
           }
         }
       }
     },
-    "AddFeed.Generate": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Web-Feed generieren"
+    "About.Header" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Über Web-Feeds"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Generate Web Feed"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "About Web Feeds"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Générer un flux web"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "À propos des flux web"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Genera feed web"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Informazioni sui feed web"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Webフィードを生成"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Webフィードについて"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "웹 피드 생성"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "웹 피드 정보"
           }
         },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tạo nguồn cấp web"
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giới thiệu về Web Feeds"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "生成网页订阅源"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关于网页订阅源"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "產生網頁訂閱源"
-          }
-        }
-      }
-    },
-    "AddFeed.GenerateFooter": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kein RSS-Feed gefunden. Mit von dir gewählten Selektoren kann direkt auf dem Gerät ein Feed aus der Seite erstellt werden."
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No RSS feed was found. Web Feeds can build one on-device by scraping the page with selectors you choose."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aucun flux RSS trouvé. Web Feeds peut en créer un sur l’appareil en analysant la page avec les sélecteurs de votre choix."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nessun feed RSS trovato. Web Feeds può crearne uno sul dispositivo analizzando la pagina con i selettori che scegli."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "RSSフィードが見つかりませんでした。選択したセレクタでページをスクレイピングし、デバイス上でWebフィードを作成できます。"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "RSS 피드를 찾을 수 없습니다. 선택한 선택자로 페이지를 스크레이핑하여 기기에서 웹 피드를 만들 수 있습니다."
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Không tìm thấy nguồn RSS. Web Feeds có thể tạo một nguồn ngay trên thiết bị bằng cách trích xuất trang với các bộ chọn bạn chọn."
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "未找到 RSS 订阅源。可以使用你选择的选择器在设备上抓取该页面并生成网页订阅源。"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "找不到 RSS 訂閱源。可以使用你選擇的選擇器在裝置上抓取該頁面並產生網頁訂閱源。"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "關於網頁訂閱源"
           }
         }
       }
     },
-    "Builder.AutoDetect": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Automatisch erkennen"
+    "AddFeed.Generate" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Web-Feed generieren"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Auto-Detect"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Generate Web Feed"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Détection automatique"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Générer un flux web"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rilevamento automatico"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Genera feed web"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "自動検出"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Webフィードを生成"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "자동 감지"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "웹 피드 생성"
           }
         },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tự động phát hiện"
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tạo nguồn cấp web"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "自动检测"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "生成网页订阅源"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "自動偵測"
-          }
-        }
-      }
-    },
-    "Builder.AutoDetect.Failed": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Selektoren konnten nicht automatisch erkannt werden. Bitte manuell eingeben."
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Could not auto-detect selectors. Try entering them manually."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Impossible de détecter automatiquement les sélecteurs. Essayez de les saisir manuellement."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Impossibile rilevare automaticamente i selettori. Prova a inserirli manualmente."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "セレクタを自動検出できませんでした。手動で入力してください。"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "선택자를 자동으로 감지할 수 없습니다. 직접 입력해 보세요."
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Không thể tự động phát hiện các bộ chọn. Hãy thử nhập thủ công."
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "无法自动检测选择器，请尝试手动输入。"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "無法自動偵測選擇器，請嘗試手動輸入。"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "產生網頁訂閱源"
           }
         }
       }
     },
-    "Builder.DateSelector": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Datum-Selektor"
+    "AddFeed.GenerateFooter" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kein RSS-Feed gefunden. Mit von dir gewählten Selektoren kann direkt auf dem Gerät ein Feed aus der Seite erstellt werden."
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Date selector"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No RSS feed was found. Web Feeds can build one on-device by scraping the page with selectors you choose."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sélecteur de date"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucun flux RSS trouvé. Web Feeds peut en créer un sur l’appareil en analysant la page avec les sélecteurs de votre choix."
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Selettore data"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessun feed RSS trovato. Web Feeds può crearne uno sul dispositivo analizzando la pagina con i selettori che scegli."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "日付セレクタ"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "RSSフィードが見つかりませんでした。選択したセレクタでページをスクレイピングし、デバイス上でWebフィードを作成できます。"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "날짜 선택자"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "RSS 피드를 찾을 수 없습니다. 선택한 선택자로 페이지를 스크레이핑하여 기기에서 웹 피드를 만들 수 있습니다."
           }
         },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bộ chọn ngày"
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không tìm thấy nguồn RSS. Web Feeds có thể tạo một nguồn ngay trên thiết bị bằng cách trích xuất trang với các bộ chọn bạn chọn."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "日期选择器"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未找到 RSS 订阅源。可以使用你选择的选择器在设备上抓取该页面并生成网页订阅源。"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "日期選擇器"
-          }
-        }
-      }
-    },
-    "Builder.Delete": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Web-Feed löschen"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Delete Web Feed"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Supprimer le flux web"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Elimina feed web"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Webフィードを削除"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "웹 피드 삭제"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Xóa nguồn cấp web"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "删除网页订阅源"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "刪除網頁訂閱源"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "找不到 RSS 訂閱源。可以使用你選擇的選擇器在裝置上抓取該頁面並產生網頁訂閱源。"
           }
         }
       }
     },
-    "Builder.DeleteConfirm.Message": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Das Rezept und die abgerufenen Artikel werden entfernt. Dies kann nicht rückgängig gemacht werden."
+    "Builder.AutoDetect" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Automatisch erkennen"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The recipe and its fetched articles will be removed. This cannot be undone."
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Auto-Detect"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La recette et les articles récupérés seront supprimés. Cette action est irréversible."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Détection automatique"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La ricetta e gli articoli recuperati verranno rimossi. L’operazione non può essere annullata."
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rilevamento automatico"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "レシピと取得した記事が削除されます。この操作は取り消せません。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動検出"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "레시피와 가져온 기사가 삭제됩니다. 이 작업은 취소할 수 없습니다."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "자동 감지"
           }
         },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Công thức và các bài viết đã tải sẽ bị xóa. Hành động này không thể hoàn tác."
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tự động phát hiện"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "配方及其已抓取的文章将被移除。此操作无法撤销。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自动检测"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "配方及其已抓取的文章將被移除。此操作無法復原。"
-          }
-        }
-      }
-    },
-    "Builder.DeleteConfirm.Title": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Diesen Web-Feed löschen?"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Delete this Web Feed?"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Supprimer ce flux web ?"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Eliminare questo feed web?"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "このWebフィードを削除しますか？"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "이 웹 피드를 삭제하시겠습니까?"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Xóa nguồn cấp web này?"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "要删除此网页订阅源吗？"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "要刪除此網頁訂閱源嗎？"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動偵測"
           }
         }
       }
     },
-    "Builder.Fetch": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Abrufen und Vorschau"
+    "Builder.AutoDetect.Failed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selektoren konnten nicht automatisch erkannt werden. Bitte manuell eingeben."
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fetch & Preview"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Could not auto-detect selectors. Try entering them manually."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Récupérer et prévisualiser"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible de détecter automatiquement les sélecteurs. Essayez de les saisir manuellement."
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recupera e anteprima"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossibile rilevare automaticamente i selettori. Prova a inserirli manualmente."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "取得してプレビュー"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "セレクタを自動検出できませんでした。手動で入力してください。"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "가져와서 미리보기"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "선택자를 자동으로 감지할 수 없습니다. 직접 입력해 보세요."
           }
         },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tải và xem trước"
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không thể tự động phát hiện các bộ chọn. Hãy thử nhập thủ công."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "抓取并预览"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法自动检测选择器，请尝试手动输入。"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "抓取並預覽"
-          }
-        }
-      }
-    },
-    "Builder.FetchMode": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Abrufmodus"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fetch mode"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mode de récupération"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Modalità di recupero"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "取得モード"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "가져오기 모드"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Chế độ tải"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "抓取模式"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "抓取模式"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法自動偵測選擇器，請嘗試手動輸入。"
           }
         }
       }
     },
-    "Builder.FetchMode.Rendered": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gerendert (für SPAs)"
+    "Builder.DateSelector" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Datum-Selektor"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rendered (for SPAs)"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Date selector"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rendu (pour les SPA)"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sélecteur de date"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Renderizzato (per SPA)"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selettore data"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "レンダリング済み（SPA向け）"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日付セレクタ"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "렌더링됨(SPA용)"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "날짜 선택자"
           }
         },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Đã kết xuất (cho SPA)"
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bộ chọn ngày"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "已渲染（适用于 SPA）"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日期选择器"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "已渲染（適用於 SPA）"
-          }
-        }
-      }
-    },
-    "Builder.FetchMode.Static": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Statisches HTML"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Static HTML"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "HTML statique"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "HTML statico"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "静的HTML"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "정적 HTML"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "HTML tĩnh"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "静态 HTML"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "靜態 HTML"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日期選擇器"
           }
         }
       }
     },
-    "Builder.ImageSelector": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bild-Selektor"
+    "Builder.Delete" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Web-Feed löschen"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Image selector"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete Web Feed"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sélecteur d’image"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Supprimer le flux web"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Selettore immagine"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elimina feed web"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "画像セレクタ"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Webフィードを削除"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "이미지 선택자"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "웹 피드 삭제"
           }
         },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bộ chọn ảnh"
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Xóa nguồn cấp web"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "图片选择器"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "删除网页订阅源"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "圖片選擇器"
-          }
-        }
-      }
-    },
-    "Builder.ItemSelector": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Element-Selektor (erforderlich)"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Item selector (required)"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sélecteur d’élément (obligatoire)"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Selettore elemento (obbligatorio)"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "アイテムセレクタ（必須）"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "항목 선택자(필수)"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bộ chọn mục (bắt buộc)"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "条目选择器（必填）"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "條目選擇器（必填）"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除網頁訂閱源"
           }
         }
       }
     },
-    "Builder.LinkSelector": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Link-Selektor"
+    "Builder.DeleteConfirm.Message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Das Rezept und die abgerufenen Artikel werden entfernt. Dies kann nicht rückgängig gemacht werden."
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Link selector"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The recipe and its fetched articles will be removed. This cannot be undone."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sélecteur de lien"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La recette et les articles récupérés seront supprimés. Cette action est irréversible."
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Selettore link"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La ricetta e gli articoli recuperati verranno rimossi. L’operazione non può essere annullata."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "リンクセレクタ"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "レシピと取得した記事が削除されます。この操作は取り消せません。"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "링크 선택자"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "레시피와 가져온 기사가 삭제됩니다. 이 작업은 취소할 수 없습니다."
           }
         },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bộ chọn liên kết"
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Công thức và các bài viết đã tải sẽ bị xóa. Hành động này không thể hoàn tác."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "链接选择器"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "配方及其已抓取的文章将被移除。此操作无法撤销。"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "連結選擇器"
-          }
-        }
-      }
-    },
-    "Builder.Name.Placeholder": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Feed-Name"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Feed name"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nom du flux"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nome del feed"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "フィード名"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "피드 이름"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tên nguồn cấp"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "订阅源名称"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "訂閱源名稱"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "配方及其已抓取的文章將被移除。此操作無法復原。"
           }
         }
       }
     },
-    "Builder.PickElements": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Elemente auswählen"
+    "Builder.DeleteConfirm.Title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diesen Web-Feed löschen?"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pick Elements"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete this Web Feed?"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Choisir des éléments"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Supprimer ce flux web ?"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Seleziona elementi"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminare questo feed web?"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "要素を選択"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このWebフィードを削除しますか？"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "요소 선택"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 웹 피드를 삭제하시겠습니까?"
           }
         },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Chọn phần tử"
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Xóa nguồn cấp web này?"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "选取元素"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要删除此网页订阅源吗？"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "選取元素"
-          }
-        }
-      }
-    },
-    "Builder.Preview.Empty": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Keine Einträge gefunden. Versuche einen allgemeineren Element-Selektor."
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No items matched. Try a broader item selector."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aucun élément correspondant. Essayez un sélecteur d’élément plus large."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nessun elemento corrispondente. Prova un selettore di elemento più ampio."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "一致するアイテムがありません。より広いアイテムセレクタを試してください。"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "일치하는 항목이 없습니다. 더 넓은 항목 선택자를 사용해 보세요."
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Không có mục nào khớp. Hãy thử bộ chọn mục rộng hơn."
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "没有匹配到任何条目。请尝试更宽松的条目选择器。"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "沒有比對到任何條目。請嘗試更寬鬆的條目選擇器。"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要刪除此網頁訂閱源嗎？"
           }
         }
       }
     },
-    "Builder.Preview.TapFetch": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tippe auf „Abrufen und Vorschau“, um die Seite zu laden."
+    "Builder.Fetch" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abrufen und Vorschau"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tap Fetch & Preview to load the page."
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fetch & Preview"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Touchez « Récupérer et prévisualiser » pour charger la page."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Récupérer et prévisualiser"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tocca «Recupera e anteprima» per caricare la pagina."
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recupera e anteprima"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "「取得してプレビュー」をタップしてページを読み込みます。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取得してプレビュー"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "‘가져와서 미리보기’를 탭하여 페이지를 불러오세요."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "가져와서 미리보기"
           }
         },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Chạm vào “Tải và xem trước” để tải trang."
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tải và xem trước"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "点按“抓取并预览”以加载页面。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "抓取并预览"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "點一下「抓取並預覽」以載入頁面。"
-          }
-        }
-      }
-    },
-    "Builder.Section.Preview": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vorschau"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Preview"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aperçu"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Anteprima"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "プレビュー"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "미리보기"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Xem trước"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "预览"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "預覽"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "抓取並預覽"
           }
         }
       }
     },
-    "Builder.Section.Selectors": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Selektoren"
+    "Builder.FetchMode" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abrufmodus"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Selectors"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fetch mode"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sélecteurs"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mode de récupération"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Selettori"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modalità di recupero"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "セレクタ"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取得モード"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "선택자"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "가져오기 모드"
           }
         },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bộ chọn"
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chế độ tải"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "选择器"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "抓取模式"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "選擇器"
-          }
-        }
-      }
-    },
-    "Builder.Section.SelectorsFooter": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Jeder Selektor wird relativ zu einem Element ausgeführt. Lass ein Feld leer, damit der Wert automatisch aus dem Inhalt des Elements ermittelt wird."
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Each selector runs relative to an item. Leave a field empty to auto-detect the value from the item's own content."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Chaque sélecteur s’applique par rapport à un élément. Laissez un champ vide pour détecter automatiquement la valeur à partir du contenu de l’élément."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ogni selettore viene eseguito in relazione a un elemento. Lascia un campo vuoto per rilevare automaticamente il valore dal contenuto dell’elemento."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "各セレクタはアイテムを基準に実行されます。フィールドを空のままにすると、アイテム自体の内容から自動的に推測します。"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "각 선택자는 항목을 기준으로 실행됩니다. 필드를 비워 두면 항목 자체의 콘텐츠에서 값을 자동으로 감지합니다."
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mỗi bộ chọn chạy tương đối với một mục. Để trống một trường để tự động phát hiện giá trị từ nội dung của chính mục đó."
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "每个选择器都会相对于条目运行。留空某个字段可从条目自身的内容中自动推断。"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "每個選擇器都會相對於條目執行。留空某個欄位可從條目自身的內容中自動推斷。"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "抓取模式"
           }
         }
       }
     },
-    "Builder.Section.Source": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Quelle"
+    "Builder.FetchMode.Rendered" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gerendert (für SPAs)"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Source"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rendered (for SPAs)"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Source"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rendu (pour les SPA)"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Origine"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Renderizzato (per SPA)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ソース"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "レンダリング済み（SPA向け）"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "소스"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "렌더링됨(SPA용)"
           }
         },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nguồn"
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đã kết xuất (cho SPA)"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "来源"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已渲染（适用于 SPA）"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "來源"
-          }
-        }
-      }
-    },
-    "Builder.Section.SourceFooter": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Im gerenderten Modus wird die Seite in einer Webansicht geladen und auf die JavaScript-Ausführung gewartet. Verwende ihn für React oder andere Single-Page-Apps."
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rendered mode loads the page in a web view and waits for JavaScript to run. Use it for React or other single-page apps."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Le mode rendu charge la page dans une vue web et attend l’exécution du JavaScript. Utilisez-le pour React ou d’autres applications à page unique."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La modalità renderizzata carica la pagina in una vista web e attende l’esecuzione del JavaScript. Usala per React o altre app a pagina singola."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "レンダリングモードはページをWebビューで読み込み、JavaScriptの実行を待ちます。Reactなどのシングルページアプリに使用してください。"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "렌더링 모드는 웹 뷰에서 페이지를 불러오고 JavaScript가 실행될 때까지 기다립니다. React 또는 기타 싱글 페이지 앱에 사용하세요."
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Chế độ kết xuất tải trang trong một web view và chờ JavaScript chạy. Dùng cho React hoặc các ứng dụng một trang khác."
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "渲染模式会在 Web 视图中加载页面并等待 JavaScript 执行。适用于 React 或其他单页应用。"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "渲染模式會在 Web 檢視中載入頁面並等待 JavaScript 執行。適用於 React 或其他單頁應用。"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已渲染（適用於 SPA）"
           }
         }
       }
     },
-    "Builder.SummarySelector": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zusammenfassung-Selektor"
+    "Builder.FetchMode.Static" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Statisches HTML"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Summary selector"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Static HTML"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sélecteur de résumé"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HTML statique"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Selettore riepilogo"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HTML statico"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "概要セレクタ"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "静的HTML"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "요약 선택자"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "정적 HTML"
           }
         },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bộ chọn tóm tắt"
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HTML tĩnh"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "摘要选择器"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "静态 HTML"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "摘要選擇器"
-          }
-        }
-      }
-    },
-    "Builder.Title": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Web-Feed"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Web Feed"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Flux web"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Feed web"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Webフィード"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "웹 피드"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nguồn cấp web"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "网页订阅源"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "網頁訂閱源"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "靜態 HTML"
           }
         }
       }
     },
-    "Builder.TitleSelector": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Titel-Selektor"
+    "Builder.ImageSelector" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bild-Selektor"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Title selector"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Image selector"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sélecteur de titre"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sélecteur d’image"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Selettore titolo"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selettore immagine"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "タイトルセレクタ"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "画像セレクタ"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "제목 선택자"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이미지 선택자"
           }
         },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bộ chọn tiêu đề"
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bộ chọn ảnh"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "标题选择器"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "图片选择器"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "標題選擇器"
-          }
-        }
-      }
-    },
-    "Builder.URL.Placeholder": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "https://example.com/blog"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "https://example.com/blog"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "https://example.com/blog"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "https://example.com/blog"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "https://example.com/blog"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "https://example.com/blog"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "https://example.com/blog"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "https://example.com/blog"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "https://example.com/blog"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "圖片選擇器"
           }
         }
       }
     },
-    "Error.FetchFailed": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Die Seite konnte nicht geladen werden. Überprüfe die URL oder versuche den gerenderten Modus."
+    "Builder.ItemSelector" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Element-Selektor (erforderlich)"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Couldn't load that page. Check the URL or try rendered mode."
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Item selector (required)"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Impossible de charger cette page. Vérifiez l’URL ou essayez le mode rendu."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sélecteur d’élément (obligatoire)"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Impossibile caricare la pagina. Controlla l’URL o prova la modalità renderizzata."
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selettore elemento (obbligatorio)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ページを読み込めませんでした。URLを確認するか、レンダリングモードをお試しください。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アイテムセレクタ（必須）"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "해당 페이지를 불러올 수 없습니다. URL을 확인하거나 렌더링 모드를 사용해 보세요."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "항목 선택자(필수)"
           }
         },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Không thể tải trang đó. Hãy kiểm tra URL hoặc thử chế độ kết xuất."
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bộ chọn mục (bắt buộc)"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "无法加载该页面。请检查网址或尝试渲染模式。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "条目选择器（必填）"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "無法載入該頁面。請檢查網址或嘗試渲染模式。"
-          }
-        }
-      }
-    },
-    "Error.ImportFailed": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Das Paket konnte nicht importiert werden."
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Couldn't import that package."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Impossible d’importer ce paquet."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Impossibile importare il pacchetto."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "パッケージを読み込めませんでした。"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "해당 패키지를 가져올 수 없습니다."
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Không thể nhập gói đó."
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "无法导入该包。"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "無法匯入該套件。"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "條目選擇器（必填）"
           }
         }
       }
     },
-    "Error.NoMatches": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Keine Einträge mit den aktuellen Selektoren gefunden."
+    "Builder.LinkSelector" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Link-Selektor"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No items matched the current selectors."
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Link selector"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aucun élément ne correspond aux sélecteurs actuels."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sélecteur de lien"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nessun elemento corrisponde ai selettori attuali."
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selettore link"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "現在のセレクタに一致するアイテムはありません。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リンクセレクタ"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "현재 선택자와 일치하는 항목이 없습니다."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "링크 선택자"
           }
         },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Không có mục nào khớp với các bộ chọn hiện tại."
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bộ chọn liên kết"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "当前选择器没有匹配到任何条目。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "链接选择器"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "目前的選擇器沒有比對到任何條目。"
-          }
-        }
-      }
-    },
-    "Error.PackageMalformed": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Das sieht nicht nach einem gültigen Sakura-RSS-Paket aus."
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This doesn't look like a valid Sakura RSS package."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cela ne ressemble pas à un paquet Sakura RSS valide."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Non sembra un pacchetto Sakura RSS valido."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "有効なRSSパッケージではないようです。"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "유효한 Sakura RSS 패키지가 아닌 것 같습니다."
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Đây không giống một gói Sakura RSS hợp lệ."
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "这看起来不是有效的 Sakura RSS 包。"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "這看起來不是有效的 Sakura RSS 套件。"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連結選擇器"
           }
         }
       }
     },
-    "Error.PackageMissingRecipe": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Im Paket fehlt die Rezeptdatei."
+    "Builder.Name.Placeholder" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Feed-Name"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The package is missing a recipe file."
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Feed name"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Il manque un fichier de recette dans le paquet."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nom du flux"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Il pacchetto non contiene il file della ricetta."
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nome del feed"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "パッケージにレシピファイルが含まれていません。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "フィード名"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "패키지에 레시피 파일이 없습니다."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "피드 이름"
           }
         },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gói thiếu tệp công thức."
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tên nguồn cấp"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "该包缺少配方文件。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "订阅源名称"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "該套件缺少配方檔案。"
-          }
-        }
-      }
-    },
-    "Error.PackageTooLarge": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dieses Paket ist größer, als Sakura importieren kann."
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This package is larger than Sakura will import."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ce paquet est plus volumineux que ce que Sakura accepte d’importer."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Questo pacchetto è più grande di quanto Sakura possa importare."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "このパッケージはサクラリーダーが読み込める上限を超えています。"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "이 패키지는 Sakura가 가져올 수 있는 크기보다 큽니다."
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gói này lớn hơn mức Sakura có thể nhập."
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "此包超出了 Sakura 可导入的大小。"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "此套件超出了 Sakura 可匯入的大小。"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "訂閱源名稱"
           }
         }
       }
     },
-    "Error.PackageUnsupportedVersion": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dieses Paket wurde mit einer neueren Version von Sakura erstellt. Aktualisiere die App und versuche es erneut."
+    "Builder.PickElements" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elemente auswählen"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This package was made with a newer version of Sakura. Update the app and try again."
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pick Elements"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ce paquet a été créé avec une version plus récente de Sakura. Mettez l’application à jour et réessayez."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choisir des éléments"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Questo pacchetto è stato creato con una versione più recente di Sakura. Aggiorna l’app e riprova."
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seleziona elementi"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "このパッケージはより新しいバージョンのサクラリーダーで作成されました。アプリを更新してからもう一度お試しください。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要素を選択"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "이 패키지는 더 최신 버전의 Sakura에서 만들어졌습니다. 앱을 업데이트한 후 다시 시도하세요."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "요소 선택"
           }
         },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gói này được tạo bằng phiên bản Sakura mới hơn. Hãy cập nhật ứng dụng và thử lại."
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chọn phần tử"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "此包是用更新版本的 Sakura 制作的。请更新应用后重试。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选取元素"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "此套件是用更新版本的 Sakura 製作的。請更新 App 後重試。"
-          }
-        }
-      }
-    },
-    "Error.Title": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Web-Feeds"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Web Feeds"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Flux web"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Feed web"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Webフィード"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "웹 피드"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nguồn cấp web"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "网页订阅源"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "網頁訂閱源"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選取元素"
           }
         }
       }
     },
-    "FeedEdit.EditRecipe": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rezept bearbeiten"
+    "Builder.Preview.Empty" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keine Einträge gefunden. Versuche einen allgemeineren Element-Selektor."
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Edit Recipe"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No items matched. Try a broader item selector."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Modifier la recette"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucun élément correspondant. Essayez un sélecteur d’élément plus large."
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Modifica ricetta"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessun elemento corrispondente. Prova un selettore di elemento più ampio."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "レシピを編集"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一致するアイテムがありません。より広いアイテムセレクタを試してください。"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "레시피 편집"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "일치하는 항목이 없습니다. 더 넓은 항목 선택자를 사용해 보세요."
           }
         },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Chỉnh sửa công thức"
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không có mục nào khớp. Hãy thử bộ chọn mục rộng hơn."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "编辑配方"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "没有匹配到任何条目。请尝试更宽松的条目选择器。"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "編輯配方"
-          }
-        }
-      }
-    },
-    "FeedEdit.Header": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Web-Feed"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Web Feed"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Flux web"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Feed web"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Webフィード"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "웹 피드"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nguồn cấp web"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "网页订阅源"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "網頁訂閱源"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有比對到任何條目。請嘗試更寬鬆的條目選擇器。"
           }
         }
       }
     },
-    "FeedEdit.SourceURL": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Quell-URL"
+    "Builder.Preview.TapFetch" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tippe auf „Abrufen und Vorschau“, um die Seite zu laden."
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Source URL"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap Fetch & Preview to load the page."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "URL source"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Touchez « Récupérer et prévisualiser » pour charger la page."
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "URL sorgente"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tocca «Recupera e anteprima» per caricare la pagina."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ソースURL"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "「取得してプレビュー」をタップしてページを読み込みます。"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "소스 URL"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "‘가져와서 미리보기’를 탭하여 페이지를 불러오세요."
           }
         },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "URL nguồn"
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chạm vào “Tải và xem trước” để tải trang."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "来源 URL"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "点按“抓取并预览”以加载页面。"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "來源 URL"
-          }
-        }
-      }
-    },
-    "Manage.Empty": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Noch keine Web-Feeds. Erstelle einen im Bildschirm „Feed hinzufügen“ oder importiere ein .srss-Paket."
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No Web Feeds yet. Create one from the Add Feed screen, or import a .srss package."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aucun flux web pour le moment. Créez-en un depuis l’écran Ajouter un flux, ou importez un paquet .srss."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ancora nessun feed web. Creane uno dalla schermata Aggiungi feed oppure importa un pacchetto .srss."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "まだWebフィードがありません。「フィードを追加」画面で作成するか、.srssパッケージを読み込んでください。"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "아직 웹 피드가 없습니다. '피드 추가' 화면에서 만들거나 .srss 패키지를 가져오세요."
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Chưa có nguồn cấp web nào. Hãy tạo một nguồn từ màn hình Thêm nguồn cấp, hoặc nhập một gói .srss."
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "还没有网页订阅源。可在“添加订阅源”界面创建，或导入 .srss 包。"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "還沒有網頁訂閱源。可在「加入訂閱源」畫面建立，或匯入 .srss 套件。"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "點一下「抓取並預覽」以載入頁面。"
           }
         }
       }
     },
-    "Manage.Export": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Als .srss exportieren"
+    "Builder.Section.Preview" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vorschau"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Export as .srss"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preview"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Exporter en .srss"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aperçu"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Esporta come .srss"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anteprima"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": ".srssとして書き出す"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "プレビュー"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": ".srss로 내보내기"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "미리보기"
           }
         },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Xuất dưới dạng .srss"
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Xem trước"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "导出为 .srss"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "预览"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "匯出為 .srss"
-          }
-        }
-      }
-    },
-    "Manage.Import": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": ".srss-Paket importieren"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Import .srss package"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Importer un paquet .srss"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Importa pacchetto .srss"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": ".srssパッケージを読み込む"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": ".srss 패키지 가져오기"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nhập gói .srss"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "导入 .srss 包"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "匯入 .srss 套件"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "預覽"
           }
         }
       }
     },
-    "Manage.ImportFooter": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sakura-RSS-Pakete (.srss) enthalten ein Rezept und ein optionales Feed-Symbol. Es wird nichts hochgeladen – der Import erfolgt vollständig auf dem Gerät."
+    "Builder.Section.Selectors" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selektoren"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sakura RSS packages (.srss) contain a recipe and an optional feed icon. Nothing is uploaded — import runs entirely on device."
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selectors"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Les paquets Sakura RSS (.srss) contiennent une recette et, facultativement, une icône de flux. Rien n’est envoyé en ligne : l’importation se fait entièrement sur l’appareil."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sélecteurs"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "I pacchetti Sakura RSS (.srss) contengono una ricetta e un’icona del feed facoltativa. Non viene caricato nulla: l’importazione avviene interamente sul dispositivo."
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selettori"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "RSSパッケージ（.srss）にはレシピとオプションのフィードアイコンが含まれます。アップロードは行われず、読み込みはすべてデバイス上で完了します。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "セレクタ"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sakura RSS 패키지(.srss)에는 레시피와 선택 사항인 피드 아이콘이 포함됩니다. 업로드되는 항목은 없으며 가져오기는 전적으로 기기에서 수행됩니다."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "선택자"
           }
         },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gói Sakura RSS (.srss) chứa một công thức và tùy chọn biểu tượng nguồn cấp. Không có gì được tải lên — việc nhập diễn ra hoàn toàn trên thiết bị."
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bộ chọn"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sakura RSS 包（.srss）包含一个配方和可选的订阅源图标。不会上传任何内容——导入完全在设备上进行。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择器"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sakura RSS 套件（.srss）包含一個配方和選用的訂閱源圖示。不會上傳任何內容——匯入完全在裝置上進行。"
-          }
-        }
-      }
-    },
-    "Manage.Section.Installed": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Installiert"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Installed"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Installés"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Installati"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "インストール済み"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "설치됨"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Đã cài đặt"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "已安装"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "已安裝"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇器"
           }
         }
       }
     },
-    "Manage.Title": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Web-Feeds verwalten"
+    "Builder.Section.SelectorsFooter" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jeder Selektor wird relativ zu einem Element ausgeführt. Lass ein Feld leer, damit der Wert automatisch aus dem Inhalt des Elements ermittelt wird."
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Manage Web Feeds"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Each selector runs relative to an item. Leave a field empty to auto-detect the value from the item's own content."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gérer les flux web"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chaque sélecteur s’applique par rapport à un élément. Laissez un champ vide pour détecter automatiquement la valeur à partir du contenu de l’élément."
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gestisci feed web"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ogni selettore viene eseguito in relazione a un elemento. Lascia un campo vuoto per rilevare automaticamente il valore dal contenuto dell’elemento."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Webフィードを管理"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "各セレクタはアイテムを基準に実行されます。フィールドを空のままにすると、アイテム自体の内容から自動的に推測します。"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "웹 피드 관리"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "각 선택자는 항목을 기준으로 실행됩니다. 필드를 비워 두면 항목 자체의 콘텐츠에서 값을 자동으로 감지합니다."
           }
         },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Quản lý nguồn cấp web"
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mỗi bộ chọn chạy tương đối với một mục. Để trống một trường để tự động phát hiện giá trị từ nội dung của chính mục đó."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "管理网页订阅源"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "每个选择器都会相对于条目运行。留空某个字段可从条目自身的内容中自动推断。"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "管理網頁訂閱源"
-          }
-        }
-      }
-    },
-    "Picker.Field.Author": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Autor"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Author"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Auteur"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Autore"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "著者"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "작성자"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tác giả"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "作者"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "作者"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "每個選擇器都會相對於條目執行。留空某個欄位可從條目自身的內容中自動推斷。"
           }
         }
       }
     },
-    "Picker.Field.Date": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Datum"
+    "Builder.Section.Source" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quelle"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Date"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Source"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Date"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Source"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Data"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Origine"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "日付"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ソース"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "날짜"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "소스"
           }
         },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ngày"
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nguồn"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "日期"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "来源"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "日期"
-          }
-        }
-      }
-    },
-    "Picker.Field.Image": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bild"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Image"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Image"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Immagine"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "画像"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "이미지"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ảnh"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "图片"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "圖片"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "來源"
           }
         }
       }
     },
-    "Picker.Field.Item": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Element-Container"
+    "Builder.Section.SourceFooter" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Im gerenderten Modus wird die Seite in einer Webansicht geladen und auf die JavaScript-Ausführung gewartet. Verwende ihn für React oder andere Single-Page-Apps."
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Item Container"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rendered mode loads the page in a web view and waits for JavaScript to run. Use it for React or other single-page apps."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Conteneur d'élément"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le mode rendu charge la page dans une vue web et attend l’exécution du JavaScript. Utilisez-le pour React ou d’autres applications à page unique."
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Contenitore elemento"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La modalità renderizzata carica la pagina in una vista web e attende l’esecuzione del JavaScript. Usala per React o altre app a pagina singola."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "アイテムコンテナ"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "レンダリングモードはページをWebビューで読み込み、JavaScriptの実行を待ちます。Reactなどのシングルページアプリに使用してください。"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "항목 컨테이너"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "렌더링 모드는 웹 뷰에서 페이지를 불러오고 JavaScript가 실행될 때까지 기다립니다. React 또는 기타 싱글 페이지 앱에 사용하세요."
           }
         },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vùng chứa mục"
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chế độ kết xuất tải trang trong một web view và chờ JavaScript chạy. Dùng cho React hoặc các ứng dụng một trang khác."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "条目容器"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "渲染模式会在 Web 视图中加载页面并等待 JavaScript 执行。适用于 React 或其他单页应用。"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "條目容器"
-          }
-        }
-      }
-    },
-    "Picker.Field.Link": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Link"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Link"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lien"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Link"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "リンク"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "링크"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Liên kết"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "链接"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "連結"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "渲染模式會在 Web 檢視中載入頁面並等待 JavaScript 執行。適用於 React 或其他單頁應用。"
           }
         }
       }
     },
-    "Picker.Field.Summary": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zusammenfassung"
+    "Builder.SummarySelector" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zusammenfassung-Selektor"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Summary"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Summary selector"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Résumé"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sélecteur de résumé"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Riepilogo"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selettore riepilogo"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "概要"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "概要セレクタ"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "요약"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "요약 선택자"
           }
         },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tóm tắt"
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bộ chọn tóm tắt"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "摘要"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "摘要选择器"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "摘要"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "摘要選擇器"
           }
         }
       }
     },
-    "Picker.Field.Title": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Titel"
+    "Builder.Title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Web-Feed"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Title"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Web Feed"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Titre"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Flux web"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Titolo"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Feed web"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "タイトル"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Webフィード"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "제목"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "웹 피드"
           }
         },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tiêu đề"
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nguồn cấp web"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "标题"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "网页订阅源"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "標題"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "網頁訂閱源"
           }
         }
       }
     },
-    "Picker.Title": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Elementauswahl"
+    "Builder.TitleSelector" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Titel-Selektor"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Element Picker"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Title selector"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sélecteur d'éléments"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sélecteur de titre"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Selettore elementi"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selettore titolo"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "要素を選択"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タイトルセレクタ"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "요소 선택기"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "제목 선택자"
           }
         },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Trình chọn phần tử"
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bộ chọn tiêu đề"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "元素选取器"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "标题选择器"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "元素選取器"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "標題選擇器"
           }
         }
       }
     },
-    "Picker.AssignTo": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zuweisen zu…"
+    "Builder.URL.Placeholder" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "https://example.com/blog"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Assign to…"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "https://example.com/blog"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Attribuer à…"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "https://example.com/blog"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Assegna a…"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "https://example.com/blog"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "割り当て先…"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "https://example.com/blog"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "할당 대상…"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "https://example.com/blog"
           }
         },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gán cho…"
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "https://example.com/blog"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "分配到…"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "https://example.com/blog"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "指派給…"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "https://example.com/blog"
           }
         }
       }
     },
-    "Picker.Children.A11y": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unterelemente anzeigen"
+    "Error.FetchFailed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die Seite konnte nicht geladen werden. Überprüfe die URL oder versuche den gerenderten Modus."
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Show children"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't load that page. Check the URL or try rendered mode."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Afficher les enfants"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible de charger cette page. Vérifiez l’URL ou essayez le mode rendu."
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mostra elementi figli"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossibile caricare la pagina. Controlla l’URL o prova la modalità renderizzata."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "子要素を表示"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ページを読み込めませんでした。URLを確認するか、レンダリングモードをお試しください。"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "하위 요소 표시"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "해당 페이지를 불러올 수 없습니다. URL을 확인하거나 렌더링 모드를 사용해 보세요."
           }
         },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hiển thị phần tử con"
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không thể tải trang đó. Hãy kiểm tra URL hoặc thử chế độ kết xuất."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "显示子元素"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法加载该页面。请检查网址或尝试渲染模式。"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "顯示子元素"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法載入該頁面。請檢查網址或嘗試渲染模式。"
           }
         }
       }
     },
-    "Picker.Children.Menu": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unterelemente"
+    "Error.ImportFailed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Das Paket konnte nicht importiert werden."
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Children"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't import that package."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enfants"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible d’importer ce paquet."
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Elementi figli"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossibile importare il pacchetto."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "子要素"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "パッケージを読み込めませんでした。"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "하위 요소"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "해당 패키지를 가져올 수 없습니다."
           }
         },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Phần tử con"
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không thể nhập gói đó."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "子元素"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法导入该包。"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "子元素"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法匯入該套件。"
           }
         }
       }
     },
-    "Picker.NoSelection": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tippe ein Element an, um es auszuwählen"
+    "Error.NoMatches" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keine Einträge mit den aktuellen Selektoren gefunden."
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tap an element to pick it"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No items matched the current selectors."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Touchez un élément pour le sélectionner"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucun élément ne correspond aux sélecteurs actuels."
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tocca un elemento per selezionarlo"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessun elemento corrisponde ai selettori attuali."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "要素をタップして選択"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "現在のセレクタに一致するアイテムはありません。"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "요소를 탭해서 선택하세요"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "현재 선택자와 일치하는 항목이 없습니다."
           }
         },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Chạm vào một phần tử để chọn"
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không có mục nào khớp với các bộ chọn hiện tại."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "轻点元素以选取"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "当前选择器没有匹配到任何条目。"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "輕點元素以選取"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目前的選擇器沒有比對到任何條目。"
+          }
+        }
+      }
+    },
+    "Error.PackageMalformed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Das sieht nicht nach einem gültigen Sakura-RSS-Paket aus."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This doesn't look like a valid Sakura RSS package."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cela ne ressemble pas à un paquet Sakura RSS valide."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Non sembra un pacchetto Sakura RSS valido."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "有効なRSSパッケージではないようです。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "유효한 Sakura RSS 패키지가 아닌 것 같습니다."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đây không giống một gói Sakura RSS hợp lệ."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "这看起来不是有效的 Sakura RSS 包。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "這看起來不是有效的 Sakura RSS 套件。"
+          }
+        }
+      }
+    },
+    "Error.PackageMissingRecipe" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Im Paket fehlt die Rezeptdatei."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The package is missing a recipe file."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Il manque un fichier de recette dans le paquet."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Il pacchetto non contiene il file della ricetta."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "パッケージにレシピファイルが含まれていません。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "패키지에 레시피 파일이 없습니다."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gói thiếu tệp công thức."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "该包缺少配方文件。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "該套件缺少配方檔案。"
+          }
+        }
+      }
+    },
+    "Error.PackageTooLarge" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dieses Paket ist größer, als Sakura importieren kann."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This package is larger than Sakura will import."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ce paquet est plus volumineux que ce que Sakura accepte d’importer."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Questo pacchetto è più grande di quanto Sakura possa importare."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このパッケージはサクラリーダーが読み込める上限を超えています。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 패키지는 Sakura가 가져올 수 있는 크기보다 큽니다."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gói này lớn hơn mức Sakura có thể nhập."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此包超出了 Sakura 可导入的大小。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此套件超出了 Sakura 可匯入的大小。"
+          }
+        }
+      }
+    },
+    "Error.PackageUnsupportedVersion" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dieses Paket wurde mit einer neueren Version von Sakura erstellt. Aktualisiere die App und versuche es erneut."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This package was made with a newer version of Sakura. Update the app and try again."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ce paquet a été créé avec une version plus récente de Sakura. Mettez l’application à jour et réessayez."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Questo pacchetto è stato creato con una versione più recente di Sakura. Aggiorna l’app e riprova."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このパッケージはより新しいバージョンのサクラリーダーで作成されました。アプリを更新してからもう一度お試しください。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 패키지는 더 최신 버전의 Sakura에서 만들어졌습니다. 앱을 업데이트한 후 다시 시도하세요."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gói này được tạo bằng phiên bản Sakura mới hơn. Hãy cập nhật ứng dụng và thử lại."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此包是用更新版本的 Sakura 制作的。请更新应用后重试。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此套件是用更新版本的 Sakura 製作的。請更新 App 後重試。"
+          }
+        }
+      }
+    },
+    "Error.Title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Web-Feeds"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Web Feeds"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Flux web"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Feed web"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Webフィード"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "웹 피드"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nguồn cấp web"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "网页订阅源"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "網頁訂閱源"
+          }
+        }
+      }
+    },
+    "FeedEdit.EditRecipe" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rezept bearbeiten"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Edit Recipe"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modifier la recette"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modifica ricetta"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "レシピを編集"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "레시피 편집"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chỉnh sửa công thức"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "编辑配方"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "編輯配方"
+          }
+        }
+      }
+    },
+    "FeedEdit.Header" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Web-Feed"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Web Feed"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Flux web"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Feed web"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Webフィード"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "웹 피드"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nguồn cấp web"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "网页订阅源"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "網頁訂閱源"
+          }
+        }
+      }
+    },
+    "FeedEdit.SourceURL" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quell-URL"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Source URL"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URL source"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URL sorgente"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ソースURL"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "소스 URL"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URL nguồn"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "来源 URL"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "來源 URL"
+          }
+        }
+      }
+    },
+    "Manage.Empty" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Noch keine Web-Feeds. Erstelle einen im Bildschirm „Feed hinzufügen“ oder importiere ein .srss-Paket."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No Web Feeds yet. Create one from the Add Feed screen, or import a .srss package."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucun flux web pour le moment. Créez-en un depuis l’écran Ajouter un flux, ou importez un paquet .srss."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ancora nessun feed web. Creane uno dalla schermata Aggiungi feed oppure importa un pacchetto .srss."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "まだWebフィードがありません。「フィードを追加」画面で作成するか、.srssパッケージを読み込んでください。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "아직 웹 피드가 없습니다. '피드 추가' 화면에서 만들거나 .srss 패키지를 가져오세요."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chưa có nguồn cấp web nào. Hãy tạo một nguồn từ màn hình Thêm nguồn cấp, hoặc nhập một gói .srss."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "还没有网页订阅源。可在“添加订阅源”界面创建，或导入 .srss 包。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "還沒有網頁訂閱源。可在「加入訂閱源」畫面建立，或匯入 .srss 套件。"
+          }
+        }
+      }
+    },
+    "Manage.Export" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Als .srss exportieren"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Export as .srss"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exporter en .srss"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esporta come .srss"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ".srssとして書き出す"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ".srss로 내보내기"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Xuất dưới dạng .srss"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "导出为 .srss"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯出為 .srss"
+          }
+        }
+      }
+    },
+    "Manage.Import" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ".srss-Paket importieren"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Import .srss package"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importer un paquet .srss"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importa pacchetto .srss"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ".srssパッケージを読み込む"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ".srss 패키지 가져오기"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nhập gói .srss"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "导入 .srss 包"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯入 .srss 套件"
+          }
+        }
+      }
+    },
+    "Manage.ImportFooter" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sakura-RSS-Pakete (.srss) enthalten ein Rezept und ein optionales Feed-Symbol. Es wird nichts hochgeladen – der Import erfolgt vollständig auf dem Gerät."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sakura RSS packages (.srss) contain a recipe and an optional feed icon. Nothing is uploaded — import runs entirely on device."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les paquets Sakura RSS (.srss) contiennent une recette et, facultativement, une icône de flux. Rien n’est envoyé en ligne : l’importation se fait entièrement sur l’appareil."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "I pacchetti Sakura RSS (.srss) contengono una ricetta e un’icona del feed facoltativa. Non viene caricato nulla: l’importazione avviene interamente sul dispositivo."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "RSSパッケージ（.srss）にはレシピとオプションのフィードアイコンが含まれます。アップロードは行われず、読み込みはすべてデバイス上で完了します。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sakura RSS 패키지(.srss)에는 레시피와 선택 사항인 피드 아이콘이 포함됩니다. 업로드되는 항목은 없으며 가져오기는 전적으로 기기에서 수행됩니다."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gói Sakura RSS (.srss) chứa một công thức và tùy chọn biểu tượng nguồn cấp. Không có gì được tải lên — việc nhập diễn ra hoàn toàn trên thiết bị."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sakura RSS 包（.srss）包含一个配方和可选的订阅源图标。不会上传任何内容——导入完全在设备上进行。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sakura RSS 套件（.srss）包含一個配方和選用的訂閱源圖示。不會上傳任何內容——匯入完全在裝置上進行。"
+          }
+        }
+      }
+    },
+    "Manage.Section.Installed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Installiert"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Installed"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Installés"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Installati"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "インストール済み"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "설치됨"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đã cài đặt"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已安装"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已安裝"
+          }
+        }
+      }
+    },
+    "Manage.Title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Web-Feeds verwalten"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Manage Web Feeds"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gérer les flux web"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gestisci feed web"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Webフィードを管理"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "웹 피드 관리"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quản lý nguồn cấp web"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "管理网页订阅源"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "管理網頁訂閱源"
+          }
+        }
+      }
+    },
+    "Picker.Field.Author" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autor"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Author"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Auteur"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autore"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "著者"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "작성자"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tác giả"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "作者"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "作者"
+          }
+        }
+      }
+    },
+    "Picker.Field.Date" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Datum"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Date"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Date"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日付"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "날짜"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ngày"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日期"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日期"
+          }
+        }
+      }
+    },
+    "Picker.Field.Image" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bild"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Image"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Image"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Immagine"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "画像"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이미지"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ảnh"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "图片"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "圖片"
+          }
+        }
+      }
+    },
+    "Picker.Field.Item" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Element-Container"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Item Container"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conteneur d'élément"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Contenitore elemento"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アイテムコンテナ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "항목 컨테이너"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vùng chứa mục"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "条目容器"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "條目容器"
+          }
+        }
+      }
+    },
+    "Picker.Field.Link" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Link"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Link"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lien"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Link"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リンク"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "링크"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Liên kết"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "链接"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連結"
+          }
+        }
+      }
+    },
+    "Picker.Field.Summary" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zusammenfassung"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Summary"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Résumé"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Riepilogo"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "概要"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "요약"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tóm tắt"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "摘要"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "摘要"
+          }
+        }
+      }
+    },
+    "Picker.Field.Title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Titel"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Title"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Titre"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Titolo"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タイトル"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "제목"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tiêu đề"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "标题"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "標題"
+          }
+        }
+      }
+    },
+    "Picker.Title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elementauswahl"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Element Picker"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sélecteur d'éléments"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selettore elementi"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要素を選択"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "요소 선택기"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trình chọn phần tử"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "元素选取器"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "元素選取器"
+          }
+        }
+      }
+    },
+    "Picker.AssignTo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zuweisen zu…"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Assign to…"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Attribuer à…"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Assegna a…"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "割り当て先…"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "할당 대상…"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gán cho…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分配到…"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "指派給…"
+          }
+        }
+      }
+    },
+    "Picker.Children.A11y" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unterelemente anzeigen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show children"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher les enfants"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostra elementi figli"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "子要素を表示"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "하위 요소 표시"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hiển thị phần tử con"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示子元素"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示子元素"
+          }
+        }
+      }
+    },
+    "Picker.Children.Menu" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unterelemente"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Children"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enfants"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elementi figli"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "子要素"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "하위 요소"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Phần tử con"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "子元素"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "子元素"
+          }
+        }
+      }
+    },
+    "Picker.NoSelection" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tippe ein Element an, um es auszuwählen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap an element to pick it"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Touchez un élément pour le sélectionner"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tocca un elemento per selezionarlo"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要素をタップして選択"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "요소를 탭해서 선택하세요"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chạm vào một phần tử để chọn"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "轻点元素以选取"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "輕點元素以選取"
           }
         }
       }
     }
   },
-  "version": "1.1"
+  "version" : "1.1"
 }


### PR DESCRIPTION
Replaces the pure text-field CSS selector workflow with a
tap-to-assign element picker.  After fetching a page, users
can open the picker, tap any visible element, then choose which
feed field it represents (Item Container, Title, Link, Date,
Author, Summary, or Image) from a confirmation dialog.

New files:
- PetalElementPickerWebView: UIViewRepresentable wrapping a
  WKWebView.  Injects a JS overlay that highlights touched
  elements and posts compact CSS selectors back via a
  WKScriptMessageHandler.  Link navigation is blocked so taps
  stay inside the picker.
- PetalElementPickerView: sheet that hosts the web view plus a
  scrollable status bar showing which fields have been assigned
  (with their selectors as chips).

Modified:
- PetalBuilderSelectorsSection: new "Pick Elements" button
  (enabled once HTML has been fetched, like Auto-Detect).
- PetalBuilderView: wires up showElementPicker state and a sheet
  that re-runs the preview when the picker is dismissed.
- Petal.xcstrings: 10 new keys localized into all 9 languages.

https://claude.ai/code/session_01GMmH8GTibGKpsuR7kiqSed