### PR TITLE
Swap title and body for feeds with generic titles

### DIFF
--- a/SakuraRSS/Classes/Feed Manager/FeedManager+Refresh.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+Refresh.swift
@@ -41,17 +41,22 @@ extension FeedManager {
             let parser = RSSParser()
             guard let parsed = parser.parse(data: data) else { return }
 
+            let feedDomain = feed.domain
+            let preparedArticles = parsed.articles.map { article in
+                BodyPriorityDomains.applying(to: article, feedDomain: feedDomain)
+            }
+
             let existingURLs = (try? database.existingArticleURLs(forFeedID: feed.id)) ?? []
             let imageBackfills: [String: String]
             if skipImageBackfill {
                 imageBackfills = [:]
             } else {
                 imageBackfills = await FeedManager.backfillMetadataImages(
-                    for: parsed.articles, skippingURLs: existingURLs
+                    for: preparedArticles, skippingURLs: existingURLs
                 )
             }
 
-            let articleTuples = parsed.articles.map { article in
+            let articleTuples = preparedArticles.map { article in
                 let resolvedImageURL = article.imageURL ?? imageBackfills[article.url]
                 return ArticleInsertItem(
                     title: article.title,

--- a/Shared/Domain Options/BodyPriorityDomains.swift
+++ b/Shared/Domain Options/BodyPriorityDomains.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// Domains whose feeds carry the meaningful article text in the
+/// body/summary while the `<title>` element holds a generic category
+/// label (e.g. the JMA extra feed at
+/// https://www.data.jma.go.jp/developer/xml/feed/extra.xml). For these
+/// feeds, the title and body are swapped so lists surface the useful
+/// information first.
+nonisolated enum BodyPriorityDomains {
+
+    static let allowlistedDomains: Set<String> = [
+        "data.jma.go.jp"
+    ]
+
+    static func shouldSwapTitleAndBody(feedDomain: String) -> Bool {
+        let host = feedDomain.lowercased()
+        return allowlistedDomains.contains(where: { host == $0 || host.hasSuffix(".\($0)") })
+    }
+
+    /// Returns a copy of `article` with title and body swapped when the
+    /// feed's domain is in the allowlist. The body is sourced from
+    /// `summary` when present, otherwise from `content`.
+    static func applying(to article: ParsedArticle, feedDomain: String) -> ParsedArticle {
+        guard shouldSwapTitleAndBody(feedDomain: feedDomain) else { return article }
+
+        let bodySource = article.summary?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let contentSource = article.content?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let newTitle: String
+        let newSummary: String?
+        if let bodySource, !bodySource.isEmpty {
+            newTitle = bodySource
+            newSummary = article.title
+        } else if let contentSource, !contentSource.isEmpty {
+            newTitle = contentSource
+            newSummary = article.title
+        } else {
+            return article
+        }
+
+        var swapped = article
+        swapped.title = collapseWhitespace(newTitle)
+        swapped.summary = newSummary
+        return swapped
+    }
+
+    private static func collapseWhitespace(_ text: String) -> String {
+        let collapsed = text.replacingOccurrences(
+            of: #"\s+"#, with: " ", options: .regularExpression
+        )
+        return collapsed.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}


### PR DESCRIPTION
## Summary
Add support for feeds that carry meaningful article text in the body/summary while using generic category labels in the title element. For these feeds, the title and body are swapped so that list views surface the useful information first.

## Changes
- **New file: `BodyPriorityDomains.swift`** - Domain allowlist and article transformation logic
  - Maintains an allowlist of domains (currently `data.jma.go.jp`) that require title/body swapping
  - Provides `shouldSwapTitleAndBody()` to check if a domain is allowlisted (supports subdomains)
  - Implements `applying()` to swap title and body for matching feeds, preferring summary over content as the new title
  - Collapses excess whitespace in the new title for cleaner display

- **Modified: `FeedManager+Refresh.swift`** - Integrate article transformation into feed refresh flow
  - Extract feed domain and apply `BodyPriorityDomains` transformation to all parsed articles before further processing
  - Use transformed articles for both image backfill and database insertion

## Implementation Details
- The transformation prefers `summary` over `content` as the source for the new title
- Falls back to returning the original article if no suitable body content is found
- Whitespace is normalized in the new title using regex to collapse multiple spaces into single spaces
- Domain matching is case-insensitive and supports subdomain matching (e.g., `sub.data.jma.go.jp`)

https://claude.ai/code/session_01EkYVHnNYdu12BPDu4qjJwx