### PR TITLE
Reorganize scrolling settings into dedicated section

### DIFF
--- a/SakuraRSS/Views/More/MoreView.swift
+++ b/SakuraRSS/Views/More/MoreView.swift
@@ -46,7 +46,6 @@ struct MoreView: View {
                     } label: {
                         Text(String(localized: "MarkAllReadPosition", table: "Settings"))
                     }
-                    Toggle(String(localized: "ScrollMarkAsRead", table: "Settings"), isOn: $scrollMarkAsRead)
                     Picker(String(localized: "UnreadBadgeMode", table: "Settings"), selection: $unreadBadgeMode) {
                         if UIDevice.current.userInterfaceIdiom == .pad {
                             Text(String(localized: "UnreadBadgeMode.HomeScreenOnly", table: "Settings"))
@@ -110,8 +109,9 @@ struct MoreView: View {
                     }
                     Toggle(String(localized: "AutoLoadWhileScrolling", table: "Settings"),
                            isOn: $autoLoadWhileScrolling)
+                    Toggle(String(localized: "ScrollMarkAsRead", table: "Settings"), isOn: $scrollMarkAsRead)
                 } header: {
-                    Text(String(localized: "Section.Batching", table: "Settings"))
+                    Text(String(localized: "Section.Scrolling", table: "Settings"))
                 } footer: {
                     Text(String(localized: "Batching.Footer", table: "Settings"))
                 }

--- a/Shared/Strings/Settings.xcstrings
+++ b/Shared/Strings/Settings.xcstrings
@@ -3777,65 +3777,6 @@
         }
       }
     },
-    "Section.Batching": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stapelverarbeitung"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Batching"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Chargement par lots"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Caricamento a blocchi"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "一括読み込み"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "일괄 로딩"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tải theo lô"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "分批加载"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "分批載入"
-          }
-        }
-      }
-    },
     "BatchingMode": {
       "extractionState": "manual",
       "localizations": {
@@ -4422,6 +4363,65 @@
           "stringUnit": {
             "state": "translated",
             "value": "滾動時自動載入"
+          }
+        }
+      }
+    },
+    "Section.Scrolling": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scrollen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scrolling"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Défilement"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scorrimento"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "スクロール時の挙動"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "스크롤"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cuộn"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "滚动"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "捲動"
           }
         }
       }


### PR DESCRIPTION
## Summary
Reorganized the settings UI to group scrolling-related options into a dedicated "Scrolling" section, moving the "ScrollMarkAsRead" toggle from the general settings area to be alongside other scroll behavior options.

## Key Changes
- Removed the unused "Section.Batching" localization string (59 lines across 9 languages)
- Added new "Section.Scrolling" localization string with translations for 9 languages (de, en, fr, it, ja, ko, vi, zh-Hans, zh-Hant)
- Moved "ScrollMarkAsRead" toggle from the top-level settings section to the scrolling behavior section
- Updated the section header from "Section.Batching" to "Section.Scrolling" for the batching/scrolling options group
- Reordered toggles so "ScrollMarkAsRead" appears after "AutoLoadWhileScrolling" within the scrolling section

## Implementation Details
- The section now logically groups scroll-related settings: "AutoLoadWhileScrolling" and "ScrollMarkAsRead"
- The footer text "Batching.Footer" remains unchanged, suggesting it applies to both auto-loading and mark-as-read behaviors
- All localization strings are properly translated across supported languages

https://claude.ai/code/session_015CbRfcz9fvwW3HH3U5QMjH