### PR TITLE
Add scroll-to-mark-as-read feature

### DIFF
--- a/SakuraRSS/Classes/Feed Manager/FeedManager+Articles.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+Articles.swift
@@ -177,6 +177,12 @@ extension FeedManager {
         updateBadgeCount()
     }
 
+    func markAllUnread() {
+        try? database.markAllUnread()
+        loadFromDatabase()
+        updateBadgeCount()
+    }
+
     func unreadCount(for feed: Feed) -> Int {
         _ = dataRevision
         return unreadCounts[feed.id] ?? 0

--- a/SakuraRSS/Views/App.swift
+++ b/SakuraRSS/Views/App.swift
@@ -142,6 +142,8 @@ struct SakuraRSSApp: App {
                 Task {
                     await feedManager.deleteAllArticlesAndRefresh()
                 }
+            case "bigbang":
+                feedManager.markAllUnread()
             case "howmanybulbs":
                 Task {
                     SpotlightIndexer.removeAllArticles()

--- a/SakuraRSS/Views/More/MoreView.swift
+++ b/SakuraRSS/Views/More/MoreView.swift
@@ -44,9 +44,7 @@ struct MoreView: View {
                     } label: {
                         Text(String(localized: "MarkAllReadPosition", table: "Settings"))
                     }
-                    Toggle(isOn: $scrollMarkAsRead) {
-                        Text(String(localized: "ScrollMarkAsRead", table: "Settings"))
-                    }
+                    Toggle(String(localized: "ScrollMarkAsRead", table: "Settings"), isOn: $scrollMarkAsRead)
                     Picker(String(localized: "UnreadBadgeMode", table: "Settings"), selection: $unreadBadgeMode) {
                         if UIDevice.current.userInterfaceIdiom == .pad {
                             Text(String(localized: "UnreadBadgeMode.HomeScreenOnly", table: "Settings"))

--- a/SakuraRSS/Views/More/MoreView.swift
+++ b/SakuraRSS/Views/More/MoreView.swift
@@ -13,6 +13,7 @@ struct MoreView: View {
     @AppStorage("BackgroundRefresh.Cooldown") private var refreshCooldown: FeedRefreshCooldown = .fiveMinutes
     @AppStorage("Display.DefaultStyle") private var defaultDisplayStyle: FeedDisplayStyle = .inbox
     @AppStorage("Display.MarkAllReadPosition") private var markAllReadPosition: MarkAllReadPosition = .bottom
+    @AppStorage("Display.ScrollMarkAsRead") private var scrollMarkAsRead: Bool = false
     @AppStorage("Display.UnreadBadgeMode") private var unreadBadgeMode: UnreadBadgeMode = .none
 
     var body: some View {
@@ -42,6 +43,9 @@ struct MoreView: View {
                             .tag(MarkAllReadPosition.none)
                     } label: {
                         Text(String(localized: "MarkAllReadPosition", table: "Settings"))
+                    }
+                    Toggle(isOn: $scrollMarkAsRead) {
+                        Text(String(localized: "ScrollMarkAsRead", table: "Settings"))
                     }
                     Picker(String(localized: "UnreadBadgeMode", table: "Settings"), selection: $unreadBadgeMode) {
                         if UIDevice.current.userInterfaceIdiom == .pad {

--- a/SakuraRSS/Views/Shared/Feed Display Styles/CompactStyleView.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/CompactStyleView.swift
@@ -34,6 +34,7 @@ struct CompactStyleView: View {
                 }, label: {
                     articleLabel(for: article)
                         .zoomSource(id: article.id, namespace: zoomNamespace)
+                        .markReadOnScroll(article: article)
                 })
                 .listRowBackground(Color.clear)
                 .listRowInsets(EdgeInsets(top: 6, leading: 16, bottom: 6, trailing: 16))
@@ -50,7 +51,6 @@ struct CompactStyleView: View {
                         )
                     }
                 }
-                .markReadOnScroll(article: article)
             }
             if let onLoadMore {
                 LoadPreviousArticlesButton(action: onLoadMore)

--- a/SakuraRSS/Views/Shared/Feed Display Styles/CompactStyleView.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/CompactStyleView.swift
@@ -50,6 +50,7 @@ struct CompactStyleView: View {
                         )
                     }
                 }
+                .markReadOnScroll(article: article)
             }
             if let onLoadMore {
                 LoadPreviousArticlesButton(action: onLoadMore)

--- a/SakuraRSS/Views/Shared/Feed Display Styles/FeedStyleView.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/FeedStyleView.swift
@@ -50,6 +50,7 @@ struct FeedStyleView: View {
                         }
                     }
                     .zoomSource(id: article.id, namespace: zoomNamespace)
+                    .markReadOnScroll(article: article)
                 }
                 .padding(.horizontal, 12)
                 .listRowBackground(Color.clear)
@@ -62,7 +63,6 @@ struct FeedStyleView: View {
                 .alignmentGuide(.listRowSeparatorTrailing) { dimensions in
                     return dimensions.width
                 }
-                .markReadOnScroll(article: article)
             }
             if let onLoadMore {
                 LoadPreviousArticlesButton(action: onLoadMore)

--- a/SakuraRSS/Views/Shared/Feed Display Styles/FeedStyleView.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/FeedStyleView.swift
@@ -62,6 +62,7 @@ struct FeedStyleView: View {
                 .alignmentGuide(.listRowSeparatorTrailing) { dimensions in
                     return dimensions.width
                 }
+                .markReadOnScroll(article: article)
             }
             if let onLoadMore {
                 LoadPreviousArticlesButton(action: onLoadMore)

--- a/SakuraRSS/Views/Shared/Feed Display Styles/GridStyleView.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/GridStyleView.swift
@@ -27,6 +27,7 @@ struct GridStyleView: View {
                     }, label: {
                         GridArticleCell(article: article)
                             .zoomSource(id: article.id, namespace: zoomNamespace)
+                            .markReadOnScroll(article: article)
                     })
                     .buttonStyle(.plain)
                     .contextMenu {
@@ -49,7 +50,6 @@ struct GridStyleView: View {
                             }
                         }
                     }
-                    .markReadOnScroll(article: article)
                 }
             }
             if let onLoadMore {

--- a/SakuraRSS/Views/Shared/Feed Display Styles/GridStyleView.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/GridStyleView.swift
@@ -49,6 +49,7 @@ struct GridStyleView: View {
                             }
                         }
                     }
