### PR TITLE
Replace onAppear with onScrollVisibilityChange for load button

### DIFF
--- a/SakuraRSS/Views/Shared/Articles/ArticlesView.swift
+++ b/SakuraRSS/Views/Shared/Articles/ArticlesView.swift
@@ -255,6 +255,7 @@ struct LoadPreviousArticlesButton: View {
     let action: () -> Void
 
     @AppStorage("Articles.AutoLoadWhileScrolling") private var autoLoadWhileScrolling: Bool = false
+    @State private var isVisible: Bool = false
 
     var body: some View {
         Group {
@@ -267,9 +268,11 @@ struct LoadPreviousArticlesButton: View {
                 }
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 12)
-                .onAppear {
-                    withAnimation(.smooth.speed(2.0)) {
-                        action()
+                .onScrollVisibilityChange(threshold: 0.1) { visible in
+                    let wasVisible = isVisible
+                    isVisible = visible
+                    if visible && !wasVisible {
+                        triggerLoad()
                     }
                 }
             } else {
@@ -288,6 +291,14 @@ struct LoadPreviousArticlesButton: View {
                 }
                 .buttonStyle(.bordered)
                 .tint(.secondary)
+            }
+        }
+    }
+
+    private func triggerLoad() {
+        Task { @MainActor in
+            withAnimation(.smooth.speed(2.0)) {
+                action()
             }
         }
     }


### PR DESCRIPTION
## Summary
Changed the trigger mechanism for the "Load Previous Articles" button from `onAppear` to `onScrollVisibilityChange`, ensuring the load action only fires when the button becomes visible during scrolling rather than on initial view appearance.

## Key Changes
- Replaced `onAppear` lifecycle hook with `onScrollVisibilityChange(threshold: 0.1)` modifier
- Added `@State private var isVisible: Bool` to track visibility state
- Implemented visibility change detection that only triggers the load action on the transition from hidden to visible
- Extracted the load logic into a new `triggerLoad()` private method for better organization
- Wrapped the action call in a `Task { @MainActor in }` block to ensure proper threading

## Implementation Details
- The visibility change handler tracks the previous visibility state (`wasVisible`) and only executes the action when the button transitions from invisible to visible
- This prevents unnecessary load triggers and ensures the button only loads articles when it actually comes into view during user scrolling
- The `triggerLoad()` method maintains the existing animation behavior (`smooth.speed(2.0)`) while providing a cleaner separation of concerns

https://claude.ai/code/session_01Xp9cY1cE9KYnWinHeo4zd1