### PR TITLE
Fix iCloud backup scheduling to prevent drift and improve reliability

### DIFF
--- a/SakuraRSS/Views/App+BackgroundTasks.swift
+++ b/SakuraRSS/Views/App+BackgroundTasks.swift
@@ -92,8 +92,31 @@ extension SakuraRSSApp {
         let request = BGProcessingTaskRequest(identifier: iCloudBackupTaskID)
         request.requiresNetworkConnectivity = true
         request.requiresExternalPower = true
-        request.earliestBeginDate = Date(timeIntervalSinceNow: TimeInterval(interval.rawValue))
+        request.earliestBeginDate = earliestBackupDate(for: interval)
         try? BGTaskScheduler.shared.submit(request)
+    }
+
+    /// For `.everyNight`, target the next occurrence of 2 AM local time so
+    /// the task's earliest run overlaps with typical overnight charging.
+    /// Using `now + 24h` caused the window to drift forward each launch,
+    /// landing mid-day when the device is rarely plugged in.
+    private func earliestBackupDate(for interval: iCloudBackupManager.BackupInterval) -> Date {
+        switch interval {
+        case .everyNight:
+            let calendar = Calendar.current
+            let now = Date()
+            var components = calendar.dateComponents([.year, .month, .day], from: now)
+            components.hour = 2
+            components.minute = 0
+            components.second = 0
+            let candidate = calendar.date(from: components) ?? now
+            if candidate > now {
+                return candidate
+            }
+            return calendar.date(byAdding: .day, value: 1, to: candidate) ?? now.addingTimeInterval(86400)
+        case .every12Hours, .every6Hours, .off:
+            return Date(timeIntervalSinceNow: TimeInterval(interval.rawValue))
+        }
     }
 
     func handleiCloudBackup(task: BGProcessingTask) {

--- a/Shared/Data Portability/iCloudBackupManager.swift
+++ b/Shared/Data Portability/iCloudBackupManager.swift
@@ -73,6 +73,8 @@ final class iCloudBackupManager: @unchecked Sendable {
     }
 
     /// Runs a backup if the user's chosen interval has elapsed since the last backup.
+    /// The system already throttled us via `earliestBeginDate`, so we allow a
+    /// 10% slack to avoid skipping a granted run over minor timing drift.
     func backupIfScheduled() async {
         let intervalRaw = UserDefaults.standard.integer(forKey: "iCloudBackup.Interval")
         let interval = BackupInterval(rawValue: intervalRaw) ?? .everyNight
@@ -81,7 +83,8 @@ final class iCloudBackupManager: @unchecked Sendable {
 
         let lastBackup = UserDefaults.standard.double(forKey: "iCloudBackup.LastBackupDate")
         let elapsed = Date().timeIntervalSince1970 - lastBackup
-        guard elapsed >= Double(interval.rawValue) else { return }
+        let threshold = Double(interval.rawValue) * 0.9
+        guard elapsed >= threshold else { return }
 
         try? await backupNow()
     }


### PR DESCRIPTION
## Summary
Improved the iCloud backup scheduling logic to prevent timing drift and increase reliability by targeting specific times for nightly backups and adding tolerance for minor timing variations.

## Key Changes
- **Refactored backup scheduling logic**: Extracted `earliestBackupDate(for:)` method to handle interval-specific scheduling strategies
- **Fixed nightly backup drift**: For `.everyNight` backups, the scheduler now targets 2 AM local time instead of using a fixed 24-hour offset. This prevents the backup window from drifting forward with each app launch and ensures backups occur during typical overnight charging periods
- **Added scheduling tolerance**: Modified `backupIfScheduled()` to use a 10% slack threshold when checking if the scheduled interval has elapsed, accounting for minor timing drift introduced by system throttling and task scheduling

## Implementation Details
- The new `earliestBackupDate(for:)` method calculates the next 2 AM occurrence for nightly backups by constructing a date with the current date but 2 AM time, then advancing to the next day if that time has already passed
- Other backup intervals (`.every12Hours`, `.every6Hours`, `.off`) continue using the original time-interval-based approach
- The 10% slack tolerance (e.g., 21.6 hours instead of 24 hours for nightly backups) prevents skipping a granted task execution due to minor timing variations while still respecting the user's chosen interval

https://claude.ai/code/session_01EXRcVWkdCvbrcC5478ZLyA