### PR TITLE
Preserve marker-encoded blocks during article translation

### DIFF
--- a/SakuraRSS/Structs/ContentBlock+Translation.swift
+++ b/SakuraRSS/Structs/ContentBlock+Translation.swift
@@ -1,0 +1,126 @@
+import Foundation
+@preconcurrency import Translation
+
+extension ContentBlock {
+
+    /// A contiguous slice of marker-encoded article text for translation purposes.
+    enum TranslationSegment {
+        /// Plain text between markers — safe to send to the translator.
+        case translatable(String)
+        /// A `{{TAG}}...{{/TAG}}` block whose payload must be preserved verbatim.
+        case preserved(String)
+    }
+
+    /// Splits marker-encoded text into translatable spans and preserved marker blocks.
+    /// Translatable spans contain everything outside of `{{IMG}}`, `{{CODE}}`, `{{VIDEO}}`,
+    /// `{{YOUTUBE}}`, `{{XPOST}}`, `{{EMBED}}`, `{{TABLE}}`, and `{{MATH}}` markers.
+    static func translationSegments(from text: String) -> [TranslationSegment] {
+        let pattern = #"\{\{(IMG|CODE|VIDEO|YOUTUBE|XPOST|EMBED|TABLE|MATH)\}\}.*?\{\{/\1\}\}"#
+        guard let regex = try? NSRegularExpression(
+            pattern: pattern, options: .dotMatchesLineSeparators
+        ) else {
+            return text.isEmpty ? [] : [.translatable(text)]
+        }
+
+        let nsText = text as NSString
+        let matches = regex.matches(in: text, range: NSRange(location: 0, length: nsText.length))
+
+        guard !matches.isEmpty else {
+            return text.isEmpty ? [] : [.translatable(text)]
+        }
+
+        var segments: [TranslationSegment] = []
+        var lastEnd = 0
+
+        for match in matches {
+            if match.range.location > lastEnd {
+                let before = nsText.substring(
+                    with: NSRange(location: lastEnd, length: match.range.location - lastEnd)
+                )
+                if !before.isEmpty {
+                    segments.append(.translatable(before))
+                }
+            }
+            segments.append(.preserved(nsText.substring(with: match.range)))
+            lastEnd = match.range.location + match.range.length
+        }
+
+        if lastEnd < nsText.length {
+            let after = nsText.substring(from: lastEnd)
+            if !after.isEmpty {
+                segments.append(.translatable(after))
+            }
+        }
+
+        return segments
+    }
+
+    /// Translates marker-encoded article text one text block at a time, batching all text blocks
+    /// (and the optional title) into a single `session.translations(from:)` call so non-text
+    /// blocks (images, code, tables, embeds, math) are preserved verbatim in the output.
+    static func translateArticleContent(
+        title: String?, markerText: String, session: TranslationSession
+    ) async throws -> (title: String?, text: String) {
+        let segments = translationSegments(from: markerText)
+
+        let titleIdentifier = "title"
+        var requests: [TranslationSession.Request] = []
+
+        if let title, !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            requests.append(
+                TranslationSession.Request(sourceText: title, clientIdentifier: titleIdentifier)
+            )
+        }
+
+        for (index, segment) in segments.enumerated() {
+            guard case .translatable(let content) = segment,
+                  !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            else { continue }
+            requests.append(
+                TranslationSession.Request(
+                    sourceText: content, clientIdentifier: segmentIdentifier(for: index)
+                )
+            )
+        }
+
+        guard !requests.isEmpty else {
+            return (title: title, text: markerText)
+        }
+
+        let responses = try await session.translations(from: requests)
+        var translatedTitle: String? = title
+        var translatedSegments: [Int: String] = [:]
+
+        for response in responses {
+            guard let identifier = response.clientIdentifier else { continue }
+            if identifier == titleIdentifier {
+                translatedTitle = response.targetText
+            } else if let index = segmentIndex(from: identifier) {
+                translatedSegments[index] = response.targetText
+            }
+        }
+
+        var rebuilt = ""
+        for (index, segment) in segments.enumerated() {
+            switch segment {
+            case .translatable(let original):
+                rebuilt += translatedSegments[index] ?? original
+            case .preserved(let marker):
+                rebuilt += marker
+            }
+        }
+
+        return (title: translatedTitle, text: rebuilt)
+    }
+
+    private static let segmentIdentifierPrefix = "seg-"
+
+    private static func segmentIdentifier(for index: Int) -> String {
+        "\(segmentIdentifierPrefix)\(index)"
+    }
+
+    private static func segmentIndex(from identifier: String) -> Int? {
+        guard identifier.hasPrefix(segmentIdentifierPrefix) else { return nil }
+        return Int(identifier.dropFirst(segmentIdentifierPrefix.count))
+    }
+}

