### PR TITLE
Fix MainActor isolation in background task handlers

### DIFF
--- a/SakuraRSS/Views/App+BackgroundTasks.swift
+++ b/SakuraRSS/Views/App+BackgroundTasks.swift
@@ -4,19 +4,25 @@ import UIKit
 extension SakuraRSSApp {
 
     func registerBackgroundTask() {
+        // Launch handlers run on BGTaskScheduler's queue; hop to the MainActor
+        // before touching `SakuraRSSApp`'s MainActor-isolated state.
         BGTaskScheduler.shared.register(
             forTaskWithIdentifier: backgroundTaskID,
             using: nil
         ) { task in
             guard let task = task as? BGAppRefreshTask else { return }
-            self.handleAppRefresh(task: task)
+            Task { @MainActor in
+                self.handleAppRefresh(task: task)
+            }
         }
         BGTaskScheduler.shared.register(
             forTaskWithIdentifier: iCloudBackupTaskID,
             using: nil
         ) { task in
             guard let task = task as? BGProcessingTask else { return }
-            self.handleiCloudBackup(task: task)
+            Task { @MainActor in
+                self.handleiCloudBackup(task: task)
+            }
         }
         scheduleAppRefresh()
         scheduleiCloudBackup()


### PR DESCRIPTION
## Summary
Fixed MainActor isolation violations in background task handlers by explicitly hopping to the MainActor before accessing `SakuraRSSApp`'s MainActor-isolated state.

## Key Changes
- Wrapped `handleAppRefresh(task:)` call in a `Task { @MainActor in }` block to ensure it runs on the main thread
- Wrapped `handleiCloudBackup(task:)` call in a `Task { @MainActor in }` block to ensure it runs on the main thread
- Added clarifying comments explaining that BGTaskScheduler handlers run on a background queue and require explicit MainActor hopping

## Implementation Details
Background task handlers registered with `BGTaskScheduler` execute on the scheduler's internal queue, not the main thread. Since `SakuraRSSApp` is a MainActor-isolated type, any access to its state from these handlers requires explicit MainActor context. The fix uses Swift's structured concurrency to safely transition from the background queue to the MainActor before calling the handler methods.

https://claude.ai/code/session_01LRebek2wEyQoMqa3Y4oT1d