+                    .markReadOnScroll(article: article)
                 }
             }
             if let onLoadMore {

--- a/SakuraRSS/Views/Shared/Feed Display Styles/InboxStyleView.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/InboxStyleView.swift
@@ -41,6 +41,7 @@ struct InboxStyleView: View {
                 .listRowSeparator(.hidden, edges: .top)
                 .listRowSeparator(.visible, edges: .bottom)
                 .listRowInsets(EdgeInsets(top: 8, leading: 12, bottom: 8, trailing: 12))
+                .markReadOnScroll(article: article)
             }
             if let onLoadMore {
                 LoadPreviousArticlesButton(action: onLoadMore)

--- a/SakuraRSS/Views/Shared/Feed Display Styles/InboxStyleView.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/InboxStyleView.swift
@@ -16,6 +16,7 @@ struct InboxStyleView: View {
                 }, label: {
                     InboxArticleRow(article: article)
                         .zoomSource(id: article.id, namespace: zoomNamespace)
+                        .markReadOnScroll(article: article)
                 })
                 .swipeActions(edge: .leading) {
                     Button {
@@ -41,7 +42,6 @@ struct InboxStyleView: View {
                 .listRowSeparator(.hidden, edges: .top)
                 .listRowSeparator(.visible, edges: .bottom)
                 .listRowInsets(EdgeInsets(top: 8, leading: 12, bottom: 8, trailing: 12))
-                .markReadOnScroll(article: article)
             }
             if let onLoadMore {
                 LoadPreviousArticlesButton(action: onLoadMore)

--- a/SakuraRSS/Views/Shared/Feed Display Styles/MagazineStyleView.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/MagazineStyleView.swift
@@ -23,6 +23,7 @@ struct MagazineStyleView: View {
                         }, label: {
                             MagazineArticleCard(article: article)
                                 .zoomSource(id: article.id, namespace: zoomNamespace)
+                                .markReadOnScroll(article: article)
                         })
                         .buttonStyle(.plain)
                         .contextMenu {
@@ -38,7 +39,6 @@ struct MagazineStyleView: View {
                                 )
                             }
                         }
-                        .markReadOnScroll(article: article)
                     }
                 }
                 .padding(.horizontal, 16)

