### PR TITLE
Debounce mark-as-read operations during scrolling

### DIFF
--- a/SakuraRSS/Classes/Feed Manager/FeedManager+PendingReads.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+PendingReads.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+extension FeedManager {
+
+    /// Debounce window before a burst of mark-read-on-scroll updates
+    /// triggers the full `loadFromDatabase()` + badge refresh.
+    private static let debouncedReadFlushDelay: Duration = .milliseconds(400)
+
+    // MARK: - Debounced Mark As Read
+
+    /// Marks an article as read without triggering a full `loadFromDatabase()`
+    /// or badge refresh on every call.  The DB row is still updated
+    /// synchronously - so any view that re-queries after the `dataRevision`
+    /// bump sees the correct state - but the expensive cascade is deferred
+    /// until the user stops scrolling.
+    ///
+    /// Use this from scroll-driven callers like `MarkReadOnScrollModifier`
+    /// where many articles can be marked in quick succession.  Explicit
+    /// user actions (tapping the read button, mark all read) should keep
+    /// using `markRead(_:)` so the UI updates immediately.
+    func markReadDebounced(_ article: Article) {
+        try? database.markArticleRead(id: article.id, read: true)
+        try? database.updateLastAccessed(articleID: article.id)
+
+        // Keep the in-memory caches consistent so lookups via
+        // `article(byID:)` and `unreadCount(for:)` don't lie during
+        // the debounce window.
+        if let idx = articles.firstIndex(where: { $0.id == article.id }),
+           !articles[idx].isRead {
+            articles[idx].isRead = true
+            let feedID = articles[idx].feedID
+            if let count = unreadCounts[feedID], count > 0 {
+                unreadCounts[feedID] = count - 1
+            }
+        }
+        dataRevision += 1
+        hasPendingDebouncedReads = true
+        scheduleDebouncedReadFlush()
+    }
+
+    /// Flushes any pending debounced reads immediately.  Safe to call when
+    /// nothing is pending.  Invoked on scene backgrounding to make sure the
+    /// badge and in-memory caches are in sync before the app suspends.
+    func flushDebouncedReads() {
+        debouncedReadFlushTask?.cancel()
+        debouncedReadFlushTask = nil
+        guard hasPendingDebouncedReads else { return }
+        hasPendingDebouncedReads = false
+        loadFromDatabase()
+        updateBadgeCount()
+    }
+
+    private func scheduleDebouncedReadFlush() {
+        debouncedReadFlushTask?.cancel()
+        debouncedReadFlushTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: FeedManager.debouncedReadFlushDelay)
+            guard !Task.isCancelled else { return }
+            self?.flushDebouncedReads()
+        }
+    }
+
+}

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+PendingReads.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+PendingReads.swift
@@ -2,29 +2,16 @@ import Foundation
 
 extension FeedManager {
 
-    /// Debounce window before a burst of mark-read-on-scroll updates
-    /// triggers the full `loadFromDatabase()` + badge refresh.
     private static let debouncedReadFlushDelay: Duration = .milliseconds(400)
 
     // MARK: - Debounced Mark As Read
 
-    /// Marks an article as read without triggering a full `loadFromDatabase()`
-    /// or badge refresh on every call.  The DB row is still updated
-    /// synchronously - so any view that re-queries after the `dataRevision`
-    /// bump sees the correct state - but the expensive cascade is deferred
-    /// until the user stops scrolling.
-    ///
-    /// Use this from scroll-driven callers like `MarkReadOnScrollModifier`
-    /// where many articles can be marked in quick succession.  Explicit
-    /// user actions (tapping the read button, mark all read) should keep
-    /// using `markRead(_:)` so the UI updates immediately.
+    /// Writes the row immediately but defers the full reload + badge refresh
+    /// until scrolling settles.
     func markReadDebounced(_ article: Article) {
         try? database.markArticleRead(id: article.id, read: true)
         try? database.updateLastAccessed(articleID: article.id)
 
-        // Keep the in-memory caches consistent so lookups via
-        // `article(byID:)` and `unreadCount(for:)` don't lie during
-        // the debounce window.
         if let idx = articles.firstIndex(where: { $0.id == article.id }),
            !articles[idx].isRead {
             articles[idx].isRead = true
@@ -38,9 +25,6 @@ extension FeedManager {
         scheduleDebouncedReadFlush()
     }
 
-    /// Flushes any pending debounced reads immediately.  Safe to call when
-    /// nothing is pending.  Invoked on scene backgrounding to make sure the
-    /// badge and in-memory caches are in sync before the app suspends.
     func flushDebouncedReads() {
         debouncedReadFlushTask?.cancel()
         debouncedReadFlushTask = nil

--- a/SakuraRSS/Classes/Feed Manager/FeedManager.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager.swift
@@ -19,6 +19,12 @@ final class FeedManager {
     private(set) var unreadCounts: [Int64: Int] = [:]
     private(set) var feedsByID: [Int64: Feed] = [:]
 
+    /// Tracks whether at least one `markReadDebounced(_:)` call has
+    /// written to the DB but has not yet run the UI-side cascade
+    /// (`loadFromDatabase()` + badge refresh).
+    @ObservationIgnored var hasPendingDebouncedReads: Bool = false
+    @ObservationIgnored var debouncedReadFlushTask: Task<Void, Never>?
+
     let database = DatabaseManager.shared
 
     init() {

--- a/SakuraRSS/Views/App.swift
+++ b/SakuraRSS/Views/App.swift
@@ -56,6 +56,14 @@ struct SakuraRSSApp: App {
                     }
                 }
                 .onReceive(
+                    NotificationCenter.default.publisher(for: UIApplication.willResignActiveNotification)
+                ) { _ in
+                    // Make sure any debounced mark-as-read-on-scroll
+                    // updates are fully applied (full reload + badge)
+                    // before the app suspends.
+                    feedManager.flushDebouncedReads()
+                }
+                .onReceive(
                     NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)
                 ) { _ in
                     // Always update the badge - cheap and user-visible.

--- a/SakuraRSS/Views/App.swift
+++ b/SakuraRSS/Views/App.swift
@@ -58,9 +58,6 @@ struct SakuraRSSApp: App {
                 .onReceive(
                     NotificationCenter.default.publisher(for: UIApplication.willResignActiveNotification)
                 ) { _ in
-                    // Make sure any debounced mark-as-read-on-scroll
-                    // updates are fully applied (full reload + badge)
-                    // before the app suspends.
                     feedManager.flushDebouncedReads()
                 }
                 .onReceive(

--- a/SakuraRSS/Views/Shared/MarkReadOnScrollModifier.swift
+++ b/SakuraRSS/Views/Shared/MarkReadOnScrollModifier.swift
@@ -48,7 +48,7 @@ struct MarkReadOnScrollModifier: ViewModifier {
                         return
                     }
                     withAnimation(.smooth.speed(2.0)) {
-                        feedManager.markRead(fresh)
+                        feedManager.markReadDebounced(fresh)
                     }
                 }
             }


### PR DESCRIPTION
## Summary
Implements debounced mark-as-read functionality to improve performance during rapid article scrolling. Database writes happen immediately, but UI updates (reload + badge refresh) are deferred until scrolling settles.

## Key Changes
- **New extension**: `FeedManager+PendingReads.swift` with debounced read marking logic
  - `markReadDebounced(_:)` - Immediately writes to DB and updates local state, schedules deferred UI refresh
  - `flushDebouncedReads()` - Executes pending UI updates (reload + badge count)
  - `scheduleDebouncedReadFlush()` - Manages 400ms debounce timer with task cancellation
- **FeedManager updates**: Added tracking properties for pending debounced reads and the flush task
- **App lifecycle**: Added `willResignActiveNotification` handler to flush pending reads when app backgrounding
- **MarkReadOnScrollModifier**: Changed from `markRead()` to `markReadDebounced()` for scroll-triggered reads

## Implementation Details
- Uses Swift's `Task.sleep(for:)` with `Duration.milliseconds(400)` for debouncing
- Cancels previous scheduled flushes when new reads occur, resetting the timer
- Maintains immediate database consistency while deferring expensive UI operations
- Ensures pending reads are flushed before app backgrounding to maintain data integrity

https://claude.ai/code/session_01DmmxmKt6s5GLeNAHR7jkAY