### PR TITLE
Fix mark-read-on-scroll freeze and animate refresh updates

### DIFF
--- a/SakuraRSS/Classes/Feed Manager/FeedManager+InstagramProfile.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+InstagramProfile.swift
@@ -75,7 +75,7 @@ extension FeedManager {
         )
 
         if reloadData {
-            await loadFromDatabaseInBackground()
+            await loadFromDatabaseInBackground(animated: true)
         }
     }
 

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+PendingReads.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+PendingReads.swift
@@ -29,15 +29,7 @@ extension FeedManager {
             decrements[newArticles[idx].feedID, default: 0] += 1
         }
         articles = newArticles
-
-        if !decrements.isEmpty {
-            var newUnreadCounts = unreadCounts
-            for (feedID, delta) in decrements {
-                guard let current = newUnreadCounts[feedID], current > 0 else { continue }
-                newUnreadCounts[feedID] = max(0, current - delta)
-            }
-            unreadCounts = newUnreadCounts
-        }
+        applyUnreadDecrements(decrements)
         updateBadgeCount()
 
         let idArray = Array(ids)

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+PendingReads.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+PendingReads.swift
@@ -18,11 +18,25 @@ extension FeedManager {
         let ids = pendingReadIDs
         pendingReadIDs.removeAll()
 
-        let indexByID = Dictionary(uniqueKeysWithValues: articles.enumerated().map { ($1.id, $0) })
+        // Collapse per-row observable writes into one notification per
+        // property so badge observers don't get invalidated N times.
+        var newArticles = articles
+        var decrements: [Int64: Int] = [:]
+        let indexByID = Dictionary(uniqueKeysWithValues: newArticles.enumerated().map { ($1.id, $0) })
         for id in ids {
-            guard let idx = indexByID[id], !articles[idx].isRead else { continue }
-            articles[idx].isRead = true
-            decrementUnreadCount(feedID: articles[idx].feedID)
+            guard let idx = indexByID[id], !newArticles[idx].isRead else { continue }
+            newArticles[idx].isRead = true
+            decrements[newArticles[idx].feedID, default: 0] += 1
+        }
+        articles = newArticles
+
+        if !decrements.isEmpty {
+            var newUnreadCounts = unreadCounts
+            for (feedID, delta) in decrements {
+                guard let current = newUnreadCounts[feedID], current > 0 else { continue }
+                newUnreadCounts[feedID] = max(0, current - delta)
+            }
+            unreadCounts = newUnreadCounts
         }
         updateBadgeCount()
 

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+Petal.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+Petal.swift
@@ -83,7 +83,7 @@ extension FeedManager {
         let parsed = await PetalEngine.fetchArticles(for: recipe)
         guard !parsed.isEmpty else {
             try? database.updateFeedLastFetched(id: feed.id, date: Date())
-            if reloadData { await loadFromDatabaseInBackground() }
+            if reloadData { await loadFromDatabaseInBackground(animated: true) }
             return
         }
 
@@ -110,7 +110,7 @@ extension FeedManager {
         }.value
 
         if reloadData {
-            await loadFromDatabaseInBackground()
+            await loadFromDatabaseInBackground(animated: true)
         }
     }
 }

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+Refresh.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+Refresh.swift
@@ -106,7 +106,7 @@ extension FeedManager {
             try database.updateFeedLastFetched(id: feed.id, date: Date())
         }.value
         if reloadData {
-            await loadFromDatabaseInBackground()
+            await loadFromDatabaseInBackground(animated: true)
         }
     }
 
@@ -268,7 +268,7 @@ extension FeedManager {
         }
         await MainActor.run { self.refreshTask = work }
         _ = await work.value
-        await loadFromDatabaseInBackground()
+        await loadFromDatabaseInBackground(animated: true)
 
         if let imagePreloadCollector, !Task.isCancelled {
             let urls = await imagePreloadCollector.drain()
@@ -366,7 +366,7 @@ extension FeedManager {
                 }
             }
         }
