### PR TITLE
Integrate NLP processing into feed refresh with progress tracking

### DIFF
--- a/Feeds/Feed.swift
+++ b/Feeds/Feed.swift
@@ -68,6 +68,15 @@ nonisolated struct Feed: Identifiable, Hashable, Sendable {
         isXFeed || isInstagramFeed || isRedditFeed || isFeedViewDomain || isPhotoViewDomain
     }
 
+    /// Feeds whose refresh path is slow because it walks paginated pages
+    /// (X, Instagram), scrapes HTML (YouTube playlists), or runs a custom
+    /// recipe (Petal).  Prioritized ahead of regular RSS feeds so the
+    /// wall-clock refresh is bounded by the slowest bucket, not by where
+    /// slow feeds happen to land in the feed list.
+    var isSlowRefreshFeed: Bool {
+        isXFeed || isInstagramFeed || isYouTubePlaylistFeed || PetalRecipe.isPetalFeedURL(url)
+    }
+
     /// The feed category section for grouped display.
     var feedSection: FeedSection {
         if isPodcast { return .audio }

--- a/Feeds/Feed.swift
+++ b/Feeds/Feed.swift
@@ -68,11 +68,7 @@ nonisolated struct Feed: Identifiable, Hashable, Sendable {
         isXFeed || isInstagramFeed || isRedditFeed || isFeedViewDomain || isPhotoViewDomain
     }
 
-    /// Feeds whose refresh path is slow because it walks paginated pages
-    /// (X, Instagram), scrapes HTML (YouTube playlists), or runs a custom
-    /// recipe (Petal).  Prioritized ahead of regular RSS feeds so the
-    /// wall-clock refresh is bounded by the slowest bucket, not by where
-    /// slow feeds happen to land in the feed list.
+    /// Feeds whose refresh path walks pages or runs a custom recipe.
     var isSlowRefreshFeed: Bool {
         isXFeed || isInstagramFeed || isYouTubePlaylistFeed || PetalRecipe.isPetalFeedURL(url)
     }

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+Refresh.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+Refresh.swift
@@ -174,15 +174,7 @@ extension FeedManager {
         await loadFromDatabaseInBackground()
     }
 
-    /// Refreshes every feed.  `skipAuthenticatedScrapers` omits X and
-    /// Instagram profile feeds (pass from background refresh tasks).
-    /// `respectCooldown` skips feeds whose `lastFetched` is within the
-    /// `BackgroundRefresh.Cooldown` window; feeds with nil `lastFetched`
-    /// always refresh.  `skipImageBackfill` disables the HTML metadata
-    /// image lookup per article (cellular-safe background paths set
-    /// this when the user has the Wi-Fi-only backfill preference on).
-    /// `runNLPAfter` chains a Content-Insights NLP pass onto the same
-    /// cancellable task so the progress donut spans both phases.
+    /// Refreshes every feed, then optionally chains the NLP pass.
     func refreshAllFeeds(
         skipAuthenticatedScrapers: Bool = false,
         respectCooldown: Bool = false,
@@ -210,12 +202,6 @@ extension FeedManager {
             return true
         }
 
-        // Slow bucket (X, Instagram, YouTube playlists, Petal) is kicked
-        // off first with a tight concurrency cap so pagination-heavy
-        // scrapers start walking immediately.  Regular RSS feeds run in
-        // parallel on a separate group with higher concurrency; both
-        // buckets share the same `refreshCompleted` counter so the donut
-        // advances smoothly across them.
         let slowFeeds = feedsToRefresh.filter { $0.isSlowRefreshFeed }
         let regularFeeds = feedsToRefresh.filter { !$0.isSlowRefreshFeed }
 
@@ -237,11 +223,6 @@ extension FeedManager {
             }
         }
 
-        // Empirically past ~8 in-flight regular fetches end-to-end wall
-        // time stops improving on cellular and regresses on Wi-Fi due to
-        // contention with the main-actor reload work.  Slow scrapers hit
-        // authenticated or rate-limited endpoints and benefit from a
-        // smaller cap so we don't thrash cookies or trip server pacing.
         let work = Task { [weak self] in
             guard let self else { return }
             async let slow: Void = self.runBoundedRefresh(
@@ -262,8 +243,7 @@ extension FeedManager {
         await loadFromDatabaseInBackground()
     }
 
-    /// Drains `feeds` through a task group capped at `maxConcurrent`
-    /// in-flight tasks, incrementing `refreshCompleted` as each finishes.
+    /// Drains `feeds` through a task group capped at `maxConcurrent`.
     fileprivate func runBoundedRefresh(
         _ feeds: [Feed],
         maxConcurrent: Int,
@@ -309,8 +289,7 @@ extension FeedManager {
         }
     }
 
-    /// Runs the Content-Insights NLP pass while mirroring progress onto
-    /// `nlpTotal` / `nlpCompleted` so the donut can cover 80–100%.
+    /// Runs the NLP pass while mirroring progress onto `nlpTotal` / `nlpCompleted`.
     fileprivate func processNewArticlesWithProgress() async {
         await NLPProcessingCoordinator.processNewArticlesIfEnabled(
             onBegin: { [weak self] total in

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+Refresh.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+Refresh.swift
@@ -181,10 +181,13 @@ extension FeedManager {
     /// always refresh.  `skipImageBackfill` disables the HTML metadata
     /// image lookup per article (cellular-safe background paths set
     /// this when the user has the Wi-Fi-only backfill preference on).
+    /// `runNLPAfter` chains a Content-Insights NLP pass onto the same
+    /// cancellable task so the progress donut spans both phases.
     func refreshAllFeeds(
         skipAuthenticatedScrapers: Bool = false,
         respectCooldown: Bool = false,
-        skipImageBackfill: Bool = false
+        skipImageBackfill: Bool = false,
+        runNLPAfter: Bool = false
     ) async {
         let cooldownSeconds: TimeInterval? = {
             guard respectCooldown else { return nil }
@@ -207,35 +210,91 @@ extension FeedManager {
             return true
         }
 
+        // Slow bucket (X, Instagram, YouTube playlists, Petal) is kicked
+        // off first with a tight concurrency cap so pagination-heavy
+        // scrapers start walking immediately.  Regular RSS feeds run in
+        // parallel on a separate group with higher concurrency; both
+        // buckets share the same `refreshCompleted` counter so the donut
+        // advances smoothly across them.
+        let slowFeeds = feedsToRefresh.filter { $0.isSlowRefreshFeed }
+        let regularFeeds = feedsToRefresh.filter { !$0.isSlowRefreshFeed }
+
         await MainActor.run {
             isLoading = true
             refreshCompleted = 0
             refreshTotal = feedsToRefresh.count
+            nlpCompleted = 0
+            nlpTotal = 0
         }
         defer {
             Task { @MainActor in
                 self.isLoading = false
                 self.refreshCompleted = 0
                 self.refreshTotal = 0
+                self.nlpCompleted = 0
+                self.nlpTotal = 0
                 self.refreshTask = nil
             }
         }
 
-        // Bounded concurrency so libraries with 100+ feeds don't spawn
-        // 100+ simultaneous URLSession tasks.  Empirically past ~8
-        // in-flight fetches end-to-end wall time stops improving on
-        // cellular and regresses on Wi-Fi due to contention with the
-        // main-actor reload work; 8 matches the parallelism already
-        // used by `backfillMetadataImages`.
-        let maxConcurrent = 8
+        // Empirically past ~8 in-flight regular fetches end-to-end wall
+        // time stops improving on cellular and regresses on Wi-Fi due to
+        // contention with the main-actor reload work.  Slow scrapers hit
+        // authenticated or rate-limited endpoints and benefit from a
+        // smaller cap so we don't thrash cookies or trip server pacing.
         let work = Task { [weak self] in
             guard let self else { return }
-            await withTaskGroup(of: Void.self) { group in
-                var submitted = 0
-                var iterator = feedsToRefresh.makeIterator()
-                while submitted < maxConcurrent, !Task.isCancelled, let feed = iterator.next() {
-                    group.addTask {
-                        guard !Task.isCancelled else { return }
+            async let slow: Void = self.runBoundedRefresh(
+                slowFeeds, maxConcurrent: 2, skipImageBackfill: skipImageBackfill
+            )
+            async let regular: Void = self.runBoundedRefresh(
+                regularFeeds, maxConcurrent: 8, skipImageBackfill: skipImageBackfill
+            )
+            _ = await (slow, regular)
+
+            if runNLPAfter, !Task.isCancelled,
+               !ProcessInfo.processInfo.isLowPowerModeEnabled {
+                await self.processNewArticlesWithProgress()
+            }
+        }
+        await MainActor.run { self.refreshTask = work }
+        _ = await work.value
+        await loadFromDatabaseInBackground()
+    }
+
+    /// Drains `feeds` through a task group capped at `maxConcurrent`
+    /// in-flight tasks, incrementing `refreshCompleted` as each finishes.
+    fileprivate func runBoundedRefresh(
+        _ feeds: [Feed],
+        maxConcurrent: Int,
+        skipImageBackfill: Bool
+    ) async {
+        guard !feeds.isEmpty else { return }
+        await withTaskGroup(of: Void.self) { group in
+            var submitted = 0
+            var iterator = feeds.makeIterator()
+            while submitted < maxConcurrent, !Task.isCancelled, let feed = iterator.next() {
+                group.addTask { [weak self] in
+                    guard let self, !Task.isCancelled else { return }
+                    try? await self.refreshFeed(
+                        feed,
+                        reloadData: false,
+                        skipImageBackfill: skipImageBackfill
+                    )
+                    if !Task.isCancelled {
+                        await MainActor.run { self.refreshCompleted += 1 }
+                    }
+                }
+                submitted += 1
+            }
+            while await group.next() != nil {
+                if Task.isCancelled {
+                    group.cancelAll()
+                    continue
+                }
+                if let feed = iterator.next() {
+                    group.addTask { [weak self] in
+                        guard let self, !Task.isCancelled else { return }
                         try? await self.refreshFeed(
                             feed,
                             reloadData: false,
@@ -245,32 +304,22 @@ extension FeedManager {
                             await MainActor.run { self.refreshCompleted += 1 }
                         }
                     }
-                    submitted += 1
-                }
-                while await group.next() != nil {
-                    if Task.isCancelled {
-                        group.cancelAll()
-                        continue
-                    }
-                    if let feed = iterator.next() {
-                        group.addTask {
-                            guard !Task.isCancelled else { return }
-                            try? await self.refreshFeed(
-                                feed,
-                                reloadData: false,
-                                skipImageBackfill: skipImageBackfill
-                            )
-                            if !Task.isCancelled {
-                                await MainActor.run { self.refreshCompleted += 1 }
-                            }
-                        }
-                    }
                 }
             }
         }
-        await MainActor.run { self.refreshTask = work }
-        _ = await work.value
-        await loadFromDatabaseInBackground()
+    }
+
+    /// Runs the Content-Insights NLP pass while mirroring progress onto
+    /// `nlpTotal` / `nlpCompleted` so the donut can cover 80–100%.
+    fileprivate func processNewArticlesWithProgress() async {
+        await NLPProcessingCoordinator.processNewArticlesIfEnabled(
+            onBegin: { [weak self] total in
+                await MainActor.run { self?.nlpTotal = total }
+            },
+            onProgress: { [weak self] in
+                await MainActor.run { self?.nlpCompleted += 1 }
+            }
+        )
     }
 
     /// Refreshes feeds that have never been fetched (e.g. added by the
@@ -365,6 +414,8 @@ extension FeedManager {
         isLoading = false
         refreshCompleted = 0
         refreshTotal = 0
+        nlpCompleted = 0
+        nlpTotal = 0
     }
 
 }

--- a/SakuraRSS/Classes/Feed Manager/FeedManager.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager.swift
@@ -13,9 +13,7 @@ final class FeedManager {
     var nlpTotal: Int = 0
     var nlpCompleted: Int = 0
 
-    /// Donut progress combining feed refresh (0–80%) and NLP processing
-    /// (80–100%).  When only one phase is active the other is treated as
-    /// neutral so the donut still advances monotonically.
+    /// Donut progress: feed refresh 0–80%, NLP processing 80–100%.
     var refreshProgress: Double {
         let hasRefresh = refreshTotal > 0
         let hasNLP = nlpTotal > 0

--- a/SakuraRSS/Classes/Feed Manager/FeedManager.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager.swift
@@ -10,9 +10,27 @@ final class FeedManager {
     var isLoading = false
     var refreshTotal: Int = 0
     var refreshCompleted: Int = 0
+    var nlpTotal: Int = 0
+    var nlpCompleted: Int = 0
+
+    /// Donut progress combining feed refresh (0–80%) and NLP processing
+    /// (80–100%).  When only one phase is active the other is treated as
+    /// neutral so the donut still advances monotonically.
     var refreshProgress: Double {
-        guard refreshTotal > 0 else { return 0 }
-        return min(max(Double(refreshCompleted) / Double(refreshTotal), 0), 1)
+        let hasRefresh = refreshTotal > 0
+        let hasNLP = nlpTotal > 0
+        guard hasRefresh || hasNLP else { return 0 }
+        let refreshFraction: Double = hasRefresh
+            ? Double(refreshCompleted) / Double(refreshTotal)
+            : 1.0
+        let nlpFraction: Double = hasNLP
+            ? Double(nlpCompleted) / Double(nlpTotal)
+            : 0.0
+        return min(max(refreshFraction * 0.8 + nlpFraction * 0.2, 0), 1)
+    }
+
+    var hasActiveRefreshProgress: Bool {
+        refreshTotal > 0 || nlpTotal > 0
     }
     private(set) var dataRevision: Int = 0
     private(set) var faviconRevision: Int = 0

--- a/SakuraRSS/Structs/NLPProcessingCoordinator.swift
+++ b/SakuraRSS/Structs/NLPProcessingCoordinator.swift
@@ -16,8 +16,8 @@ enum NLPProcessingCoordinator {
     /// Processes unprocessed articles if Content Insights is enabled.
     /// `onBegin` fires once with the total; `onProgress` fires per article.
     static func processNewArticlesIfEnabled(
-        onBegin: @Sendable (Int) async -> Void = { _ in },
-        onProgress: @Sendable () async -> Void = { }
+        onBegin: @escaping @Sendable (Int) async -> Void = { _ in },
+        onProgress: @escaping @Sendable () async -> Void = { }
     ) async {
         let defaults = UserDefaults.standard
         let contentInsightsEnabled = defaults.bool(forKey: "Intelligence.ContentInsights.Enabled")

--- a/SakuraRSS/Structs/NLPProcessingCoordinator.swift
+++ b/SakuraRSS/Structs/NLPProcessingCoordinator.swift
@@ -14,8 +14,14 @@ enum NLPProcessingCoordinator {
     nonisolated private static let chunkSize = 20
 
     /// Processes unprocessed articles if Content Insights is enabled.
-    /// Called after feed refresh completes.
-    static func processNewArticlesIfEnabled() async {
+    /// Called after feed refresh completes.  `onBegin` fires once with
+    /// the total article count (0 when nothing to do).  `onProgress`
+    /// fires after each article, including skipped ones, so callers can
+    /// drive a progress indicator that always reaches its total.
+    static func processNewArticlesIfEnabled(
+        onBegin: @Sendable (Int) async -> Void = { _ in },
+        onProgress: @Sendable () async -> Void = { }
+    ) async {
         let defaults = UserDefaults.standard
         let contentInsightsEnabled = defaults.bool(forKey: "Intelligence.ContentInsights.Enabled")
         guard contentInsightsEnabled else {
@@ -47,6 +53,8 @@ enum NLPProcessingCoordinator {
             logger.debug("processNewArticlesIfEnabled: \(toProcess.count) articles to process")
             #endif
 
+            await onBegin(toProcess.count)
+
             // Reuse a single sentiment tagger and a single name-type tagger
             // across every article in this pass.  NLTagger construction is
             // measurably expensive; setting `.string` on an existing tagger
@@ -56,14 +64,17 @@ enum NLPProcessingCoordinator {
 
             var processedSinceYield = 0
             for pending in toProcess {
-                guard let article = try? database.article(byID: pending.id) else { continue }
-                processArticleSync(
-                    article,
-                    sentimentTagger: pending.needsSentiment ? sentimentTagger : nil,
-                    nameTagger: pending.needsEntities ? nameTagger : nil,
-                    runSentiment: pending.needsSentiment,
-                    runEntities: pending.needsEntities
-                )
+                if Task.isCancelled { break }
+                if let article = try? database.article(byID: pending.id) {
+                    processArticleSync(
+                        article,
+                        sentimentTagger: pending.needsSentiment ? sentimentTagger : nil,
+                        nameTagger: pending.needsEntities ? nameTagger : nil,
+                        runSentiment: pending.needsSentiment,
+                        runEntities: pending.needsEntities
+                    )
+                }
+                await onProgress()
                 processedSinceYield += 1
                 if processedSinceYield >= chunkSize {
                     processedSinceYield = 0

--- a/SakuraRSS/Structs/NLPProcessingCoordinator.swift
+++ b/SakuraRSS/Structs/NLPProcessingCoordinator.swift
@@ -14,10 +14,7 @@ enum NLPProcessingCoordinator {
     nonisolated private static let chunkSize = 20
 
     /// Processes unprocessed articles if Content Insights is enabled.
-    /// Called after feed refresh completes.  `onBegin` fires once with
-    /// the total article count (0 when nothing to do).  `onProgress`
-    /// fires after each article, including skipped ones, so callers can
-    /// drive a progress indicator that always reaches its total.
+    /// `onBegin` fires once with the total; `onProgress` fires per article.
     static func processNewArticlesIfEnabled(
         onBegin: @Sendable (Int) async -> Void = { _ in },
         onProgress: @Sendable () async -> Void = { }

--- a/SakuraRSS/Views/App+BackgroundTasks.swift
+++ b/SakuraRSS/Views/App+BackgroundTasks.swift
@@ -62,9 +62,9 @@ extension SakuraRSSApp {
             await manager.refreshAllFeeds(
                 skipAuthenticatedScrapers: true,
                 respectCooldown: true,
-                skipImageBackfill: skipImageBackfill
+                skipImageBackfill: skipImageBackfill,
+                runNLPAfter: true
             )
-            await NLPProcessingCoordinator.processNewArticlesIfEnabled()
             manager.updateBadgeCount()
         }
 

--- a/SakuraRSS/Views/App.swift
+++ b/SakuraRSS/Views/App.swift
@@ -36,16 +36,14 @@ struct SakuraRSSApp: App {
                             group.addTask { await InstagramProfileScraper.migrateWebKitCookiesIfNeeded() }
                         }
                     }
-                    await feedManager.refreshAllFeeds(respectCooldown: true)
+                    await feedManager.refreshAllFeeds(
+                        respectCooldown: true,
+                        runNLPAfter: true
+                    )
                     UserDefaults.standard.set(false, forKey: "App.StartupInProgress")
                     feedManager.updateBadgeCount()
                     requestReviewIfNeeded()
                     reindexSpotlightIfSchemaChanged()
-                    if !ProcessInfo.processInfo.isLowPowerModeEnabled {
-                        Task.detached(priority: .utility) {
-                            await NLPProcessingCoordinator.processNewArticlesIfEnabled()
-                        }
-                    }
                 }
                 .onReceive(
                     NotificationCenter.default.publisher(for: UIApplication.willResignActiveNotification)

--- a/SakuraRSS/Views/Home/HomeView.swift
+++ b/SakuraRSS/Views/Home/HomeView.swift
@@ -52,7 +52,7 @@ struct HomeView: View {
                         }
                     }
                     ToolbarItemGroup(placement: .topBarLeading) {
-                        if feedManager.isLoading && feedManager.refreshTotal > 0 {
+                        if feedManager.isLoading && feedManager.hasActiveRefreshProgress {
                             FeedRefreshProgressDonut(
                                 progress: feedManager.refreshProgress,
                                 onStop: { feedManager.cancelRefresh() }


### PR DESCRIPTION
## Summary
This PR integrates NLP (Natural Language Processing) article processing into the feed refresh workflow and adds progress tracking for both refresh and NLP operations. The changes consolidate the separate refresh and NLP passes into a unified operation with a combined progress indicator.

## Key Changes

- **Unified refresh + NLP workflow**: Added `runNLPAfter` parameter to `refreshAllFeeds()` to optionally chain NLP processing after feed refresh completes, eliminating the need for separate detached tasks
- **Differential concurrency limits**: Separated feeds into "slow" (X, Instagram, YouTube playlists, Petal recipes) and "regular" categories with different concurrency limits (2 vs 8) to optimize performance
- **Progress tracking**: Added `nlpTotal` and `nlpCompleted` properties to track NLP progress separately from refresh progress
- **Combined progress indicator**: Updated `refreshProgress` to blend refresh (0–80%) and NLP (80–100%) progress into a single donut chart metric
- **NLP callback support**: Modified `NLPProcessingCoordinator.processNewArticlesIfEnabled()` to accept optional `onBegin` and `onProgress` callbacks for real-time progress updates
- **Refactored refresh logic**: Extracted bounded concurrency task group logic into `runBoundedRefresh()` helper method for reusability
- **Low power mode check**: Moved low power mode check into the refresh flow to prevent NLP processing when battery saver is enabled
- **Updated call sites**: Modified app startup and background task refresh calls to use `runNLPAfter: true`, removing separate NLP task scheduling

## Implementation Details

- The `runBoundedRefresh()` method maintains a sliding window of concurrent tasks, submitting new work as tasks complete
- Progress callbacks fire on the main actor to safely update UI state
- Task cancellation is checked throughout to allow graceful interruption
- The combined progress metric weights refresh at 80% and NLP at 20% to reflect typical operation time distribution

https://claude.ai/code/session_01AFPW5eyBTtTCEPXHLoTvzD