### PR TITLE
Add note.com integration with profile photo fetching

### DIFF
--- a/Feeds/Favicon Cache/FaviconCache+Profiles.swift
+++ b/Feeds/Favicon Cache/FaviconCache+Profiles.swift
@@ -9,6 +9,7 @@ extension FaviconCache {
         if host.contains("youtube.com") || host.contains("youtu.be") { return true }
         if host == "bsky.app" || host.hasSuffix(".bsky.app") { return true }
         if host == "reddit.com" || host.hasSuffix(".reddit.com") { return true }
+        if host == "note.com" || host.hasSuffix(".note.com") { return true }
         if DisplayStyleFeedDomains.shouldPreferFeedView(feedDomain: host) { return true }
         return false
     }
@@ -56,6 +57,20 @@ extension FaviconCache {
         return UIImage(data: data)
     }
 
+    /// Fetches a note.com creator's profile photo via the public v2
+    /// creators API. note.com doesn't expose a usable og:image on the
+    /// profile page, so we pull it from `/api/v2/creators/<urlname>`.
+    nonisolated func fetchNoteProfileAvatar(handle: String) async -> UIImage? {
+        let scraper = NoteProfileScraper()
+        let result = await scraper.scrapeProfile(handle: handle)
+        guard let imageURLString = result.profileImageURL,
+              let imageURL = URL(string: imageURLString),
+              let (data, _) = try? await Self.urlSession.data(from: imageURL) else {
+            return nil
+        }
+        return UIImage(data: data)
+    }
+
     /// Fetches a subreddit's community icon via the Reddit Community Scraper.
     /// Reddit doesn't expose the styled community icon through og:image,
     /// so we pull it from `/r/<name>/about.json`.