--- a/SakuraRSS/Views/Shared/Feed Display Styles/MagazineStyleView.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/MagazineStyleView.swift
@@ -38,6 +38,7 @@ struct MagazineStyleView: View {
                                 )
                             }
                         }
+                        .markReadOnScroll(article: article)
                     }
                 }
                 .padding(.horizontal, 16)

--- a/SakuraRSS/Views/Shared/Feed Display Styles/PhotosStyleView.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/PhotosStyleView.swift
@@ -14,6 +14,7 @@ struct PhotosStyleView: View {
                 ForEach(articles) { article in
                     PhotosArticleCard(article: article, youTubeArticle: $youTubeArticle)
                         .zoomSource(id: article.id, namespace: zoomNamespace)
+                        .markReadOnScroll(article: article)
                 }
                 if let onLoadMore {
                     LoadPreviousArticlesButton(action: onLoadMore)

--- a/SakuraRSS/Views/Shared/Feed Display Styles/PodcastStyleView.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/PodcastStyleView.swift
@@ -75,6 +75,7 @@ struct PodcastStyleView: View {
                         }
                     }
                 }
+                .markReadOnScroll(article: article)
             }
             if let onLoadMore {
                 LoadPreviousArticlesButton(action: onLoadMore)

--- a/SakuraRSS/Views/Shared/Feed Display Styles/PodcastStyleView.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/PodcastStyleView.swift
@@ -29,6 +29,7 @@ struct PodcastStyleView: View {
 
                     PodcastEpisodeRow(article: article)
                         .zoomSource(id: article.id, namespace: zoomNamespace)
+                        .markReadOnScroll(article: article)
                 }
                 .listRowBackground(Color.clear)
                 .listRowInsets(EdgeInsets(top: 8, leading: 12, bottom: 8, trailing: 16))
@@ -75,7 +76,6 @@ struct PodcastStyleView: View {
                         }
                     }
                 }
-                .markReadOnScroll(article: article)
             }
             if let onLoadMore {
                 LoadPreviousArticlesButton(action: onLoadMore)

--- a/SakuraRSS/Views/Shared/Feed Display Styles/TimelineStyleView.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/TimelineStyleView.swift
@@ -30,12 +30,12 @@ struct TimelineStyleView: View {
                                 isFeatured: groupIndex == 0 && index == 0
                             )
                             .zoomSource(id: article.id, namespace: zoomNamespace)
+                            .markReadOnScroll(article: article)
                         }
                         .listRowBackground(Color.clear)
                         .listRowInsets(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))
                         .listRowSeparator(.hidden)
                         .listRowSpacing(0)
-                        .markReadOnScroll(article: article)
                     }
                 } header: {
                     Text(group.key)

--- a/SakuraRSS/Views/Shared/Feed Display Styles/TimelineStyleView.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/TimelineStyleView.swift
@@ -35,6 +35,7 @@ struct TimelineStyleView: View {
                         .listRowInsets(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))
                         .listRowSeparator(.hidden)
                         .listRowSpacing(0)
+                        .markReadOnScroll(article: article)
                     }
                 } header: {
                     Text(group.key)

--- a/SakuraRSS/Views/Shared/Feed Display Styles/VideoStyleView.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/VideoStyleView.swift
@@ -33,6 +33,7 @@ struct VideoStyleView: View {
                     } label: {
                         VideoArticleCard(article: article)
                             .zoomSource(id: article.id, namespace: zoomNamespace)
+                            .markReadOnScroll(article: article)
                     }
                     .buttonStyle(.plain)
                     .contextMenu {
@@ -68,7 +69,6 @@ struct VideoStyleView: View {
                             }
                         }
                     }