--- a/SakuraRSS/Views/Shared/Article Detail/ArticleDetailView+Translation.swift
+++ b/SakuraRSS/Views/Shared/Article Detail/ArticleDetailView+Translation.swift
@@ -27,25 +27,19 @@ extension ArticleDetailView {
                 // Translation failed; user can retry
             }
         } else {
-            let source = ContentBlock.plainText(from: extractedText ?? article.summary ?? "")
-            guard !source.isEmpty else { return }
+            let source = extractedText ?? article.summary ?? ""
+            guard !ContentBlock.plainText(from: source).isEmpty else { return }
             do {
-                let requests = [
-                    TranslationSession.Request(sourceText: article.title),
-                    TranslationSession.Request(sourceText: source)
-                ]
-                let responses = try await session.translations(from: requests)
-                if responses.count >= 2 {
-                    translatedTitle = responses[0].targetText
-                    translatedText = responses[1].targetText
-                    hasCachedTranslation = true
-                    showingTranslation = true
-                    try? DatabaseManager.shared.cacheArticleTranslation(
-                        title: responses[0].targetText,
-                        text: responses[1].targetText,
-                        for: article.id
-                    )
-                }
+                let result = try await ContentBlock.translateArticleContent(
+                    title: article.title, markerText: source, session: session
+                )
+                translatedTitle = result.title
+                translatedText = result.text
+                hasCachedTranslation = true
+                showingTranslation = true
+                try? DatabaseManager.shared.cacheArticleTranslation(
+                    title: result.title, text: result.text, for: article.id
+                )
             } catch {
                 // Translation failed; user can retry
             }

--- a/SakuraRSS/Views/Shared/Feed Display Styles/Scroll/ScrollExpandedArticleView.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/Scroll/ScrollExpandedArticleView.swift
@@ -350,25 +350,19 @@ struct ScrollExpandedArticleView: View { // swiftlint:disable:this type_body_len
                 // Translation failed; user can retry
             }
         } else {
-            let source = ContentBlock.plainText(from: extractedText ?? article.summary ?? "")
-            guard !source.isEmpty else { return }
+            let source = extractedText ?? article.summary ?? ""
+            guard !ContentBlock.plainText(from: source).isEmpty else { return }
             do {
-                let requests = [
-                    TranslationSession.Request(sourceText: article.title),
-                    TranslationSession.Request(sourceText: source)
-                ]
-                let responses = try await session.translations(from: requests)
-                if responses.count >= 2 {
-                    translatedTitle = responses[0].targetText
-                    translatedText = responses[1].targetText
-                    hasCachedTranslation = true
-                    showingTranslation = true
-                    try? DatabaseManager.shared.cacheArticleTranslation(
-                        title: responses[0].targetText,
-                        text: responses[1].targetText,
-                        for: article.id
-                    )
-                }
+                let result = try await ContentBlock.translateArticleContent(
+                    title: article.title, markerText: source, session: session
+                )
+                translatedTitle = result.title
+                translatedText = result.text
+                hasCachedTranslation = true
+                showingTranslation = true
+                try? DatabaseManager.shared.cacheArticleTranslation(
+                    title: result.title, text: result.text, for: article.id
+                )
             } catch {
                 // Translation failed; user can retry
             }

--- a/SakuraRSS/Views/Shared/YouTube Player/YouTubePlayerView+Translation.swift
+++ b/SakuraRSS/Views/Shared/YouTube Player/YouTubePlayerView+Translation.swift
@@ -28,15 +28,17 @@ extension YouTubePlayerView {
                 // Translation failed; user can retry
             }
         } else {
-            let source = ContentBlock.plainText(from: descriptionSource ?? "")
-            guard !source.isEmpty else { return }
+            let source = descriptionSource ?? ""
+            guard !ContentBlock.plainText(from: source).isEmpty else { return }
             do {
-                let response = try await session.translate(source)
-                translatedText = response.targetText
+                let result = try await ContentBlock.translateArticleContent(
+                    title: nil, markerText: source, session: session
+                )
+                translatedText = result.text
                 hasCachedTranslation = true
                 showingTranslation = true
                 try? DatabaseManager.shared.cacheArticleTranslation(
-                    title: nil, text: response.targetText, for: article.id
+                    title: nil, text: result.text, for: article.id
                 )
             } catch {
                 // Translation failed; user can retry


### PR DESCRIPTION
## Summary
This PR adds intelligent translation support for marker-encoded article content, ensuring that non-text blocks (images, code, tables, embeds, math, etc.) are preserved verbatim during translation while only translatable text segments are sent to the translation service.

## Key Changes
- **New `ContentBlock+Translation.swift`**: Introduces translation infrastructure with:
  - `TranslationSegment` enum to distinguish between translatable text and preserved marker blocks
  - `translationSegments(from:)` method that parses marker-encoded text using regex to identify `{{TAG}}...{{/TAG}}` blocks for images, code, videos, YouTube embeds, cross-posts, embedded content, tables, and math
  - `translateArticleContent(title:markerText:session:)` method that batches all translatable segments and the optional title into a single translation session call, then reconstructs the output with preserved markers intact

- **Updated translation call sites** in three views:
  - `ArticleDetailView+Translation.swift`
  - `ScrollExpandedArticleView.swift`
  - `YouTubePlayerView+Translation.swift`
  
  All now use the new `translateArticleContent()` method instead of manually creating translation requests, ensuring consistent marker preservation across the app.

## Implementation Details
- Uses regex pattern matching with `.dotMatchesLineSeparators` option to handle multi-line marker blocks
- Segments are identified by index-based client identifiers (`seg-0`, `seg-1`, etc.) to map translation responses back to their source segments
- Empty segments and whitespace-only content are filtered out before translation to reduce API calls
- The title is handled as a special case with the identifier `"title"` and is optional
- Preserved marker blocks are reconstructed verbatim in their original positions, maintaining document structure

https://claude.ai/code/session_01RAcS6Lq96gHJhYRszg2r6g