### PR TITLE
Fix marker parsing when content contains escaped delimiters

### DIFF
--- a/Feeds/Article Extractor/ArticleMarker.swift
+++ b/Feeds/Article Extractor/ArticleMarker.swift
@@ -50,10 +50,8 @@ nonisolated enum ArticleMarker {
         return result
     }
 
-    /// Runs `regex` against `text`; if it finds nothing but the text
-    /// carries PUA-escaped delimiters, retries against the unescaped
-    /// form. Returns the `NSString` that the match ranges index into
-    /// so callers can substring out captured groups directly.
+    /// Runs `regex` against `text`, retrying on the unescaped form when
+    /// the as-is pass finds nothing but PUA delimiters are present.
     static func regexMatches(
         of regex: NSRegularExpression, in text: String
     ) -> (nsText: NSString, matches: [NSTextCheckingResult]) {

--- a/Feeds/Article Extractor/ArticleMarker.swift
+++ b/Feeds/Article Extractor/ArticleMarker.swift
@@ -49,4 +49,27 @@ nonisolated enum ArticleMarker {
         }
         return result
     }
+
+    /// Runs `regex` against `text`; if it finds nothing but the text
+    /// carries PUA-escaped delimiters, retries against the unescaped
+    /// form. Returns the `NSString` that the match ranges index into
+    /// so callers can substring out captured groups directly.
+    static func regexMatches(
+        of regex: NSRegularExpression, in text: String
+    ) -> (nsText: NSString, matches: [NSTextCheckingResult]) {
+        let nsOriginal = text as NSString
+        let original = regex.matches(
+            in: text, range: NSRange(location: 0, length: nsOriginal.length)
+        )
+        if !original.isEmpty || !text.contains("\u{E000}") {
+            return (nsOriginal, original)
+        }
+        let unescaped = unescape(text)
+        let nsUnescaped = unescaped as NSString
+        let retry = regex.matches(
+            in: unescaped,
+            range: NSRange(location: 0, length: nsUnescaped.length)
+        )
+        return retry.isEmpty ? (nsOriginal, original) : (nsUnescaped, retry)
+    }
 }

--- a/SakuraRSS/Structs/ContentBlock+Translation.swift
+++ b/SakuraRSS/Structs/ContentBlock+Translation.swift
@@ -22,27 +22,11 @@ extension ContentBlock {
             return text.isEmpty ? [] : [.translatable(text)]
         }
 