-                    .markReadOnScroll(article: article)
                 }
             }
             .padding(.bottom)

--- a/SakuraRSS/Views/Shared/Feed Display Styles/VideoStyleView.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/VideoStyleView.swift
@@ -68,6 +68,7 @@ struct VideoStyleView: View {
                             }
                         }
                     }
+                    .markReadOnScroll(article: article)
                 }
             }
             .padding(.bottom)

--- a/SakuraRSS/Views/Shared/MarkReadOnScrollModifier.swift
+++ b/SakuraRSS/Views/Shared/MarkReadOnScrollModifier.swift
@@ -12,20 +12,27 @@ struct MarkReadOnScrollModifier: ViewModifier {
 
     @State private var hasBeenVisible = false
 
+    private var latestIsRead: Bool {
+        feedManager.article(byID: article.id)?.isRead ?? article.isRead
+    }
+
     func body(content: Content) -> some View {
         content
             .onScrollVisibilityChange(threshold: 0.5) { isVisible in
                 guard scrollMarkAsRead else { return }
                 if isVisible {
                     hasBeenVisible = true
-                } else if hasBeenVisible, !article.isRead {
+                } else if hasBeenVisible, !latestIsRead {
                     #if DEBUG
                     debugPrint("[ScrollMarkAsRead] Marking article as read: \(article.id) — \(article.title)")
                     #endif
-                    let articleToMark = article
+                    let articleID = article.id
                     Task { @MainActor in
+                        guard let fresh = feedManager.article(byID: articleID), !fresh.isRead else {
+                            return
+                        }
                         withAnimation(.smooth.speed(2.0)) {
-                            feedManager.markRead(articleToMark)
+                            feedManager.markRead(fresh)
                         }
                     }
                 }

--- a/SakuraRSS/Views/Shared/MarkReadOnScrollModifier.swift
+++ b/SakuraRSS/Views/Shared/MarkReadOnScrollModifier.swift
@@ -22,7 +22,9 @@ struct MarkReadOnScrollModifier: ViewModifier {
                     #if DEBUG
                     debugPrint("[ScrollMarkAsRead] Marking article as read: \(article.id) — \(article.title)")
                     #endif
-                    feedManager.markRead(article)
+                    withAnimation(.smooth.speed(2.0)) {
+                        feedManager.markRead(article)
+                    }
                 }
             }
     }

--- a/SakuraRSS/Views/Shared/MarkReadOnScrollModifier.swift
+++ b/SakuraRSS/Views/Shared/MarkReadOnScrollModifier.swift
@@ -19,6 +19,9 @@ struct MarkReadOnScrollModifier: ViewModifier {
                 if isVisible {
                     hasBeenVisible = true
                 } else if hasBeenVisible, !article.isRead {
+                    #if DEBUG
+                    debugPrint("[ScrollMarkAsRead] Marking article as read: \(article.id) — \(article.title)")
+                    #endif
                     feedManager.markRead(article)
                 }
             }

--- a/SakuraRSS/Views/Shared/MarkReadOnScrollModifier.swift
+++ b/SakuraRSS/Views/Shared/MarkReadOnScrollModifier.swift
@@ -18,31 +18,28 @@ struct MarkReadOnScrollModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         content
-            .onScrollVisibilityChange(threshold: 0.5) { isVisible in
-                guard scrollMarkAsRead else { return }
-                if isVisible {
-                    hasBeenVisible = true
-                } else if hasBeenVisible, !latestIsRead {
-                    #if DEBUG
-                    debugPrint("[ScrollMarkAsRead] Marking article as read: \(article.id) — \(article.title)")
-                    #endif
-                    let articleID = article.id
-                    Task { @MainActor in
-                        guard let fresh = feedManager.article(byID: articleID), !fresh.isRead else {
-                            return
-                        }
-                        withAnimation(.smooth.speed(2.0)) {
-                            feedManager.markRead(fresh)
-                        }
-                    }
-                }
-            }
             .onAppear {
+                hasBeenVisible = true
                 if article.isRead != latestIsRead {
                     #if DEBUG
                     debugPrint("[ScrollMarkAsRead] Stale read state on appear for \(article.id), reloading")
                     #endif
                     feedManager.loadFromDatabase()
+                }
+            }
+            .onDisappear {
+                guard scrollMarkAsRead, hasBeenVisible, !latestIsRead else { return }
+                #if DEBUG
+                debugPrint("[ScrollMarkAsRead] Marking article as read: \(article.id) — \(article.title)")
+                #endif
+                let articleID = article.id
+                Task { @MainActor in
+                    guard let fresh = feedManager.article(byID: articleID), !fresh.isRead else {
+                        return
+                    }
+                    withAnimation(.smooth.speed(2.0)) {
+                        feedManager.markRead(fresh)
+                    }
                 }
             }
     }

