### PR TITLE
Add batching modes for paginating older articles

### DIFF
--- a/SakuraRSS/Classes/Feed Manager/FeedManager+Batching.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+Batching.swift
@@ -1,0 +1,177 @@
+import Foundation
+
+extension FeedManager {
+
+    // MARK: - Count-based Batches (All)
+
+    func articles(limit: Int) -> [Article] {
+        _ = dataRevision
+        let fetchLimit = max(limit * 4, 100)
+        var all = (try? database.allArticles(limit: fetchLimit)) ?? []
+        let muted = mutedFeedIDs
+        if !muted.isEmpty {
+            all = all.filter { !muted.contains($0.feedID) }
+        }
+        return Array(applyAllRules(all).prefix(limit))
+    }
+
+    func hasMoreArticles(beyond count: Int) -> Bool {
+        _ = dataRevision
+        let fetchLimit = count + max(count, 100)
+        var all = (try? database.allArticles(limit: fetchLimit)) ?? []
+        let muted = mutedFeedIDs
+        if !muted.isEmpty {
+            all = all.filter { !muted.contains($0.feedID) }
+        }
+        return applyAllRules(all).count > count
+    }
+
+    // MARK: - Count-based Batches (Section)
+
+    func articles(for section: FeedSection, limit: Int) -> [Article] {
+        let sectionFeedIDs = Set(feeds.filter { $0.feedSection == section }.map(\.id))
+        guard !sectionFeedIDs.isEmpty else { return [] }
+        return Array(articles(limit: limit * 3).filter { sectionFeedIDs.contains($0.feedID) }.prefix(limit))
+    }
+
+    func hasMoreArticles(for section: FeedSection, beyond count: Int) -> Bool {
+        let sectionFeedIDs = Set(feeds.filter { $0.feedSection == section }.map(\.id))
+        guard !sectionFeedIDs.isEmpty else { return false }
+        let filtered = articles(limit: (count + 1) * 3).filter { sectionFeedIDs.contains($0.feedID) }
+        return filtered.count > count
+    }
+
+    // MARK: - Count-based Batches (Feed)
+
+    func hasMoreArticles(for feed: Feed, beyond count: Int) -> Bool {
+        _ = dataRevision
+        let all = (try? database.articles(forFeedID: feed.id, limit: count + 1)) ?? []
+        return applyRules(all, feedID: feed.id).count > count
+    }
+
+    // MARK: - Count-based Batches (List)
+
+    func articles(for list: FeedList, limit: Int) -> [Article] {
+        let listFeedIDs = feedIDs(for: list)
+        guard !listFeedIDs.isEmpty else { return [] }
+        let pooled = articles(limit: limit * 3).filter { listFeedIDs.contains($0.feedID) }
+        return Array(applyListRules(pooled, listID: list.id).prefix(limit))
+    }
+
+    func hasMoreArticles(for list: FeedList, beyond count: Int) -> Bool {
+        let listFeedIDs = feedIDs(for: list)
+        guard !listFeedIDs.isEmpty else { return false }
+        let pooled = articles(limit: (count + 1) * 3).filter { listFeedIDs.contains($0.feedID) }
+        return applyListRules(pooled, listID: list.id).count > count
+    }
+
+    // MARK: - Date-based Batches (List)
+
+    func articles(for list: FeedList, since date: Date) -> [Article] {
+        let listFeedIDs = feedIDs(for: list)
+        guard !listFeedIDs.isEmpty else { return [] }
+        let filtered = articles(since: date).filter { listFeedIDs.contains($0.feedID) }
+        return applyListRules(filtered, listID: list.id)
+    }
+
+    func nextArticleChunk(for list: FeedList, before date: Date, chunkDays days: Int) -> Date? {
+        _ = dataRevision
+        let listFeedIDs = feedIDs(for: list)
+        guard !listFeedIDs.isEmpty else { return nil }
+        let calendar = Calendar.current
+        let muted = mutedFeedIDs
+        var cursor = date
+        var iterations = 0
+        let maxIterations = FeedManager.chunkWalkLimit
+        while iterations < maxIterations {
+            iterations += 1
+            guard (try? database.earliestArticleDate(before: cursor)) ?? nil != nil else { return nil }
+            guard let newStart = calendar.date(byAdding: .day, value: -days, to: cursor) else { return nil }
+            let windowArticles = (try? database.allArticles(from: newStart, to: cursor, limit: 10000)) ?? []
+            var visible = muted.isEmpty ? windowArticles : windowArticles.filter { !muted.contains($0.feedID) }
+            visible = applyAllRules(visible).filter { listFeedIDs.contains($0.feedID) }
+            visible = applyListRules(visible, listID: list.id)
+            if !visible.isEmpty {
+                return newStart
+            }
+            cursor = newStart
+        }
+        return nil
+    }
+
+    // MARK: - Date-based Batches (Arbitrary Window)
+
+    /// Walks backwards in `chunkDays`-sized windows until it finds a window
+    /// that contains at least one visible article, honoring muted feeds and
+    /// per-feed / per-list rules. Returns the start date of that window, or
+    /// `nil` if no older content exists.
+    func nextArticleChunk(before date: Date, chunkDays days: Int) -> Date? {
+        _ = dataRevision
+        let calendar = Calendar.current
+        let muted = mutedFeedIDs
+        var cursor = date
+        var iterations = 0
+        let maxIterations = FeedManager.chunkWalkLimit
+        while iterations < maxIterations {
+            iterations += 1
+            guard (try? database.earliestArticleDate(before: cursor)) ?? nil != nil else { return nil }
+            guard let newStart = calendar.date(byAdding: .day, value: -days, to: cursor) else { return nil }
+            let windowArticles = (try? database.allArticles(from: newStart, to: cursor, limit: 10000)) ?? []
+            var visible = muted.isEmpty ? windowArticles : windowArticles.filter { !muted.contains($0.feedID) }
+            visible = applyAllRules(visible)
+            if !visible.isEmpty {
+                return newStart
+            }
+            cursor = newStart
+        }
+        return nil
+    }
+
+    /// Section-scoped variant of `nextArticleChunk(before:chunkDays:)`.
+    func nextArticleChunk(for section: FeedSection, before date: Date, chunkDays days: Int) -> Date? {
+        _ = dataRevision
+        let sectionFeedIDs = Set(feeds.filter { $0.feedSection == section }.map(\.id))
+        guard !sectionFeedIDs.isEmpty else { return nil }
+        let calendar = Calendar.current
+        let muted = mutedFeedIDs
+        var cursor = date
+        var iterations = 0
+        let maxIterations = FeedManager.chunkWalkLimit
+        while iterations < maxIterations {
+            iterations += 1
+            guard (try? database.earliestArticleDate(before: cursor)) ?? nil != nil else { return nil }
+            guard let newStart = calendar.date(byAdding: .day, value: -days, to: cursor) else { return nil }
+            let windowArticles = (try? database.allArticles(from: newStart, to: cursor, limit: 10000)) ?? []
+            var visible = muted.isEmpty ? windowArticles : windowArticles.filter { !muted.contains($0.feedID) }
+            visible = applyAllRules(visible).filter { sectionFeedIDs.contains($0.feedID) }
+            if !visible.isEmpty {
+                return newStart
+            }
+            cursor = newStart
+        }
+        return nil
+    }
+
+    /// Feed-scoped variant of `nextArticleChunk(before:chunkDays:)`.
+    func nextArticleChunk(for feed: Feed, before date: Date, chunkDays days: Int) -> Date? {
+        _ = dataRevision
+        let calendar = Calendar.current
+        var cursor = date
+        var iterations = 0
+        let maxIterations = FeedManager.chunkWalkLimit
+        while iterations < maxIterations {
+            iterations += 1
+            guard (try? database.earliestArticleDate(forFeedID: feed.id, before: cursor)) ?? nil != nil else {
+                return nil
+            }
+            guard let newStart = calendar.date(byAdding: .day, value: -days, to: cursor) else { return nil }
+            let windowArticles = ((try? database.articles(forFeedID: feed.id, since: newStart)) ?? [])
+                .filter { ($0.publishedDate ?? .distantPast) < cursor }
+            if !applyRules(windowArticles, feedID: feed.id).isEmpty {
+                return newStart
+            }
+            cursor = newStart
+        }
+        return nil
+    }
+}