@@ -78,6 +93,10 @@ extension FaviconCache {
         if RedditCommunityScraper.isRedditSubredditURL(url),
            let subreddit = RedditCommunityScraper.extractSubredditName(from: url) {
             return await fetchRedditCommunityIcon(subreddit: subreddit)
+        }
+        if NoteProfileScraper.isNoteProfileURL(url),
+           let handle = NoteProfileScraper.extractHandle(from: url) {
+            return await fetchNoteProfileAvatar(handle: handle)
         }
         do {
             let (data, _) = try await Self.urlSession.data(from: url)

--- a/Feeds/Feed Discovery/FeedDiscovery+SocialMedia.swift
+++ b/Feeds/Feed Discovery/FeedDiscovery+SocialMedia.swift
@@ -30,6 +30,9 @@ extension FeedDiscovery {
         if let mastodonFeed = await detectMastodonFeed(url: url) {
             return mastodonFeed
         }
+        if let noteFeed = await detectNoteFeed(url: url) {
+            return noteFeed
+        }
         return nil
     }
 
@@ -213,6 +216,16 @@ extension FeedDiscovery {
               !handle.isEmpty else { return nil }
 
         return await probeFeedAt(domain: "bsky.app", path: "/profile/\(handle)/rss")
+    }
+
+    /// Detects note.com creator profile URLs and constructs the RSS feed URL.
+    /// Format: note.com/<urlname> → note.com/<urlname>/rss
+    func detectNoteFeed(url: URL) async -> DiscoveredFeed? {
+        guard NoteProfileScraper.isNoteProfileURL(url),
+              let handle = NoteProfileScraper.extractHandle(from: url) else {
+            return nil
+        }
+        return await probeFeedAt(domain: "note.com", path: "/\(handle)/rss")
     }
 
     /// Detects Mastodon profile URLs and constructs the RSS feed URL.

--- a/Feeds/Feed.swift
+++ b/Feeds/Feed.swift
@@ -56,6 +56,11 @@ nonisolated struct Feed: Identifiable, Hashable, Sendable {
         return host == "reddit.com" || host.hasSuffix(".reddit.com")
     }
 
+    var isNoteFeed: Bool {
+        let host = domain.lowercased()
+        return host == "note.com" || host.hasSuffix(".note.com")
+    }
+
     var isCircleIcon: Bool {
         FaviconCircularDomains.shouldUseCircleIcon(feedDomain: domain)
     }
@@ -65,7 +70,8 @@ nonisolated struct Feed: Identifiable, Hashable, Sendable {
     }
 
     var isSocialFeed: Bool {
-        isXFeed || isInstagramFeed || isRedditFeed || isFeedViewDomain || isPhotoViewDomain
+        isXFeed || isInstagramFeed || isRedditFeed || isNoteFeed
+            || isFeedViewDomain || isPhotoViewDomain
     }
 
     /// Feeds whose refresh path walks pages or runs a custom recipe.

--- a/Integrations/Note/NoteProfileScraper+Fetching.swift
+++ b/Integrations/Note/NoteProfileScraper+Fetching.swift
@@ -20,10 +20,8 @@ extension NoteProfileScraper {
 
             let payload = (root["data"] as? [String: Any]) ?? root
 
-            let imageURL = (payload["user_profile_image_path"] as? String)
-                ?? (payload["userProfileImagePath"] as? String)
-            let displayName = (payload["nickname"] as? String)
-                ?? (payload["name"] as? String)
+            let imageURL = payload["profileImageUrl"] as? String
+            let displayName = payload["nickname"] as? String
 
             let cleanedImage = imageURL.flatMap { $0.isEmpty ? nil : $0 }
             let cleanedName = displayName.flatMap { $0.isEmpty ? nil : $0 }

--- a/Integrations/Note/NoteProfileScraper+Fetching.swift
+++ b/Integrations/Note/NoteProfileScraper+Fetching.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+extension NoteProfileScraper {
+
+    /// Calls the v2 creators API and extracts the profile photo URL and
+    /// display name. Returns an empty result on any failure; the favicon
+    /// lookup path treats this as a miss and falls back to the generic
+    /// favicon fetch.
+    func performFetch(url: URL) async -> NoteProfileScrapeResult {
+        var request = URLRequest(url: url)
+        request.setValue(sakuraUserAgent, forHTTPHeaderField: "User-Agent")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        let empty = NoteProfileScrapeResult(profileImageURL: nil, displayName: nil)
+
+        do {
+            let (data, _) = try await URLSession.shared.data(for: request)
+            guard let root = try JSONSerialization.jsonObject(with: data)
+                    as? [String: Any] else { return empty }
+
+            let payload = (root["data"] as? [String: Any]) ?? root
+
+            let imageURL = (payload["user_profile_image_path"] as? String)
+                ?? (payload["userProfileImagePath"] as? String)
+            let displayName = (payload["nickname"] as? String)
+                ?? (payload["name"] as? String)
+
+            let cleanedImage = imageURL.flatMap { $0.isEmpty ? nil : $0 }
+            let cleanedName = displayName.flatMap { $0.isEmpty ? nil : $0 }
+
+            return NoteProfileScrapeResult(
+                profileImageURL: cleanedImage,
+                displayName: cleanedName
+            )
+        } catch {
+            print("[NoteProfile] Fetch failed - \(error.localizedDescription)")
+            return empty
+        }
+    }
+}

--- a/Integrations/Note/NoteProfileScraper.swift
+++ b/Integrations/Note/NoteProfileScraper.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+/// Result of scraping a note.com creator via the public `/api/v2/creators`
+/// endpoint.
+struct NoteProfileScrapeResult: Sendable {
+    let profileImageURL: String?
+    let displayName: String?
+}
+
+/// Fetches note.com creator metadata (profile photo, display name) from the
+/// public v2 creators API. No login required.
+final class NoteProfileScraper {
+
+    /// Path segments that live under `note.com` but are not creator handles.
+    static let reservedHandles: Set<String> = [
+        "api", "search", "magazine", "magazines", "circle", "login", "signup",
+        "hashtag", "topic", "topics", "notifications", "settings", "m", "info",
+        "help", "contest", "timeline", "notes", "n"
+    ]
+
+    // MARK: - Static Helpers
+
+    /// Returns true if the URL points to a note.com creator profile page
+    /// (e.g. `https://note.com/<urlname>`). Excludes RSS and article URLs.
+    nonisolated static func isNoteProfileURL(_ url: URL) -> Bool {
+        guard isNoteHost(url.host) else { return false }
+        let components = url.pathComponents.filter { $0 != "/" }
+        guard components.count == 1 else { return false }
+        return isValidHandle(components[0])
+    }
+
+    /// Returns true if the feed URL points at note.com's `/rss` endpoint.
+    nonisolated static func isNoteFeedURL(_ urlString: String) -> Bool {
+        guard let url = URL(string: urlString) else { return false }
+        guard isNoteHost(url.host) else { return false }
+        let components = url.pathComponents.filter { $0 != "/" }
+        guard components.count == 2,
+              components.last?.lowercased() == "rss" else { return false }
+        return isValidHandle(components[0])
+    }
+
+    /// Extracts the creator's urlname from any note.com URL (profile, RSS,
+    /// article, etc.).
+    nonisolated static func extractHandle(from url: URL) -> String? {
+        guard isNoteHost(url.host) else { return nil }
+        let components = url.pathComponents.filter { $0 != "/" }
+        guard let first = components.first else { return nil }
+        return isValidHandle(first) ? first : nil
+    }
+
+    /// Constructs the canonical RSS feed URL for a creator.
+    nonisolated static func feedURL(for handle: String) -> String {
+        "https://note.com/\(handle)/rss"
+    }
+
+    /// Constructs the public profile URL for a creator.
+    nonisolated static func profileURL(for handle: String) -> URL? {
+        URL(string: "https://note.com/\(handle)")
+    }
+
+    /// Constructs the v2 creators API URL used to fetch metadata.
+    nonisolated static func creatorAPIURL(for handle: String) -> URL? {
+        URL(string: "https://note.com/api/v2/creators/\(handle)")
+    }
+
+    private nonisolated static func isNoteHost(_ host: String?) -> Bool {
+        guard let host = host?.lowercased() else { return false }
+        return host == "note.com" || host == "www.note.com"
+    }
+
+    private nonisolated static func isValidHandle(_ handle: String) -> Bool {
+        guard !handle.isEmpty else { return false }
+        return !reservedHandles.contains(handle.lowercased())
+    }
+
+    // MARK: - Public
+
+    /// Fetches metadata for the given creator handle.
+    func scrapeProfile(handle: String) async -> NoteProfileScrapeResult {
+        guard let url = Self.creatorAPIURL(for: handle) else {
+            return NoteProfileScrapeResult(profileImageURL: nil, displayName: nil)
+        }
+        return await performFetch(url: url)
+    }
+}

--- a/Integrations/Note/NoteProfileScraper.swift
+++ b/Integrations/Note/NoteProfileScraper.swift
@@ -12,7 +12,7 @@ struct NoteProfileScrapeResult: Sendable {
 final class NoteProfileScraper {
 
     /// Path segments that live under `note.com` but are not creator handles.
-    static let reservedHandles: Set<String> = [
+    nonisolated static let reservedHandles: Set<String> = [
         "api", "search", "magazine", "magazines", "circle", "login", "signup",
         "hashtag", "topic", "topics", "notifications", "settings", "m", "info",
         "help", "contest", "timeline", "notes", "n"

--- a/Shared/Domain Options/Favicons/FaviconCircularDomains.swift
+++ b/Shared/Domain Options/Favicons/FaviconCircularDomains.swift
@@ -15,7 +15,9 @@ nonisolated enum FaviconCircularDomains {
         "pixelfed.tokyo",
         // YouTube
         "youtube.com",
-        "youtu.be"
+        "youtu.be",
+        // note
+        "note.com"
     ]
 
     static func shouldUseCircleIcon(feedDomain: String) -> Bool {


### PR DESCRIPTION
## Summary
- Adds note.com to the social feed section via a new `isNoteFeed` check on `Feed` and inclusion in `isSocialFeed`.
- Adds a lightweight `NoteProfileScraper` that calls note.com's public v2 creators API (`/api/v2/creators/<urlname>`) and returns the profile photo URL + display name.
- Routes favicon lookups for note.com domains through the new scraper from `FaviconCache+Profiles`, treating note.com as a profile-based domain and displaying icons as circles.
- Teaches `FeedDiscovery` to rewrite `https://note.com/<urlname>` profile URLs to the canonical `https://note.com/<urlname>/rss` feed so the Add Feed action picks them up.

## Test plan
- [ ] Share a note.com creator URL (e.g. `https://note.com/<urlname>`) via the Add Feed extension and confirm the RSS feed is discovered.
- [ ] Refresh a note.com feed and confirm it appears under the Social section.
- [ ] Confirm the feed favicon displays the creator's circular profile photo.
- [ ] Verify the other social integrations (X, Instagram, Reddit, Mastodon, Bluesky, YouTube) still discover and display correctly.

https://claude.ai/code/session_013TeBo448pNCoWThy9Korb8