--- a/SakuraRSS/Views/Shared/MarkReadOnScrollModifier.swift
+++ b/SakuraRSS/Views/Shared/MarkReadOnScrollModifier.swift
@@ -37,6 +37,14 @@ struct MarkReadOnScrollModifier: ViewModifier {
                     }
                 }
             }
+            .onAppear {
+                if article.isRead != latestIsRead {
+                    #if DEBUG
+                    debugPrint("[ScrollMarkAsRead] Stale read state on appear for \(article.id), reloading")
+                    #endif
+                    feedManager.loadFromDatabase()
+                }
+            }
     }
 }
 

--- a/SakuraRSS/Views/Shared/MarkReadOnScrollModifier.swift
+++ b/SakuraRSS/Views/Shared/MarkReadOnScrollModifier.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+/// Marks an article as read once it has been visible and then scrolled out of
+/// view. Enabled only when the user has opted in via the
+/// `Display.ScrollMarkAsRead` setting.
+struct MarkReadOnScrollModifier: ViewModifier {
+
+    @Environment(FeedManager.self) private var feedManager
+    @AppStorage("Display.ScrollMarkAsRead") private var scrollMarkAsRead: Bool = false
+
+    let article: Article
+
+    @State private var hasBeenVisible = false
+
+    func body(content: Content) -> some View {
+        content
+            .onScrollVisibilityChange(threshold: 0.5) { isVisible in
+                guard scrollMarkAsRead else { return }
+                if isVisible {
+                    hasBeenVisible = true
+                } else if hasBeenVisible, !article.isRead {
+                    feedManager.markRead(article)
+                }
+            }
+    }
+}
+
+extension View {
+    func markReadOnScroll(article: Article) -> some View {
+        modifier(MarkReadOnScrollModifier(article: article))
+    }
+}