-        // Mirror `ContentBlock.parse`: if the as-is pass finds no markers
-        // but the text carries PUA-escaped delimiters, reparse against the
-        // unescaped form so image/code/embed blocks stay preserved instead
-        // of being fed into the translator as opaque Unicode runs.
-        var nsText = text as NSString
-        var matches = regex.matches(
-            in: text, range: NSRange(location: 0, length: nsText.length)
-        )
-
-        if matches.isEmpty && text.contains("\u{E000}") {
-            let unescaped = ArticleMarker.unescape(text)
-            let nsUnescaped = unescaped as NSString
-            let retry = regex.matches(
-                in: unescaped,
-                range: NSRange(location: 0, length: nsUnescaped.length)
-            )
-            if !retry.isEmpty {
-                nsText = nsUnescaped
-                matches = retry
-            }
-        }
+        // Use the same escape-fallback as `ContentBlock.parse` so image,
+        // code, and embed blocks stay preserved when upstream text carries
+        // escaped delimiters instead of being fed into the translator as
+        // opaque Unicode runs.
+        let (nsText, matches) = ArticleMarker.regexMatches(of: regex, in: text)
 
         guard !matches.isEmpty else {
             return text.isEmpty ? [] : [.translatable(text)]

--- a/SakuraRSS/Structs/ContentBlock+Translation.swift
+++ b/SakuraRSS/Structs/ContentBlock+Translation.swift
@@ -22,8 +22,27 @@ extension ContentBlock {
             return text.isEmpty ? [] : [.translatable(text)]
         }
 
-        let nsText = text as NSString
-        let matches = regex.matches(in: text, range: NSRange(location: 0, length: nsText.length))
+        // Mirror `ContentBlock.parse`: if the as-is pass finds no markers
+        // but the text carries PUA-escaped delimiters, reparse against the
+        // unescaped form so image/code/embed blocks stay preserved instead
+        // of being fed into the translator as opaque Unicode runs.
+        var nsText = text as NSString
+        var matches = regex.matches(
+            in: text, range: NSRange(location: 0, length: nsText.length)
+        )
+
+        if matches.isEmpty && text.contains("\u{E000}") {
+            let unescaped = ArticleMarker.unescape(text)
+            let nsUnescaped = unescaped as NSString
+            let retry = regex.matches(
+                in: unescaped,
+                range: NSRange(location: 0, length: nsUnescaped.length)
+            )
+            if !retry.isEmpty {
+                nsText = nsUnescaped
+                matches = retry
+            }
+        }
 
         guard !matches.isEmpty else {
             return text.isEmpty ? [] : [.translatable(text)]

--- a/SakuraRSS/Structs/ContentBlock+Translation.swift
+++ b/SakuraRSS/Structs/ContentBlock+Translation.swift
@@ -22,10 +22,6 @@ extension ContentBlock {
             return text.isEmpty ? [] : [.translatable(text)]
         }
 
-        // Use the same escape-fallback as `ContentBlock.parse` so image,
-        // code, and embed blocks stay preserved when upstream text carries
-        // escaped delimiters instead of being fed into the translator as
-        // opaque Unicode runs.
         let (nsText, matches) = ArticleMarker.regexMatches(of: regex, in: text)
 
         guard !matches.isEmpty else {

--- a/SakuraRSS/Structs/ContentBlock.swift
+++ b/SakuraRSS/Structs/ContentBlock.swift
@@ -134,8 +134,30 @@ enum ContentBlock: Identifiable {
             return [.text(ArticleMarker.unescape(text))]
         }
 
-        let nsText = text as NSString
-        let matches = regex.matches(in: text, range: NSRange(location: 0, length: nsText.length))
+        // Pick the form that yields markers. Producers normally emit real
+        // `{{TAG}}` delimiters and PUA-escape only literal marker text in
+        // user content, but some extraction paths run `ArticleMarker.escape`
+        // over their own output and turn real markers into escaped ones.
+        // If the as-is pass finds no markers but the text carries escaped
+        // delimiters, reparse against the unescaped form so those blocks
+        // render as content instead of leaking as literal `{{TAG}}` text.
+        var nsText = text as NSString
+        var matches = regex.matches(
+            in: text, range: NSRange(location: 0, length: nsText.length)
+        )
+
+        if matches.isEmpty && text.contains("\u{E000}") {
+            let unescaped = ArticleMarker.unescape(text)
+            let nsUnescaped = unescaped as NSString
+            let retry = regex.matches(
+                in: unescaped,
+                range: NSRange(location: 0, length: nsUnescaped.length)
+            )
+            if !retry.isEmpty {
+                nsText = nsUnescaped
+                matches = retry
+            }
+        }
 
         guard !matches.isEmpty else {
             return [.text(ArticleMarker.unescape(text))]

--- a/SakuraRSS/Structs/ContentBlock.swift
+++ b/SakuraRSS/Structs/ContentBlock.swift
@@ -134,30 +134,12 @@ enum ContentBlock: Identifiable {
             return [.text(ArticleMarker.unescape(text))]
         }
 
-        // Pick the form that yields markers. Producers normally emit real
-        // `{{TAG}}` delimiters and PUA-escape only literal marker text in
-        // user content, but some extraction paths run `ArticleMarker.escape`
-        // over their own output and turn real markers into escaped ones.
-        // If the as-is pass finds no markers but the text carries escaped
-        // delimiters, reparse against the unescaped form so those blocks
-        // render as content instead of leaking as literal `{{TAG}}` text.
-        var nsText = text as NSString
-        var matches = regex.matches(
-            in: text, range: NSRange(location: 0, length: nsText.length)
-        )
-
-        if matches.isEmpty && text.contains("\u{E000}") {
-            let unescaped = ArticleMarker.unescape(text)
-            let nsUnescaped = unescaped as NSString
-            let retry = regex.matches(
-                in: unescaped,
-                range: NSRange(location: 0, length: nsUnescaped.length)
-            )
-            if !retry.isEmpty {
-                nsText = nsUnescaped
-                matches = retry
-            }
-        }
+        // Fall back to the unescaped form when the text carries only
+        // PUA-escaped delimiters — some extraction paths run
+        // `ArticleMarker.escape` over their own output and flip real
+        // markers to the escaped form, which would otherwise leak as
+        // literal `{{TAG}}` text.
+        let (nsText, matches) = ArticleMarker.regexMatches(of: regex, in: text)
 
         guard !matches.isEmpty else {
             return [.text(ArticleMarker.unescape(text))]

--- a/SakuraRSS/Structs/ContentBlock.swift
+++ b/SakuraRSS/Structs/ContentBlock.swift
@@ -134,11 +134,6 @@ enum ContentBlock: Identifiable {
             return [.text(ArticleMarker.unescape(text))]
         }
 
-        // Fall back to the unescaped form when the text carries only
-        // PUA-escaped delimiters — some extraction paths run
-        // `ArticleMarker.escape` over their own output and flip real
-        // markers to the escaped form, which would otherwise leak as
-        // literal `{{TAG}}` text.
         let (nsText, matches) = ArticleMarker.regexMatches(of: regex, in: text)
 
         guard !matches.isEmpty else {

--- a/SakuraRSS/Views/Shared/Article Detail/ArticleDetailView+Extraction.swift
+++ b/SakuraRSS/Views/Shared/Article Detail/ArticleDetailView+Extraction.swift
@@ -333,6 +333,7 @@ extension ArticleDetailView {
         // Show spinner immediately to avoid flashing article.summary
         // while extraction is pending
         isExtracting = true
+        defer { isExtracting = false }
 
         // Clear cached images for this article
         if let imageURL = article.imageURL {
@@ -366,6 +367,11 @@ extension ArticleDetailView {
         let previousText = extractedText
         extractedText = nil
         await extractArticleContent()
+        // `extractArticleContent` flips `isExtracting` off via its own defer
+        // before returning. Re-assert it so the spinner stays visible while
+        // the fallback restoration below runs, avoiding a brief render with
+        // `article.summary` when the new extraction produced nothing.
+        isExtracting = true
 
         // If re-extraction produced nothing, restore the previous content
         // and re-cache it so subsequent loads still work.

--- a/SakuraRSS/Views/Shared/Article Detail/ArticleDetailView+Extraction.swift
+++ b/SakuraRSS/Views/Shared/Article Detail/ArticleDetailView+Extraction.swift
@@ -367,10 +367,8 @@ extension ArticleDetailView {
         let previousText = extractedText
         extractedText = nil
         await extractArticleContent()
-        // `extractArticleContent` flips `isExtracting` off via its own defer
-        // before returning. Re-assert it so the spinner stays visible while
-        // the fallback restoration below runs, avoiding a brief render with
-        // `article.summary` when the new extraction produced nothing.
+        // Re-assert over `extractArticleContent`'s own `defer` so the
+        // spinner stays visible through the fallback restoration below.
         isExtracting = true
 
         // If re-extraction produced nothing, restore the previous content


### PR DESCRIPTION
## Summary
This PR fixes an issue where article content with escaped marker delimiters (`{{TAG}}`) would fail to parse correctly, causing them to leak as literal text instead of being recognized as content blocks. The fix implements a fallback parsing strategy that unescapes the text and reparses it when the initial pass finds no markers but detects PUA-escaped delimiters.

## Key Changes

- **ContentBlock.swift**: Added fallback logic to `parse()` that detects when text contains escaped delimiters (`\u{E000}`) but no markers are found. When detected, the text is unescaped and reparsed to properly identify content blocks instead of treating escaped delimiters as literal text.

- **ContentBlock+Translation.swift**: Mirrored the same fallback parsing logic in the translation path to ensure image/code/embed blocks are preserved during translation instead of being treated as opaque Unicode sequences.

- **ArticleDetailView+Extraction.swift**: Fixed spinner visibility during content re-extraction by:
  - Adding a `defer` block to reset `isExtracting` flag in `extractArticleContent()`
  - Re-asserting `isExtracting = true` after re-extraction to keep the spinner visible during fallback restoration, preventing a brief flash of the article summary

## Implementation Details

The fix addresses a scenario where some extraction paths run `ArticleMarker.escape()` over their own output, converting real markers into escaped ones. The solution checks for the presence of PUA escape characters (`\u{E000}`) and only performs the expensive unescape-and-reparse operation when necessary, maintaining performance for the common case where markers are already in the correct form.

https://claude.ai/code/session_01R5vj3CCYpvuapPjc6LsJkL