-        await loadFromDatabaseInBackground()
+        await loadFromDatabaseInBackground(animated: true)
     }
 
     func refreshAllFeedsAndFavicons() async {
@@ -424,7 +424,7 @@ extension FeedManager {
         }
         await MainActor.run { self.refreshTask = work }
         _ = await work.value
-        await loadFromDatabaseInBackground()
+        await loadFromDatabaseInBackground(animated: true)
         regenerateAllAcronymIcons()
         notifyFaviconChange()
     }

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+XProfile.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+XProfile.swift
@@ -67,7 +67,7 @@ extension FeedManager {
         )
 
         if reloadData {
-            await loadFromDatabaseInBackground()
+            await loadFromDatabaseInBackground(animated: true)
         }
     }
 

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+YouTubePlaylist.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+YouTubePlaylist.swift
@@ -63,7 +63,7 @@ extension FeedManager {
         )
 
         if reloadData {
-            await loadFromDatabaseInBackground()
+            await loadFromDatabaseInBackground(animated: true)
         }
     }
 

--- a/SakuraRSS/Classes/Feed Manager/FeedManager.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager.swift
@@ -102,6 +102,18 @@ final class FeedManager {
         }
     }
 
+    /// Applies per-feed decrement deltas in a single mutation so observers
+    /// only receive one notification for the batch.
+    func applyUnreadDecrements(_ decrements: [Int64: Int]) {
+        guard !decrements.isEmpty else { return }
+        var newCounts = unreadCounts
+        for (feedID, delta) in decrements {
+            guard let current = newCounts[feedID], current > 0 else { continue }
+            newCounts[feedID] = max(0, current - delta)
+        }
+        unreadCounts = newCounts
+    }
+
     func bumpDataRevision() {
         dataRevision += 1
     }

--- a/SakuraRSS/Classes/Feed Manager/FeedManager.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager.swift
@@ -61,7 +61,7 @@ final class FeedManager {
         }
     }
 
-    func loadFromDatabaseInBackground() async {
+    func loadFromDatabaseInBackground(animated: Bool = false) async {
         let dbm = database
         do {
             let (loadedFeeds, loadedArticles, loadedUnreadCounts, loadedLists) = try await Task.detached {
@@ -72,12 +72,19 @@ final class FeedManager {
                 return (feeds, articles, unreadCounts, lists)
             }.value
             await MainActor.run {
-                self.feeds = loadedFeeds
-                self.feedsByID = Dictionary(uniqueKeysWithValues: loadedFeeds.map { ($0.id, $0) })
-                self.articles = loadedArticles
-                self.unreadCounts = loadedUnreadCounts
-                self.lists = loadedLists
-                self.dataRevision += 1
+                let apply = {
+                    self.feeds = loadedFeeds
+                    self.feedsByID = Dictionary(uniqueKeysWithValues: loadedFeeds.map { ($0.id, $0) })
+                    self.articles = loadedArticles
+                    self.unreadCounts = loadedUnreadCounts
+                    self.lists = loadedLists
+                    self.dataRevision += 1
+                }
+                if animated {
+                    withAnimation(.smooth.speed(2.0)) { apply() }
+                } else {
+                    apply()
+                }
             }
         } catch {
             print("Failed to load from database: \(error)")


### PR DESCRIPTION
## Summary

- **Fix mark-read-on-scroll freeze.** `flushDebouncedReads` mutated `articles[idx].isRead` and `unreadCounts[feedID]` through the `@Observable` subscripts inside a loop. Every iteration copied the 200-element array and re-invalidated every `unreadCount(...)` observer (sidebar rows, tab badge, feed cells), producing a visible hitch when a scroll batch landed. The flush now accumulates into local copies and assigns each observable property exactly once, so the whole batch fires a single notification per property.
- **Animate refresh content updates.** Add an `animated: Bool = false` flag to `loadFromDatabaseInBackground` that wraps the main-actor assignment in `withAnimation(.smooth.speed(2.0))`. Every refresh path (single-feed, all-feeds, favicons, unfetched, YouTube playlist, X, Instagram, Petal) now opts in, so pulled-to-refresh content fades in smoothly. App launch, foreground rehydrate, and delete paths keep the existing instant behavior via the default.

## Test plan

- [ ] Enable scroll-mark-as-read, scroll through a long article list, and confirm the previously visible hitch at ~400 ms after scrolling stops is gone.
- [ ] Verify sidebar feed badges and the tab badge update to match the new read state after a scroll batch.
- [ ] Pull to refresh on the All Articles view — new articles should animate in using `.smooth.speed(2.0)` rather than popping.
- [ ] Pull to refresh on a single feed, a YouTube playlist feed, an X feed, an Instagram feed, and a Petal feed — animation should apply in each.
- [ ] Cold-launch the app and confirm the initial list still renders without an unwanted animation.