--- a/SakuraRSS/Views/Feeds/FeedArticlesView.swift
+++ b/SakuraRSS/Views/Feeds/FeedArticlesView.swift
@@ -5,7 +5,9 @@ struct FeedArticlesView: View {
     @Environment(FeedManager.self) var feedManager
     let feed: Feed
 
-    @State private var loadedSinceDate: Date = FeedManager.currentChunkStart()
+    @AppStorage("Articles.BatchingMode") private var batchingMode: BatchingMode = .day1
+    @State private var loadedSinceDate: Date = BatchingMode.current().initialSinceDate()
+    @State private var loadedCount: Int = BatchingMode.current().initialCount()
     @AppStorage("Display.MarkAllReadPosition") private var markAllReadPosition: MarkAllReadPosition = .bottom
     @AppStorage("Instagram.HideReels") private var hideReels: Bool = false
 
@@ -13,13 +15,31 @@ struct FeedArticlesView: View {
         feedManager.feeds.first(where: { $0.id == feed.id }) ?? feed
     }
 
-    private var nextOlderChunk: Date? {
-        feedManager.nextArticleChunk(for: feed, before: loadedSinceDate)
+    private var loadMoreAction: (() -> Void)? {
+        if let days = batchingMode.chunkDays {
+            guard let next = feedManager.nextArticleChunk(for: feed,
+                                                          before: loadedSinceDate,
+                                                          chunkDays: days) else {
+                return nil
+            }
+            return { loadedSinceDate = next }
+        }
+        if let batch = batchingMode.batchSize {
+            guard feedManager.hasMoreArticles(for: feed, beyond: loadedCount) else { return nil }
+            return { loadedCount += batch }
+        }
+        return nil
     }
 
     private var filteredArticles: [Article] {
-        var articles = feedManager.undatedArticles(for: feed)
-            + feedManager.articles(for: feed, since: loadedSinceDate)
+        var articles: [Article]
+        if batchingMode.isCountBased {
+            articles = feedManager.undatedArticles(for: feed)
+                + feedManager.articles(for: feed, limit: loadedCount)
+        } else {
+            articles = feedManager.undatedArticles(for: feed)
+                + feedManager.articles(for: feed, since: loadedSinceDate)
+        }
         if hideReels && feed.isInstagramFeed {
             articles = articles.filter { !$0.url.contains("/reel/") }
         }
@@ -38,9 +58,7 @@ struct FeedArticlesView: View {
             isFeedViewDomain: feed.isFeedViewDomain,
             isFeedCompactViewDomain: feed.isFeedCompactViewDomain,
             isTimelineViewDomain: feed.isTimelineViewDomain,
-            onLoadMore: nextOlderChunk.map { chunk in
-                { loadedSinceDate = chunk }
-            },
+            onLoadMore: loadMoreAction,
             onRefresh: { [feed] in
                 try? await feedManager.refreshFeed(feed)
             },
@@ -53,6 +71,10 @@ struct FeedArticlesView: View {
         }
         .markAllReadToolbar(show: markAllReadPosition == .bottom) {
             feedManager.markAllRead(feed: feed)
+        }
+        .onChange(of: batchingMode) { _, newMode in
+            loadedSinceDate = newMode.initialSinceDate()
+            loadedCount = newMode.initialCount()
         }
     }
 }

--- a/SakuraRSS/Views/Home/AllArticlesView.swift
+++ b/SakuraRSS/Views/Home/AllArticlesView.swift
@@ -100,7 +100,9 @@ struct AllArticlesView: View {
     @Environment(FeedManager.self) var feedManager
 
     @AppStorage("Home.SelectedSection") private var selectedSelection: HomeSelection = .section(.feed)
-    @State private var loadedSinceDate: Date = FeedManager.currentChunkStart()
+    @AppStorage("Articles.BatchingMode") private var batchingMode: BatchingMode = .day1
+    @State private var loadedSinceDate: Date = BatchingMode.current().initialSinceDate()
+    @State private var loadedCount: Int = BatchingMode.current().initialCount()
     @AppStorage("Display.MarkAllReadPosition") private var markAllReadPosition: MarkAllReadPosition = .bottom
     @AppStorage("WhileYouSlept.DismissedDate") private var whileYouSleptDismissedDate: String = ""
     @AppStorage("TodaysSummary.DismissedDate") private var todaysSummaryDismissedDate: String = ""
@@ -120,15 +122,30 @@ struct AllArticlesView: View {
     }
 
     private var displayedArticles: [Article] {
-        var articles = feedManager.articles(since: loadedSinceDate)
+        var articles: [Article]
+        if batchingMode.isCountBased {
+            articles = feedManager.articles(limit: loadedCount)
+        } else {
+            articles = feedManager.articles(since: loadedSinceDate)
+        }
         if hideInstagramReels {
             articles = articles.filter { !$0.url.contains("/reel/") }
         }
         return articles
     }
 
-    private var nextOlderChunk: Date? {
-        feedManager.nextArticleChunk(before: loadedSinceDate)
+    private var loadMoreAction: (() -> Void)? {
+        if let days = batchingMode.chunkDays {
+            guard let next = feedManager.nextArticleChunk(before: loadedSinceDate, chunkDays: days) else {
+                return nil
+            }
+            return { loadedSinceDate = next }
+        }
+        if let batch = batchingMode.batchSize {
+            guard feedManager.hasMoreArticles(beyond: loadedCount) else { return nil }
+            return { loadedCount += batch }
+        }
+        return nil
     }
 
     private var currentTitle: String {
@@ -218,6 +235,10 @@ struct AllArticlesView: View {
         .onChange(of: feedManager.lists) {
             validateSelection()
         }
+        .onChange(of: batchingMode) { _, newMode in
+            loadedSinceDate = newMode.initialSinceDate()
+            loadedCount = newMode.initialCount()
+        }
         .onAppear {
             refreshBookmarksTip()
         }
@@ -265,9 +286,7 @@ struct AllArticlesView: View {
                     todaysSummaryDismissedDate = ""
                 }
             },
-            onLoadMore: nextOlderChunk.map { chunk in
-                { loadedSinceDate = chunk }
-            },
+            onLoadMore: loadMoreAction,
             onRefresh: {
                 await feedManager.refreshAllFeeds()
             },

--- a/SakuraRSS/Views/Home/HomeSectionView.swift
+++ b/SakuraRSS/Views/Home/HomeSectionView.swift
@@ -6,20 +6,39 @@ struct HomeSectionView: View {
 
     let section: FeedSection
 
-    @State private var loadedSinceDate: Date = FeedManager.currentChunkStart()
+    @AppStorage("Articles.BatchingMode") private var batchingMode: BatchingMode = .day1
+    @State private var loadedSinceDate: Date = BatchingMode.current().initialSinceDate()
+    @State private var loadedCount: Int = BatchingMode.current().initialCount()
     @AppStorage("Display.MarkAllReadPosition") private var markAllReadPosition: MarkAllReadPosition = .bottom
     @AppStorage("Instagram.HideReels") private var hideInstagramReels: Bool = false
 
     private var displayedArticles: [Article] {
-        var articles = feedManager.articles(for: section, since: loadedSinceDate)
+        var articles: [Article]
+        if batchingMode.isCountBased {
+            articles = feedManager.articles(for: section, limit: loadedCount)
+        } else {
+            articles = feedManager.articles(for: section, since: loadedSinceDate)
+        }
         if hideInstagramReels {
             articles = articles.filter { !$0.url.contains("/reel/") }
         }
         return articles
     }
 
-    private var nextOlderChunk: Date? {
-        feedManager.nextArticleChunk(for: section, before: loadedSinceDate)
+    private var loadMoreAction: (() -> Void)? {
+        if let days = batchingMode.chunkDays {
+            guard let next = feedManager.nextArticleChunk(for: section,
+                                                          before: loadedSinceDate,
+                                                          chunkDays: days) else {
+                return nil
+            }
+            return { loadedSinceDate = next }
+        }
+        if let batch = batchingMode.batchSize {
+            guard feedManager.hasMoreArticles(for: section, beyond: loadedCount) else { return nil }
+            return { loadedCount += batch }
+        }
+        return nil
     }
 
     var body: some View {
@@ -30,9 +49,7 @@ struct HomeSectionView: View {
             isVideoFeed: section == .video,
             isPodcastFeed: section == .audio,
             isFeedViewDomain: section == .social,
-            onLoadMore: nextOlderChunk.map { chunk in
-                { loadedSinceDate = chunk }
-            },
+            onLoadMore: loadMoreAction,
             onRefresh: {
                 await feedManager.refreshAllFeeds()
             },
@@ -45,6 +62,10 @@ struct HomeSectionView: View {
         }
         .markAllReadToolbar(show: markAllReadPosition == .bottom) {
             feedManager.markAllRead(for: section)
+        }
+        .onChange(of: batchingMode) { _, newMode in
+            loadedSinceDate = newMode.initialSinceDate()
+            loadedCount = newMode.initialCount()
         }
     }
 }

--- a/SakuraRSS/Views/Home/ListSectionView.swift
+++ b/SakuraRSS/Views/Home/ListSectionView.swift
@@ -6,15 +6,32 @@ struct ListSectionView: View {
 
     let list: FeedList
 
-    @State private var showingOlderArticles = false
+    @AppStorage("Articles.BatchingMode") private var batchingMode: BatchingMode = .day1
+    @State private var loadedSinceDate: Date = BatchingMode.current().initialSinceDate()
+    @State private var loadedCount: Int = BatchingMode.current().initialCount()
     @AppStorage("Display.MarkAllReadPosition") private var markAllReadPosition: MarkAllReadPosition = .bottom
 
     private var displayedArticles: [Article] {
-        if showingOlderArticles {
-            return feedManager.todayArticles(for: list) + feedManager.olderArticles(for: list)
-        } else {
-            return feedManager.todayArticles(for: list)
+        if batchingMode.isCountBased {
+            return feedManager.articles(for: list, limit: loadedCount)
         }
+        return feedManager.articles(for: list, since: loadedSinceDate)
+    }
+
+    private var loadMoreAction: (() -> Void)? {
+        if let days = batchingMode.chunkDays {
+            guard let next = feedManager.nextArticleChunk(for: list,
+                                                          before: loadedSinceDate,
+                                                          chunkDays: days) else {
+                return nil
+            }
+            return { loadedSinceDate = next }
+        }
+        if let batch = batchingMode.batchSize {
+            guard feedManager.hasMoreArticles(for: list, beyond: loadedCount) else { return nil }
+            return { loadedCount += batch }
+        }
+        return nil
     }
 
     var body: some View {
@@ -22,9 +39,7 @@ struct ListSectionView: View {
             articles: displayedArticles,
             title: list.name,
             feedKey: "list.\(list.id)",
-            onLoadMore: showingOlderArticles ? nil : {
-                showingOlderArticles = true
-            },
+            onLoadMore: loadMoreAction,
             onRefresh: {
                 await feedManager.refreshAllFeeds()
             },
@@ -37,6 +52,10 @@ struct ListSectionView: View {
         }
         .markAllReadToolbar(show: markAllReadPosition == .bottom) {
             feedManager.markAllRead(for: list)
+        }
+        .onChange(of: batchingMode) { _, newMode in
+            loadedSinceDate = newMode.initialSinceDate()
+            loadedCount = newMode.initialCount()
         }
     }
 }

--- a/SakuraRSS/Views/More/MoreView.swift
+++ b/SakuraRSS/Views/More/MoreView.swift
@@ -83,20 +83,26 @@ struct MoreView: View {
 
                 Section {
                     Picker(selection: $batchingMode) {
-                        Text(String(localized: "Batching.Day1", table: "Settings"))
-                            .tag(BatchingMode.day1)
-                        Text(String(localized: "Batching.Day3", table: "Settings"))
-                            .tag(BatchingMode.day3)
-                        Text(String(localized: "Batching.Week1", table: "Settings"))
-                            .tag(BatchingMode.week1)
-                        Text(String(localized: "Batching.Items25", table: "Settings"))
-                            .tag(BatchingMode.items25)
-                        Text(String(localized: "Batching.Items50", table: "Settings"))
-                            .tag(BatchingMode.items50)
-                        Text(String(localized: "Batching.Items100", table: "Settings"))
-                            .tag(BatchingMode.items100)
-                        Text(String(localized: "Batching.Off", table: "Settings"))
-                            .tag(BatchingMode.off)
+                        Section {
+                            Text(String(localized: "Batching.Day1", table: "Settings"))
+                                .tag(BatchingMode.day1)
+                            Text(String(localized: "Batching.Day3", table: "Settings"))
+                                .tag(BatchingMode.day3)
+                            Text(String(localized: "Batching.Week1", table: "Settings"))
+                                .tag(BatchingMode.week1)
+                        }
+                        Section {
+                            Text(String(localized: "Batching.Items25", table: "Settings"))
+                                .tag(BatchingMode.items25)
+                            Text(String(localized: "Batching.Items50", table: "Settings"))
+                                .tag(BatchingMode.items50)
+                            Text(String(localized: "Batching.Items100", table: "Settings"))
+                                .tag(BatchingMode.items100)
+                        }
+                        Section {
+                            Text(String(localized: "Batching.Off", table: "Settings"))
+                                .tag(BatchingMode.off)
+                        }
                     } label: {
                         Text(String(localized: "BatchingMode", table: "Settings"))
                     }

--- a/SakuraRSS/Views/More/MoreView.swift
+++ b/SakuraRSS/Views/More/MoreView.swift
@@ -14,6 +14,8 @@ struct MoreView: View {
     @AppStorage("Display.DefaultStyle") private var defaultDisplayStyle: FeedDisplayStyle = .inbox
     @AppStorage("Display.MarkAllReadPosition") private var markAllReadPosition: MarkAllReadPosition = .bottom
     @AppStorage("Display.UnreadBadgeMode") private var unreadBadgeMode: UnreadBadgeMode = .none
+    @AppStorage("Articles.BatchingMode") private var batchingMode: BatchingMode = .day1
+    @AppStorage("Articles.AutoLoadWhileScrolling") private var autoLoadWhileScrolling: Bool = false
 
     var body: some View {
         NavigationStack {
@@ -77,6 +79,33 @@ struct MoreView: View {
                             }
                         }
                     }
+                }
+
+                Section {
+                    Picker(selection: $batchingMode) {
+                        Text(String(localized: "Batching.Day1", table: "Settings"))
+                            .tag(BatchingMode.day1)
+                        Text(String(localized: "Batching.Day3", table: "Settings"))
+                            .tag(BatchingMode.day3)
+                        Text(String(localized: "Batching.Week1", table: "Settings"))
+                            .tag(BatchingMode.week1)
+                        Text(String(localized: "Batching.Items25", table: "Settings"))
+                            .tag(BatchingMode.items25)
+                        Text(String(localized: "Batching.Items50", table: "Settings"))
+                            .tag(BatchingMode.items50)
+                        Text(String(localized: "Batching.Items100", table: "Settings"))
+                            .tag(BatchingMode.items100)
+                        Text(String(localized: "Batching.Off", table: "Settings"))
+                            .tag(BatchingMode.off)
+                    } label: {
+                        Text(String(localized: "BatchingMode", table: "Settings"))
+                    }
+                    Toggle(String(localized: "AutoLoadWhileScrolling", table: "Settings"),
+                           isOn: $autoLoadWhileScrolling)
+                } header: {
+                    Text(String(localized: "Section.Batching", table: "Settings"))
+                } footer: {
+                    Text(String(localized: "Batching.Footer", table: "Settings"))
                 }
 
                 Section {

--- a/SakuraRSS/Views/Shared/Articles/ArticlesView.swift
+++ b/SakuraRSS/Views/Shared/Articles/ArticlesView.swift
@@ -246,23 +246,44 @@ struct ArticlesView: View {
 }
 
 struct LoadPreviousArticlesButton: View {
+
     let action: () -> Void
 
+    @AppStorage("Articles.AutoLoadWhileScrolling") private var autoLoadWhileScrolling: Bool = false
+
     var body: some View {
-        Button {
-            withAnimation(.smooth.speed(2.0)) {
-                action()
+        Group {
+            if autoLoadWhileScrolling {
+                HStack(spacing: 8) {
+                    ProgressView()
+                    Text(String(localized: "LoadPrevious.Loading", table: "Articles"))
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 12)
+                .onAppear {
+                    withAnimation(.smooth.speed(2.0)) {
+                        action()
+                    }
+                }
+            } else {
+                Button {
+                    withAnimation(.smooth.speed(2.0)) {
+                        action()
+                    }
+                } label: {
+                    HStack {
+                        Image(systemName: "clock.arrow.circlepath")
+                        Text(String(localized: "LoadPrevious", table: "Articles"))
+                    }
+                    .font(.subheadline)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 12)
+                }
+                .buttonStyle(.bordered)
+                .tint(.secondary)
             }
-        } label: {
-            HStack {
-                Image(systemName: "clock.arrow.circlepath")
-                Text(String(localized: "LoadPrevious", table: "Articles"))
-            }
-            .font(.subheadline)
-            .frame(maxWidth: .infinity)
-            .padding(.vertical, 12)
         }
-        .buttonStyle(.bordered)
-        .tint(.secondary)
     }
 }

--- a/Shared/BatchingMode.swift
+++ b/Shared/BatchingMode.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+/// Controls how the Home / Feed / List views paginate older articles behind
+/// the "Show Older Content" affordance.  Date-based modes walk backwards in
+/// fixed-size day windows; count-based modes grow a running limit by a fixed
+/// number of items; `.off` loads everything up-front with no paging.
+nonisolated enum BatchingMode: String, CaseIterable, Identifiable, Sendable {
+    case off
+    case day1
+    case day3
+    case week1
+    case items25
+    case items50
+    case items100
+
+    var id: String { rawValue }
+
+    /// Number of days covered by one date-based batch, or `nil` for
+    /// non-date-based modes.
+    var chunkDays: Int? {
+        switch self {
+        case .day1: return 1
+        case .day3: return 3
+        case .week1: return 7
+        default: return nil
+        }
+    }
+
+    /// Number of items added per count-based batch, or `nil` for
+    /// non-count-based modes.
+    var batchSize: Int? {
+        switch self {
+        case .items25: return 25
+        case .items50: return 50
+        case .items100: return 100
+        default: return nil
+        }
+    }
+
+    var isDateBased: Bool { chunkDays != nil }
+    var isCountBased: Bool { batchSize != nil }
+
+    /// Date at which the initial batch should begin for date-based modes.
+    /// Returns `.distantPast` for non-date-based modes so existing
+    /// `articles(since:)` callers keep working.
+    func initialSinceDate() -> Date {
+        guard let days = chunkDays else { return Date(timeIntervalSince1970: 0) }
+        let startOfToday = Calendar.current.startOfDay(for: Date())
+        return Calendar.current.date(byAdding: .day, value: -(days - 1), to: startOfToday)
+            ?? startOfToday
+    }
+
+    /// Initial item count for the first count-based batch.
+    func initialCount() -> Int { batchSize ?? 0 }
+
+    /// The currently persisted mode, used to seed `@State` values so the
+    /// initial window matches the stored configuration rather than the
+    /// `@AppStorage` default.
+    static func current() -> BatchingMode {
+        let raw = UserDefaults.standard.string(forKey: "Articles.BatchingMode")
+        return raw.flatMap(BatchingMode.init(rawValue:)) ?? .day1
+    }
+}

--- a/Shared/Strings/Articles.xcstrings
+++ b/Shared/Strings/Articles.xcstrings
@@ -4425,6 +4425,65 @@
           }
         }
       }
+    },
+    "LoadPrevious.Loading": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ältere Artikel werden geladen…"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Loading older articles…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chargement des articles plus anciens…"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Caricamento articoli più vecchi…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "過去の記事を読み込み中…"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이전 기사 로드 중…"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đang tải bài viết cũ hơn…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在加载更早的文章…"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在載入較舊的文章…"
+          }
+        }
+      }
     }
   },
   "version": "1.1"

--- a/Shared/Strings/Articles.xcstrings
+++ b/Shared/Strings/Articles.xcstrings
@@ -4432,55 +4432,55 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ältere Artikel werden geladen…"
+            "value": "Ältere Inhalte werden geladen…"
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Loading older articles…"
+            "value": "Loading older content…"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Chargement des articles plus anciens…"
+            "value": "Chargement du contenu plus ancien…"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Caricamento articoli più vecchi…"
+            "value": "Caricamento contenuti più vecchi…"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "過去の記事を読み込み中…"
+            "value": "過去のコンテンツを読み込み中…"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "이전 기사 로드 중…"
+            "value": "이전 콘텐츠 로드 중…"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Đang tải bài viết cũ hơn…"
+            "value": "Đang tải nội dung cũ hơn…"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "正在加载更早的文章…"
+            "value": "正在加载更早的内容…"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "正在載入較舊的文章…"
+            "value": "正在載入較舊的內容…"
           }
         }
       }

--- a/Shared/Strings/Settings.xcstrings
+++ b/Shared/Strings/Settings.xcstrings
@@ -3717,6 +3717,655 @@
           }
         }
       }
