### PR TITLE
Skip article extraction for one-cushioned domains

### DIFF
--- a/SakuraRSS/Views/Shared/Article Detail/ArticleDetailView+Extraction.swift
+++ b/SakuraRSS/Views/Shared/Article Detail/ArticleDetailView+Extraction.swift
@@ -154,7 +154,16 @@ extension ArticleDetailView {
             return
         }
 
-        if !isRedditLinkedArticle, let content = article.content, !content.isEmpty {
+        // For one-cushioned domains (e.g. news.yahoo.co.jp), the feed content
+        // is only a short preview, and we must follow the cushion page to the
+        // real article. Skip the feed-content shortcut in that case.
+        let isOneCushionedArticle: Bool = {
+            guard let url = URL(string: article.url) else { return false }
+            return OneCushionedDomains.isOneCushioned(url: url)
+        }()
+
+        if !isRedditLinkedArticle, !isOneCushionedArticle,
+           let content = article.content, !content.isEmpty {
             let baseURL = URL(string: article.url)
             let text = ArticleExtractor.extractText(fromHTML: content,
                                                     baseURL: baseURL,

--- a/SakuraRSS/Views/Shared/Article Detail/ArticleDetailView+Extraction.swift
+++ b/SakuraRSS/Views/Shared/Article Detail/ArticleDetailView+Extraction.swift
@@ -154,9 +154,6 @@ extension ArticleDetailView {
             return
         }
 
-        // For one-cushioned domains (e.g. news.yahoo.co.jp), the feed content
-        // is only a short preview, and we must follow the cushion page to the
-        // real article. Skip the feed-content shortcut in that case.
         let isOneCushionedArticle: Bool = {
             guard let url = URL(string: article.url) else { return false }
             return OneCushionedDomains.isOneCushioned(url: url)


### PR DESCRIPTION
## Summary
Updated the article detail view to skip content extraction for articles from one-cushioned domains, similar to how Reddit-linked articles are already handled.

## Key Changes
- Added detection logic to identify if an article URL belongs to a one-cushioned domain using `OneCushionedDomains.isOneCushioned(url:)`
- Modified the content extraction condition to exclude one-cushioned articles from HTML text extraction, preventing unnecessary processing of articles that may have limited or restricted content access

## Implementation Details
- The one-cushioned domain check is performed once and stored in a local variable for efficiency
- The check is integrated into the existing conditional guard alongside the Reddit article check, maintaining consistent handling of special article sources

https://claude.ai/code/session_014jWPH8tQq6LkGZPYrx2Yrp