### PR TITLE
Add feed refresh progress indicator to Home tab

### DIFF
--- a/SakuraRSS/Classes/Feed Manager/FeedManager+Refresh.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+Refresh.swift
@@ -173,9 +173,6 @@ extension FeedManager {
         skipAuthenticatedScrapers: Bool = false,
         respectCooldown: Bool = false
     ) async {
-        await MainActor.run { isLoading = true }
-        defer { Task { @MainActor in self.isLoading = false } }
-
         let cooldownSeconds: TimeInterval? = {
             guard respectCooldown else { return nil }
             let raw = UserDefaults.standard.string(forKey: "BackgroundRefresh.Cooldown")
@@ -185,18 +182,36 @@ extension FeedManager {
         let now = Date()
 
         let currentFeeds = feeds
+        let feedsToRefresh = currentFeeds.filter { feed in
+            if skipAuthenticatedScrapers, feed.isXFeed || feed.isInstagramFeed {
+                return false
+            }
+            if let cooldownSeconds,
+               let lastFetched = feed.lastFetched,
+               now.timeIntervalSince(lastFetched) < cooldownSeconds {
+                return false
+            }
+            return true
+        }
+
+        await MainActor.run {
+            isLoading = true
+            refreshCompleted = 0
+            refreshTotal = feedsToRefresh.count
+        }
+        defer {
+            Task { @MainActor in
+                self.isLoading = false
+                self.refreshCompleted = 0
+                self.refreshTotal = 0
+            }
+        }
+
         await withTaskGroup(of: Void.self) { group in
-            for feed in currentFeeds {
-                if skipAuthenticatedScrapers, feed.isXFeed || feed.isInstagramFeed {
-                    continue
-                }
-                if let cooldownSeconds,
-                   let lastFetched = feed.lastFetched,
-                   now.timeIntervalSince(lastFetched) < cooldownSeconds {
-                    continue
-                }
+            for feed in feedsToRefresh {
                 group.addTask {
                     try? await self.refreshFeed(feed, reloadData: false)
+                    await MainActor.run { self.refreshCompleted += 1 }
                 }
             }
         }
@@ -224,14 +239,25 @@ extension FeedManager {
     }
 
     func refreshAllFeedsAndFavicons() async {
-        await MainActor.run { isLoading = true }
-        defer { Task { @MainActor in self.isLoading = false } }
-
         let currentFeeds = feeds
+        await MainActor.run {
+            isLoading = true
+            refreshCompleted = 0
+            refreshTotal = currentFeeds.count
+        }
+        defer {
+            Task { @MainActor in
+                self.isLoading = false
+                self.refreshCompleted = 0
+                self.refreshTotal = 0
+            }
+        }
+
         async let feedRefresh: Void = withTaskGroup(of: Void.self) { group in
             for feed in currentFeeds {
                 group.addTask {
                     try? await self.refreshFeed(feed, updateTitle: false, reloadData: false)
+                    await MainActor.run { self.refreshCompleted += 1 }
                 }
             }
         }

--- a/SakuraRSS/Classes/Feed Manager/FeedManager.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager.swift
@@ -8,6 +8,12 @@ final class FeedManager {
     var articles: [Article] = []
     var lists: [FeedList] = []
     var isLoading = false
+    var refreshTotal: Int = 0
+    var refreshCompleted: Int = 0
+    var refreshProgress: Double {
+        guard refreshTotal > 0 else { return 0 }
+        return min(max(Double(refreshCompleted) / Double(refreshTotal), 0), 1)
+    }
     private(set) var dataRevision: Int = 0
     private(set) var faviconRevision: Int = 0
     private(set) var unreadCounts: [Int64: Int] = [:]

--- a/SakuraRSS/Views/Home/HomeView.swift
+++ b/SakuraRSS/Views/Home/HomeView.swift
@@ -24,6 +24,14 @@ struct HomeView: View {
                 .environment(\.navigateToFeed, { feed in path.append(feed) })
                 .environment(\.hidesMarkAllReadToolbar, true)
                 .toolbar {
+                    ToolbarItemGroup(placement: .topBarLeading) {
+                        if feedManager.isLoading && feedManager.refreshTotal > 0 {
+                            FeedRefreshProgressDonut(
+                                progress: feedManager.refreshProgress
+                            )
+                        }
+                    }
+                    .sharedBackgroundVisibility(.hidden)
                     if markAllReadPosition == .top {
                         ToolbarItemGroup(placement: .topBarLeading) {
                             Button {

--- a/SakuraRSS/Views/Shared/FeedRefreshProgressDonut.swift
+++ b/SakuraRSS/Views/Shared/FeedRefreshProgressDonut.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+/// A small donut-shaped progress indicator displayed in the Home tab
+/// toolbar while feeds are refreshing.  The ring fills from empty to
+/// full as each individual feed finishes loading.
+struct FeedRefreshProgressDonut: View {
+
+    let progress: Double
+    var size: CGFloat = 18
+    var lineWidth: CGFloat = 2.5
+
+    private var clampedProgress: Double {
+        min(max(progress, 0), 1)
+    }
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .stroke(Color.secondary.opacity(0.25), lineWidth: lineWidth)
+            Circle()
+                .trim(from: 0, to: clampedProgress)
+                .stroke(
+                    Color.accentColor,
+                    style: StrokeStyle(lineWidth: lineWidth, lineCap: .round)
+                )
+                .rotationEffect(.degrees(-90))
+                .animation(.smooth, value: clampedProgress)
+        }
+        .frame(width: size, height: size)
+        .accessibilityElement()
+        .accessibilityLabel(Text(String(localized: "Refresh.Progress", table: "Home")))
+        .accessibilityValue(
+            Text(clampedProgress, format: .percent.precision(.fractionLength(0)))
+        )
+    }
+}

--- a/Shared/Strings/Home.xcstrings
+++ b/Shared/Strings/Home.xcstrings
@@ -1,6 +1,65 @@
 {
   "sourceLanguage": "en",
   "strings": {
+    "Refresh.Progress": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Feeds werden aktualisiert"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Refreshing feeds"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualisation des flux"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aggiornamento dei feed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フィードを更新中"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "피드 새로 고침 중"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đang làm mới nguồn cấp"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在刷新订阅源"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在更新訂閱源"
+          }
+        }
+      }
+    },
     "TodaysSummary.CombinePrompt": {
       "extractionState": "manual",
       "localizations": {


### PR DESCRIPTION
## Summary
This PR adds a visual progress indicator to the Home tab toolbar that displays the real-time progress of feed refreshes. As feeds are refreshed, a donut-shaped progress ring fills from empty to full, providing users with feedback on the refresh operation's completion status.

## Key Changes
- **New `FeedRefreshProgressDonut` component**: A small donut-shaped progress indicator that animates as feeds are refreshed, with accessibility support for screen readers
- **Progress tracking in `FeedManager`**: Added `refreshTotal` and `refreshCompleted` properties to track the number of feeds being refreshed and how many have completed
- **Computed `refreshProgress` property**: Calculates the progress percentage (0-1) based on completed vs. total feeds
- **Updated refresh methods**: Modified `refreshAllFeeds()` and `refreshAllFeedsAndFavicons()` to:
  - Pre-calculate which feeds need refreshing (respecting cooldown and authentication settings)
  - Initialize progress tracking before starting refresh operations
  - Increment `refreshCompleted` as each feed finishes
  - Reset progress counters when refresh completes
- **Home tab integration**: Added the progress donut to the top bar leading placement, visible only during active refresh operations
- **Localization**: Added "Refresh.Progress" string with translations for 9 languages (English, German, French, Italian, Japanese, Korean, Vietnamese, Simplified Chinese, Traditional Chinese)

## Implementation Details
- The progress indicator uses smooth animation for visual feedback
- Progress is clamped between 0 and 1 to handle edge cases
- The donut ring fills with the accent color and includes proper accessibility labels and values
- Refresh progress is properly reset in defer blocks to ensure cleanup even if operations fail

https://claude.ai/code/session_01FQwHsAJhvsuTSp2Rq5xLRp