+    },
+    "Section.Batching": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stapelverarbeitung"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Batching"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chargement par lots"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Caricamento a blocchi"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一括読み込み"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "일괄 로딩"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tải theo lô"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "分批加载"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "分批載入"
+          }
+        }
+      }
+    },
+    "BatchingMode": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ältere Inhalte laden nach"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show Older Content By"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afficher le contenu plus ancien par"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostra contenuti più vecchi per"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "過去のコンテンツの表示単位"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이전 콘텐츠 표시 단위"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hiển thị nội dung cũ theo"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示更早内容的方式"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顯示較舊內容的方式"
+          }
+        }
+      }
+    },
+    "Batching.Day1": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 Tag"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 Day"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 jour"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 giorno"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1日"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1일"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 ngày"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 天"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 天"
+          }
+        }
+      }
+    },
+    "Batching.Day3": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3 Tage"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3 Days"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3 jours"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3 giorni"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3日"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3일"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3 ngày"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3 天"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3 天"
+          }
+        }
+      }
+    },
+    "Batching.Week1": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 Woche"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 Week"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 semaine"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 settimana"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1週間"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1주"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 tuần"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 周"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 週"
+          }
+        }
+      }
+    },
+    "Batching.Items25": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "25 Einträge"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "25 Items"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "25 éléments"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "25 elementi"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "25件"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "25개"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "25 mục"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "25 条"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "25 項"
+          }
+        }
+      }
+    },
+    "Batching.Items50": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "50 Einträge"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "50 Items"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "50 éléments"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "50 elementi"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "50件"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "50개"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "50 mục"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "50 条"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "50 項"
+          }
+        }
+      }
+    },
+    "Batching.Items100": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "100 Einträge"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "100 Items"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "100 éléments"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "100 elementi"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "100件"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "100개"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "100 mục"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "100 条"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "100 項"
+          }
+        }
+      }
+    },
+    "Batching.Off": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aus"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Off"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Désactivé"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disattivato"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "オフ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "끔"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tắt"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关闭"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "關閉"
+          }
+        }
+      }
+    },
+    "Batching.Footer": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Legt fest, wie viele ältere Artikel bei jedem Antippen von „Ältere Inhalte anzeigen“ geladen werden. Bei „Aus“ werden alle älteren Artikel auf einmal geladen."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Controls how many older articles are loaded each time you reach the bottom of the list. When off, all older articles load at once."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contrôle combien d’articles plus anciens sont chargés à chaque fois que vous atteignez le bas de la liste. Désactivé, tous les articles anciens sont chargés en une fois."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Determina quanti articoli più vecchi vengono caricati ogni volta che raggiungi il fondo dell’elenco. Se disattivato, tutti gli articoli vecchi vengono caricati in una sola volta."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リストの末尾に達するたびに読み込まれる過去の記事の数を設定します。オフにするとすべての過去の記事を一度に読み込みます。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "목록 하단에 도달할 때마다 불러올 이전 기사 수를 설정합니다. 끄면 이전 기사를 한 번에 모두 불러옵니다."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Xác định số lượng bài viết cũ hơn được tải mỗi khi bạn đến cuối danh sách. Khi tắt, tất cả bài viết cũ sẽ được tải cùng lúc."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "控制每次滚动到列表底部时载入的更早文章数量。关闭时将一次性载入所有更早的文章。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "控制每次滾動至清單底端時載入的較舊文章數量。關閉時將一次載入所有較舊的文章。"
+          }
+        }
+      }
+    },
+    "AutoLoadWhileScrolling": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beim Scrollen automatisch laden"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auto-Load While Scrolling"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Charger automatiquement en faisant défiler"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Carica automaticamente durante lo scorrimento"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "スクロール中に自動読み込み"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "스크롤 시 자동 로드"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tự động tải khi cuộn"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "滚动时自动加载"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "滾動時自動載入"
+          }
+        }
+      }
     }
   },
   "version": "1.1"

