### PR TITLE
Make the refresh progress donut tap-to-cancel

### DIFF
--- a/SakuraRSS/Classes/Feed Manager/FeedManager+Refresh.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+Refresh.swift
@@ -217,6 +217,7 @@ extension FeedManager {
                 self.isLoading = false
                 self.refreshCompleted = 0
                 self.refreshTotal = 0
+                self.refreshTask = nil
             }
         }
 
@@ -227,33 +228,48 @@ extension FeedManager {
         // main-actor reload work; 8 matches the parallelism already
         // used by `backfillMetadataImages`.
         let maxConcurrent = 8
-        await withTaskGroup(of: Void.self) { group in
-            var submitted = 0
-            var iterator = feedsToRefresh.makeIterator()
-            while submitted < maxConcurrent, let feed = iterator.next() {
-                group.addTask {
-                    try? await self.refreshFeed(
-                        feed,
-                        reloadData: false,
-                        skipImageBackfill: skipImageBackfill
-                    )
-                    await MainActor.run { self.refreshCompleted += 1 }
-                }
-                submitted += 1
-            }
-            while await group.next() != nil {
-                if let feed = iterator.next() {
+        let work = Task { [weak self] in
+            guard let self else { return }
+            await withTaskGroup(of: Void.self) { group in
+                var submitted = 0
+                var iterator = feedsToRefresh.makeIterator()
+                while submitted < maxConcurrent, !Task.isCancelled, let feed = iterator.next() {
                     group.addTask {
+                        guard !Task.isCancelled else { return }
                         try? await self.refreshFeed(
                             feed,
                             reloadData: false,
                             skipImageBackfill: skipImageBackfill
                         )
-                        await MainActor.run { self.refreshCompleted += 1 }
+                        if !Task.isCancelled {
+                            await MainActor.run { self.refreshCompleted += 1 }
+                        }
+                    }
+                    submitted += 1
+                }
+                while await group.next() != nil {
+                    if Task.isCancelled {
+                        group.cancelAll()
+                        continue
+                    }
+                    if let feed = iterator.next() {
+                        group.addTask {
+                            guard !Task.isCancelled else { return }
+                            try? await self.refreshFeed(
+                                feed,
+                                reloadData: false,
+                                skipImageBackfill: skipImageBackfill
+                            )
+                            if !Task.isCancelled {
+                                await MainActor.run { self.refreshCompleted += 1 }
+                            }
+                        }
                     }
                 }
             }
         }
+        await MainActor.run { self.refreshTask = work }
+        _ = await work.value
         await loadFromDatabaseInBackground()
     }
 
@@ -289,36 +305,63 @@ extension FeedManager {
                 self.isLoading = false
                 self.refreshCompleted = 0
                 self.refreshTotal = 0
+                self.refreshTask = nil
             }
         }
 
         let maxConcurrent = 8
-        async let feedRefresh: Void = withTaskGroup(of: Void.self) { group in
-            var submitted = 0
-            var iterator = currentFeeds.makeIterator()
-            while submitted < maxConcurrent, let feed = iterator.next() {
-                group.addTask {
-                    try? await self.refreshFeed(feed, updateTitle: false, reloadData: false)
-                    await MainActor.run { self.refreshCompleted += 1 }
-                }
-                submitted += 1
-            }
-            while await group.next() != nil {
-                if let feed = iterator.next() {
+        let work = Task { [weak self] in
+            guard let self else { return }
+            async let feedRefresh: Void = withTaskGroup(of: Void.self) { group in
+                var submitted = 0
+                var iterator = currentFeeds.makeIterator()
+                while submitted < maxConcurrent, !Task.isCancelled, let feed = iterator.next() {
                     group.addTask {
+                        guard !Task.isCancelled else { return }
                         try? await self.refreshFeed(feed, updateTitle: false, reloadData: false)
-                        await MainActor.run { self.refreshCompleted += 1 }
+                        if !Task.isCancelled {
+                            await MainActor.run { self.refreshCompleted += 1 }
+                        }
+                    }
+                    submitted += 1
+                }
+                while await group.next() != nil {
+                    if Task.isCancelled {
+                        group.cancelAll()
+                        continue
+                    }
+                    if let feed = iterator.next() {
+                        group.addTask {
+                            guard !Task.isCancelled else { return }
+                            try? await self.refreshFeed(feed, updateTitle: false, reloadData: false)
+                            if !Task.isCancelled {
+                                await MainActor.run { self.refreshCompleted += 1 }
+                            }
+                        }
                     }
                 }
             }
+            async let faviconRefresh: Void = FaviconCache.shared.refreshFavicons(
+                for: currentFeeds.map { ($0.domain, $0.siteURL as String?) }
+            )
+            _ = await (feedRefresh, faviconRefresh)
         }
-        async let faviconRefresh: Void = FaviconCache.shared.refreshFavicons(
-            for: currentFeeds.map { ($0.domain, $0.siteURL as String?) }
-        )
-        _ = await (feedRefresh, faviconRefresh)
+        await MainActor.run { self.refreshTask = work }
+        _ = await work.value
         await loadFromDatabaseInBackground()
         regenerateAllAcronymIcons()
         notifyFaviconChange()
+    }
+
+    /// Cancels the in-flight `refreshAllFeeds` / `refreshAllFeedsAndFavicons`
+    /// task, if any.  URLSession fetches that are already in-flight receive
+    /// a `CancellationError`, no further feeds are submitted to the task
+    /// group, and the UI state (`isLoading`, progress counters) is torn down
+    /// by the refresh method's `defer` block once the task unwinds.
+    @MainActor
+    func cancelRefresh() {
+        refreshTask?.cancel()
+        refreshTask = nil
     }
 
 }

--- a/SakuraRSS/Classes/Feed Manager/FeedManager.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager.swift
@@ -24,6 +24,7 @@ final class FeedManager {
     /// (`loadFromDatabase()` + badge refresh).
     @ObservationIgnored var hasPendingDebouncedReads: Bool = false
     @ObservationIgnored var debouncedReadFlushTask: Task<Void, Never>?
+    @ObservationIgnored var refreshTask: Task<Void, Never>?
 
     let database = DatabaseManager.shared
 

--- a/SakuraRSS/Views/Home/HomeView.swift
+++ b/SakuraRSS/Views/Home/HomeView.swift
@@ -27,7 +27,8 @@ struct HomeView: View {
                     ToolbarItemGroup(placement: .topBarLeading) {
                         if feedManager.isLoading && feedManager.refreshTotal > 0 {
                             FeedRefreshProgressDonut(
-                                progress: feedManager.refreshProgress
+                                progress: feedManager.refreshProgress,
+                                onStop: { feedManager.cancelRefresh() }
                             )
                         }
                     }

--- a/SakuraRSS/Views/Shared/FeedRefreshProgressDonut.swift
+++ b/SakuraRSS/Views/Shared/FeedRefreshProgressDonut.swift
@@ -2,18 +2,46 @@ import SwiftUI
 
 /// A small donut-shaped progress indicator displayed in the Home tab
 /// toolbar while feeds are refreshing.  The ring fills from empty to
-/// full as each individual feed finishes loading.
+/// full as each individual feed finishes loading.  When `onStop` is
+/// supplied the donut becomes a button with a stop glyph in the
+/// center, letting the user cancel the refresh.
 struct FeedRefreshProgressDonut: View {
 
     let progress: Double
     var size: CGFloat = 18
     var lineWidth: CGFloat = 2.5
+    var onStop: (() -> Void)? = nil
 
     private var clampedProgress: Double {
         min(max(progress, 0), 1)
     }
 
     var body: some View {
+        if let onStop {
+            Button(action: onStop) {
+                donut
+            }
+            .buttonStyle(.plain)
+            .contentShape(Rectangle())
+            .accessibilityLabel(
+                Text(String(localized: "Refresh.Stop", table: "Home"))
+            )
+            .accessibilityValue(
+                Text(clampedProgress, format: .percent.precision(.fractionLength(0)))
+            )
+        } else {
+            donut
+                .accessibilityElement()
+                .accessibilityLabel(
+                    Text(String(localized: "Refresh.Progress", table: "Home"))
+                )
+                .accessibilityValue(
+                    Text(clampedProgress, format: .percent.precision(.fractionLength(0)))
+                )
+        }
+    }
+
+    private var donut: some View {
         ZStack {
             Circle()
                 .stroke(Color.secondary.opacity(0.25), lineWidth: lineWidth)
@@ -25,12 +53,12 @@ struct FeedRefreshProgressDonut: View {
                 )
                 .rotationEffect(.degrees(-90))
                 .animation(.smooth, value: clampedProgress)
+            if onStop != nil {
+                RoundedRectangle(cornerRadius: 1, style: .continuous)
+                    .fill(Color.accentColor)
+                    .frame(width: size * 0.32, height: size * 0.32)
+            }
         }
         .frame(width: size, height: size)
-        .accessibilityElement()
-        .accessibilityLabel(Text(String(localized: "Refresh.Progress", table: "Home")))
-        .accessibilityValue(
-            Text(clampedProgress, format: .percent.precision(.fractionLength(0)))
-        )
     }
 }

--- a/Shared/Strings/Home.xcstrings
+++ b/Shared/Strings/Home.xcstrings
@@ -60,6 +60,65 @@
         }
       }
     },
+    "Refresh.Stop": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktualisierung der Feeds stoppen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stop refreshing feeds"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arrêter l'actualisation des flux"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Interrompi l'aggiornamento dei feed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フィードの更新を停止"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "피드 새로 고침 중지"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dừng làm mới nguồn cấp"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "停止刷新订阅源"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "停止更新訂閱源"
+          }
+        }
+      }
+    },
     "TodaysSummary.CombinePrompt": {
       "extractionState": "manual",
       "localizations": {


### PR DESCRIPTION
Tapping the toolbar donut while feeds are refreshing now cancels the
in-flight refresh task. FeedManager stores a handle to the current
refreshAllFeeds / refreshAllFeedsAndFavicons task so the button action
can cancel it; the task group stops submitting new feeds on cancel and
existing URLSession fetches throw CancellationError. A stop glyph is
drawn in the center of the donut when it is tappable.