### PR TITLE
Batch database updates for mark-as-read and last-accessed timestamps

### DIFF
--- a/SakuraRSS/Classes/Feed Manager/FeedManager+PendingReads.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+PendingReads.swift
@@ -22,14 +22,16 @@ extension FeedManager {
         debouncedReadFlushTask?.cancel()
         debouncedReadFlushTask = nil
         guard !pendingReadIDs.isEmpty else { return }
-        let ids = pendingReadIDs
+        let ids = Array(pendingReadIDs)
         pendingReadIDs.removeAll()
         let dbm = database
         Task.detached(priority: .utility) { [weak self] in
-            for id in ids {
-                try? dbm.markArticleRead(id: id, read: true)
-                try? dbm.updateLastAccessed(articleID: id)
-            }
+            // Two batched UPDATEs (one for the read flag, one for the
+            // access timestamp) instead of 2N per-row statements — keeps
+            // CPU and disk light even when dozens of rows scroll past in
+            // quick succession.
+            try? dbm.markArticlesRead(ids: ids, read: true)
+            try? dbm.updateLastAccessed(articleIDs: ids)
             // Skip the UI-side reload: `markReadDebounced` already applied
             // the read state and unread-count decrement to the in-memory
             // arrays, so `articles` + `unreadCounts` already match what a

--- a/SakuraRSS/Views/Shared/Articles/ArticlesView.swift
+++ b/SakuraRSS/Views/Shared/Articles/ArticlesView.swift
@@ -36,6 +36,7 @@ struct ArticlesView: View {
     @State private var displayStyle: FeedDisplayStyle
     @State private var isShowingMarkAllReadConfirmation = false
     @AppStorage("Articles.HideRead") private var hideRead = false
+    @AppStorage("Display.ScrollMarkAsRead") private var scrollMarkAsRead: Bool = false
     @AppStorage("Display.MarkAllReadPosition") private var markAllReadPosition: MarkAllReadPosition = .bottom
     private let viewStyleSwitcherTip = ViewStyleSwitcherTip()
 
@@ -96,6 +97,10 @@ struct ArticlesView: View {
     }
 
     private var hideReadSupported: Bool {
+        // Hiding read items conflicts with mark-as-read-on-scroll: rows would
+        // disappear as they pass the viewport edge and yank the scroll
+        // position. Force the toggle off while that setting is enabled.
+        guard !scrollMarkAsRead else { return false }
         let style = effectiveDisplayStyle
         return style == .inbox || style == .magazine || style == .compact
     }

--- a/Shared/Database Manager/DatabaseManager+Articles.swift
+++ b/Shared/Database Manager/DatabaseManager+Articles.swift
@@ -255,6 +255,15 @@ nonisolated extension DatabaseManager {
         try database.run(target.update(articleIsRead <- read))
     }
 
+    /// Batched counterpart of `markArticleRead(id:read:)` — applies a single
+    /// `UPDATE ... WHERE id IN (...)` so N scroll-mark-as-read events collapse
+    /// into one SQLite write instead of N.
+    func markArticlesRead(ids: [Int64], read: Bool) throws {
+        guard !ids.isEmpty else { return }
+        let target = articles.filter(ids.contains(articleID))
+        try database.run(target.update(articleIsRead <- read))
+    }
+
     func toggleBookmark(id: Int64) throws {
         guard let row = try database.pluck(articles.filter(articleID == id)) else { return }
         let current = row[articleIsBookmarked]
@@ -304,6 +313,14 @@ nonisolated extension DatabaseManager {
 
     func updateLastAccessed(articleID id: Int64) throws {
         let target = articles.filter(articleID == id)
+        try database.run(target.update(articleLastAccessed <- Date().timeIntervalSince1970))
+    }
+
+    /// Batched counterpart of `updateLastAccessed(articleID:)` — stamps the
+    /// same timestamp across all ids in one `UPDATE`.
+    func updateLastAccessed(articleIDs ids: [Int64]) throws {
+        guard !ids.isEmpty else { return }
+        let target = articles.filter(ids.contains(articleID))
         try database.run(target.update(articleLastAccessed <- Date().timeIntervalSince1970))
     }
 


### PR DESCRIPTION
## Summary
Optimizes database performance by batching mark-as-read and last-accessed timestamp updates, collapsing N individual row updates into 2 bulk `UPDATE ... WHERE id IN (...)` statements. This significantly reduces CPU and disk I/O when users scroll through articles quickly.

## Key Changes
- **DatabaseManager**: Added two new batched update methods:
  - `markArticlesRead(ids:read:)` — bulk update read status for multiple articles
  - `updateLastAccessed(articleIDs:)` — bulk update last-accessed timestamp for multiple articles

- **FeedManager+PendingReads**: Refactored the deferred read-marking flush to use the new batched methods instead of looping through individual updates. Converts the pending read IDs set to an array once, then applies both updates in a single detached task.

- **ArticlesView**: Added a new `scrollMarkAsRead` user preference and implemented a guard to prevent the "hide read articles" toggle from being enabled simultaneously, as it would cause rows to disappear and disrupt scroll position during mark-as-read-on-scroll operations.

## Implementation Details
- The batched methods use SQLite's `WHERE id IN (...)` clause for efficient bulk operations
- Both methods include guard checks to skip execution on empty ID arrays
- The timestamp is captured once per batch rather than per-row, ensuring consistency
- UI-side state is already updated before the database flush, so no reload is needed after the batched updates complete

https://claude.ai/code/session_017GyvKFJxbPu8kteV7dXsft