--- a/Shared/Strings/Settings.xcstrings
+++ b/Shared/Strings/Settings.xcstrings
@@ -4255,55 +4255,55 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Legt fest, wie viele ältere Artikel bei jedem Antippen von „Ältere Inhalte anzeigen“ geladen werden. Bei „Aus“ werden alle älteren Artikel auf einmal geladen."
+            "value": "Legt fest, wie viele ältere Inhalte bei jedem Erreichen des Listenendes geladen werden. Bei „Aus“ werden alle älteren Inhalte auf einmal geladen."
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Controls how many older articles are loaded each time you reach the bottom of the list. When off, all older articles load at once."
+            "value": "Controls how much older content is loaded each time you reach the bottom of the list. When off, all older content loads at once."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Contrôle combien d’articles plus anciens sont chargés à chaque fois que vous atteignez le bas de la liste. Désactivé, tous les articles anciens sont chargés en une fois."
+            "value": "Contrôle la quantité de contenu plus ancien chargée à chaque fois que vous atteignez le bas de la liste. Désactivé, tout le contenu ancien est chargé en une fois."
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Determina quanti articoli più vecchi vengono caricati ogni volta che raggiungi il fondo dell’elenco. Se disattivato, tutti gli articoli vecchi vengono caricati in una sola volta."
+            "value": "Determina quanto contenuto più vecchio viene caricato ogni volta che raggiungi il fondo dell’elenco. Se disattivato, tutto il contenuto vecchio viene caricato in una sola volta."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "リストの末尾に達するたびに読み込まれる過去の記事の数を設定します。オフにするとすべての過去の記事を一度に読み込みます。"
+            "value": "リストの末尾に達するたびに読み込まれる過去のコンテンツの量を設定します。オフにするとすべての過去のコンテンツを一度に読み込みます。"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "목록 하단에 도달할 때마다 불러올 이전 기사 수를 설정합니다. 끄면 이전 기사를 한 번에 모두 불러옵니다."
+            "value": "목록 하단에 도달할 때마다 불러올 이전 콘텐츠 양을 설정합니다. 끄면 이전 콘텐츠를 한 번에 모두 불러옵니다."
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Xác định số lượng bài viết cũ hơn được tải mỗi khi bạn đến cuối danh sách. Khi tắt, tất cả bài viết cũ sẽ được tải cùng lúc."
+            "value": "Xác định lượng nội dung cũ hơn được tải mỗi khi bạn đến cuối danh sách. Khi tắt, toàn bộ nội dung cũ sẽ được tải cùng lúc."
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "控制每次滚动到列表底部时载入的更早文章数量。关闭时将一次性载入所有更早的文章。"
+            "value": "控制每次滚动到列表底部时载入的更早内容数量。关闭时将一次性载入所有更早的内容。"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "控制每次滾動至清單底端時載入的較舊文章數量。關閉時將一次載入所有較舊的文章。"
+            "value": "控制每次滾動至清單底端時載入的較舊內容數量。關閉時將一次載入所有較舊的內容。"
           }
         }
       }