--- a/SakuraRSS/Views/Shared/MarkReadOnScrollModifier.swift
+++ b/SakuraRSS/Views/Shared/MarkReadOnScrollModifier.swift
@@ -11,6 +11,7 @@ struct MarkReadOnScrollModifier: ViewModifier {
     let article: Article
 
     @State private var hasBeenVisible = false
+    @State private var lastKnownMinY: CGFloat = 0
 
     private var latestIsRead: Bool {
         feedManager.article(byID: article.id)?.isRead ?? article.isRead
@@ -18,6 +19,11 @@ struct MarkReadOnScrollModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         content
+            .onGeometryChange(for: CGFloat.self) { proxy in
+                proxy.frame(in: .global).minY
+            } action: { newValue in
+                lastKnownMinY = newValue
+            }
             .onAppear {
                 hasBeenVisible = true
                 if article.isRead != latestIsRead {
@@ -29,6 +35,10 @@ struct MarkReadOnScrollModifier: ViewModifier {
             }
             .onDisappear {
                 guard scrollMarkAsRead, hasBeenVisible, !latestIsRead else { return }
+                // Only mark as read when the row scrolled off the TOP of the
+                // viewport (user scrolled down past it). A negative minY means
+                // the row's top edge is above the screen's origin.
+                guard lastKnownMinY < 0 else { return }
                 #if DEBUG
                 debugPrint("[ScrollMarkAsRead] Marking article as read: \(article.id) — \(article.title)")
                 #endif

--- a/SakuraRSS/Views/Shared/MarkReadOnScrollModifier.swift
+++ b/SakuraRSS/Views/Shared/MarkReadOnScrollModifier.swift
@@ -22,8 +22,11 @@ struct MarkReadOnScrollModifier: ViewModifier {
                     #if DEBUG
                     debugPrint("[ScrollMarkAsRead] Marking article as read: \(article.id) — \(article.title)")
                     #endif
-                    withAnimation(.smooth.speed(2.0)) {
-                        feedManager.markRead(article)
+                    let articleToMark = article
+                    Task { @MainActor in
+                        withAnimation(.smooth.speed(2.0)) {
+                            feedManager.markRead(articleToMark)
+                        }
                     }
                 }
             }

--- a/Shared/Database Manager/DatabaseManager+Articles.swift
+++ b/Shared/Database Manager/DatabaseManager+Articles.swift
@@ -242,6 +242,11 @@ nonisolated extension DatabaseManager {
         try database.run(target.update(articleIsRead <- true))
     }
 
+    func markAllUnread() throws {
+        let target = articles.filter(articleIsRead == true)
+        try database.run(target.update(articleIsRead <- false))
+    }
+
     func unreadCount(forFeedID fid: Int64) throws -> Int {
         try database.scalar(articles.filter(articleFeedID == fid && articleIsRead == false).count)
     }

--- a/Shared/Strings/Localizable.xcstrings
+++ b/Shared/Strings/Localizable.xcstrings
@@ -18,6 +18,9 @@
     "·" : {
       "shouldTranslate" : false
     },
+    "@%@" : {
+      "shouldTranslate" : false
+    },
     "%@" : {
       "shouldTranslate" : false
     },

--- a/Shared/Strings/Settings.xcstrings
+++ b/Shared/Strings/Settings.xcstrings
@@ -2302,6 +2302,65 @@
         }
       }
     },
+    "ScrollMarkAsRead": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beim Scrollen als gelesen markieren"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scroll to Mark as Read"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Marquer comme lu au défilement"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Segna come letto scorrendo"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "スクロールで既読にする"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "스크롤하여 읽음으로 표시"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đánh dấu đã đọc khi cuộn"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "滚动时标为已读"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "滾動時標為已讀"
+          }
+        }
+      }
+    },
     "SearchDisplayStyle": {
       "extractionState": "manual",
       "localizations": {


### PR DESCRIPTION
## Summary
This PR introduces a new "Scroll to Mark as Read" feature that automatically marks articles as read when they scroll out of view, along with a complementary "Mark All Unread" function for bulk operations.

## Key Changes

- **New `MarkReadOnScrollModifier`**: A view modifier that tracks article visibility and automatically marks articles as read when they scroll off the top of the viewport. The feature is opt-in via the `Display.ScrollMarkAsRead` setting and includes safeguards to prevent marking already-read articles or articles that haven't been visible yet.

- **Mark All Unread functionality**: Added `markAllUnread()` methods to both `FeedManager` and `DatabaseManager` to support bulk marking of all articles as unread, accessible via the "bigbang" debug command.

- **Settings integration**: Added the new `Display.ScrollMarkAsRead` setting with full localization support across 9 languages (English, German, French, Italian, Japanese, Korean, Vietnamese, Simplified Chinese, and Traditional Chinese).

- **UI updates**: Applied the `.markReadOnScroll()` modifier to all feed display styles (Compact, Feed, Grid, Inbox, Magazine, Photos, Podcast, Timeline, and Video) to enable the feature across the entire app.

- **Settings UI**: Added toggle for the new scroll-mark-as-read setting in `MoreView`.

## Implementation Details

- The modifier uses `onGeometryChange` to track the article's vertical position and `onDisappear` to detect when it scrolls out of view
- Only marks as read when `lastKnownMinY < 0` (scrolled past the top), preventing false positives from articles scrolled down but still visible
- Includes state validation to handle stale read states and prevent race conditions with a fresh database lookup before marking
- Uses smooth animation when marking articles as read for better UX
- Debug logging included for troubleshooting scroll-mark-as-read behavior

https://claude.ai/code/session_01MwVcGhQxMBh2XYt5rPowMh