### PR TITLE
Fix favicon caching logic in FeedEditSheet

### DIFF
--- a/SakuraRSS/Views/Feeds/FeedEditSheet+Icons.swift
+++ b/SakuraRSS/Views/Feeds/FeedEditSheet+Icons.swift
@@ -43,8 +43,7 @@ extension FeedEditSheet {
                let imageURL = URL(string: imageURLString),
                let (data, _) = try? await URLSession.shared.data(for: .sakura(url: imageURL)),
                let image = UIImage(data: data) {
-                await FaviconCache.shared.setCustomFavicon(image, feedID: feed.id, skipTrimming: true)
-                customIconImage = nil
+                customIconImage = image
                 currentFavicon = image
                 selectedPhoto = nil
                 iconURLInput = ""
@@ -63,8 +62,7 @@ extension FeedEditSheet {
                let imageURL = URL(string: imageURLString),
                let (data, _) = try? await URLSession.shared.data(for: .sakura(url: imageURL)),
                let image = UIImage(data: data) {
-                await FaviconCache.shared.setCustomFavicon(image, feedID: feed.id, skipTrimming: true)
-                customIconImage = nil
+                customIconImage = image
                 currentFavicon = image
                 selectedPhoto = nil
                 iconURLInput = ""
@@ -75,7 +73,7 @@ extension FeedEditSheet {
 
         await FaviconCache.shared.refreshFavicons(for: [(domain: feed.domain, siteURL: feed.siteURL)])
         if let image = await FaviconCache.shared.favicon(for: feed.domain, siteURL: feed.siteURL) {
-            customIconImage = nil
+            customIconImage = image
             currentFavicon = image
             selectedPhoto = nil
             iconURLInput = ""


### PR DESCRIPTION
## Summary
Fixed incorrect favicon state management in the FeedEditSheet icon handling. The previous implementation was clearing the custom icon image after setting it in the cache, which prevented the UI from displaying the newly selected or refreshed favicon.

## Key Changes
- **Icon URL input**: Changed from clearing `customIconImage` to assigning the loaded image directly
- **Photo selection**: Changed from clearing `customIconImage` to assigning the loaded image directly  
- **Favicon refresh**: Changed from clearing `customIconImage` to assigning the refreshed favicon from cache
- **Removed redundant cache calls**: Eliminated direct `FaviconCache.shared.setCustomFavicon()` calls since the state is now properly managed through `customIconImage`

## Implementation Details
The fix ensures that when a favicon is loaded (whether from a URL, photo library, or cache refresh), the `customIconImage` state variable is set to the actual image rather than being cleared to `nil`. This allows the UI to properly display the favicon while maintaining the correct state flow through `currentFavicon` and other related properties.

https://claude.ai/code/session_01HSyALsLxN8UfEfjXVswY8P