### PR DESCRIPTION
## Summary
Implements configurable batching modes to control how older articles are loaded when users reach the bottom of article lists. This allows for flexible pagination strategies ranging from loading everything at once to loading content in fixed-size batches (by date or item count).

## Key Changes

- **New `BatchingMode` enum** (`Shared/BatchingMode.swift`): Defines seven batching strategies:
  - `.off`: Load all content upfront
  - `.day1`, `.day3`, `.week1`: Date-based batching (walk backwards in fixed-day windows)
  - `.items25`, `.items50`, `.items100`: Count-based batching (grow limit by fixed item counts)

- **Extended `FeedManager` with batching methods** (`FeedManager+Batching.swift`):
  - Count-based methods: `articles(limit:)`, `hasMoreArticles(beyond:)` for all/section/feed/list scopes
  - Date-based methods: `nextArticleChunk(before:chunkDays:)` for all/section/feed/list scopes
  - Respects muted feeds and applies per-feed/per-list visibility rules

- **Updated article list views** to support both batching modes:
  - `AllArticlesView`, `HomeSectionView`, `FeedArticlesView`, `ListSectionView`
  - Each view now tracks either `loadedSinceDate` (date-based) or `loadedCount` (count-based)
  - Dynamically switches between date and count-based loading based on `batchingMode`

- **Settings UI** (`MoreView`): Added batching mode picker with options grouped by type (date-based vs count-based)

- **Auto-load feature**: New `AutoLoadWhileScrolling` toggle that automatically loads older content when reaching the bottom, with visual loading indicator

- **Localization**: Added 650+ lines of translations for all batching modes and related strings across 9 languages (English, German, French, Italian, Japanese, Korean, Vietnamese, Simplified Chinese, Traditional Chinese)

## Implementation Details

- Batching respects existing filtering rules (muted feeds, per-feed rules, per-list rules)
- Date-based modes use `Calendar` to walk backwards in fixed-day windows, with iteration limits to prevent infinite loops
- Count-based modes fetch larger pools and filter down to requested counts
- Initial state is seeded from `UserDefaults` to match persisted configuration
- `LoadPreviousArticlesButton` adapts UI based on `autoLoadWhileScrolling` setting

https://claude.ai/code/session_01RRKNkACKdVqCgwfJJJB1QC