### PR TITLE
Replace SceneStorage with State in FeedEditSheet

### DIFF
--- a/SakuraRSS/Views/Feeds/FeedEditSheet.swift
+++ b/SakuraRSS/Views/Feeds/FeedEditSheet.swift
@@ -8,11 +8,11 @@ struct FeedEditSheet: View {
 
     let feed: Feed
 
-    @SceneStorage("FeedEditSheet.name") private var name = ""
-    @SceneStorage("FeedEditSheet.url") private var url = ""
-    @SceneStorage("FeedEditSheet.iconURLInput") var iconURLInput = ""
-    @SceneStorage("FeedEditSheet.useDefaultIcon") var useDefaultIcon = false
-    @SceneStorage("FeedEditSheet.hasInitialized") private var hasInitialized = false
+    @State private var name = ""
+    @State private var url = ""
+    @State var iconURLInput = ""
+    @State var useDefaultIcon = false
+    @State private var hasInitialized = false
     @State private var openMode: FeedOpenMode = .inAppViewer
     @State private var articleSource: ArticleSource = .automatic
     @State var selectedPhoto: PhotosPickerItem?
@@ -208,7 +208,6 @@ struct FeedEditSheet: View {
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
                     Button(role: .cancel) {
-                        clearSceneStorage()
                         dismiss()
                     }
                 }
@@ -323,16 +322,7 @@ struct FeedEditSheet: View {
         } else {
             UserDefaults.standard.set(articleSource.rawValue, forKey: "articleSource-\(feed.id)")
         }
-        clearSceneStorage()
         dismiss()
-    }
-
-    private func clearSceneStorage() {
-        name = ""
-        url = ""
-        iconURLInput = ""
-        useDefaultIcon = false
-        hasInitialized = false
     }
 
 }


### PR DESCRIPTION
## Summary
Refactored `FeedEditSheet` to use `@State` properties instead of `@SceneStorage` for managing feed editing form state, and removed the associated cleanup logic.

## Key Changes
- Converted all `@SceneStorage` properties to `@State`:
  - `name`, `url`, `iconURLInput`, `useDefaultIcon`, and `hasInitialized`
- Removed `clearSceneStorage()` method that was manually resetting state values
- Removed calls to `clearSceneStorage()` from the cancel button action and save completion

## Implementation Details
This change simplifies state management by using local view state instead of scene-persistent storage. The form state is now scoped to the sheet's lifecycle rather than persisting across scene sessions, which is more appropriate for a modal editing interface. The removal of manual cleanup logic reduces code complexity and potential for state inconsistencies.

https://claude.ai/code/session_01Go2A6VvhZ2vid83sBJCya8