### PR TITLE
Stage read articles until refresh or explicit hide

### DIFF
--- a/SakuraRSS/Classes/Feed Manager/FeedManager+InstagramProfile.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+InstagramProfile.swift
@@ -76,6 +76,7 @@ extension FeedManager {
 
         if reloadData {
             await loadFromDatabaseInBackground(animated: true)
+            await MainActor.run { self.bumpRefreshRevision() }
         }
     }
 

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+Petal.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+Petal.swift
@@ -83,7 +83,10 @@ extension FeedManager {
         let parsed = await PetalEngine.fetchArticles(for: recipe)
         guard !parsed.isEmpty else {
             try? database.updateFeedLastFetched(id: feed.id, date: Date())
-            if reloadData { await loadFromDatabaseInBackground(animated: true) }
+            if reloadData {
+                await loadFromDatabaseInBackground(animated: true)
+                await MainActor.run { self.bumpRefreshRevision() }
+            }
             return
         }
 
@@ -111,6 +114,7 @@ extension FeedManager {
 
         if reloadData {
             await loadFromDatabaseInBackground(animated: true)
+            await MainActor.run { self.bumpRefreshRevision() }
         }
     }
 }

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+Refresh.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+Refresh.swift
@@ -107,6 +107,7 @@ extension FeedManager {
         }.value
         if reloadData {
             await loadFromDatabaseInBackground(animated: true)
+            await MainActor.run { self.bumpRefreshRevision() }
         }
     }
 
@@ -271,6 +272,7 @@ extension FeedManager {
         await MainActor.run { self.refreshTask = work }
         _ = await work.value
         await loadFromDatabaseInBackground(animated: true)
+        await MainActor.run { self.bumpRefreshRevision() }
 
         if let imagePreloadCollector, !Task.isCancelled {
             let urls = await imagePreloadCollector.drain()
@@ -427,6 +429,7 @@ extension FeedManager {
         await MainActor.run { self.refreshTask = work }
         _ = await work.value
         await loadFromDatabaseInBackground(animated: true)
+        await MainActor.run { self.bumpRefreshRevision() }
         regenerateAllAcronymIcons()
         notifyFaviconChange()
     }

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+XProfile.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+XProfile.swift
@@ -68,6 +68,7 @@ extension FeedManager {
 
         if reloadData {
             await loadFromDatabaseInBackground(animated: true)
+            await MainActor.run { self.bumpRefreshRevision() }
         }
     }
 

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+YouTubePlaylist.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+YouTubePlaylist.swift
@@ -64,6 +64,7 @@ extension FeedManager {
 
         if reloadData {
             await loadFromDatabaseInBackground(animated: true)
+            await MainActor.run { self.bumpRefreshRevision() }
         }
     }
 

--- a/SakuraRSS/Classes/Feed Manager/FeedManager.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager.swift
@@ -32,6 +32,9 @@ final class FeedManager {
     }
     private(set) var dataRevision: Int = 0
     private(set) var faviconRevision: Int = 0
+    /// Bumped when any feed refresh completes so views can flush any
+    /// staged UI state (e.g. the mark-as-read staging buffer) on refresh.
+    private(set) var refreshRevision: Int = 0
     private(set) var unreadCounts: [Int64: Int] = [:]
     private(set) var feedsByID: [Int64: Feed] = [:]
 
@@ -116,6 +119,10 @@ final class FeedManager {
 
     func bumpDataRevision() {
         dataRevision += 1
+    }
+
+    func bumpRefreshRevision() {
+        refreshRevision += 1
     }
 
 }

--- a/SakuraRSS/Views/Shared/Article Detail/XEmbedBlockView.swift
+++ b/SakuraRSS/Views/Shared/Article Detail/XEmbedBlockView.swift
@@ -9,7 +9,6 @@ struct XEmbedBlockView: View {
 
     let url: URL
 
-    @Environment(\.openURL) private var openURL
     @State private var tweet: ParsedTweet?
     @State private var isLoading = false
     @State private var loadFailed = false
@@ -19,20 +18,19 @@ struct XEmbedBlockView: View {
     }
 
     var body: some View {
-        Button {
-            openURL(url)
-        } label: {
-            content
-                .padding(12)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 12)
-                        .strokeBorder(.secondary.opacity(0.2), lineWidth: 1)
-                )
-        }
-        .buttonStyle(.plain)
-        .task { await loadTweet() }
+        content
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .strokeBorder(.secondary.opacity(0.2), lineWidth: 1)
+            )
+            .contentShape(.rect(cornerRadius: 12))
+            .onTapGesture {
+                UIApplication.shared.open(url)
+            }
+            .task { await loadTweet() }
     }
 
     @ViewBuilder
@@ -86,9 +84,6 @@ struct XEmbedBlockView: View {
     @ViewBuilder
     private var header: some View {
         HStack(spacing: 6) {
-            Image(systemName: "bird")
-                .font(.caption.bold())
-                .foregroundStyle(.secondary)
             if let tweet {
                 Text(tweet.author)
                     .font(.caption.bold())

--- a/SakuraRSS/Views/Shared/Articles/ArticlesView.swift
+++ b/SakuraRSS/Views/Shared/Articles/ArticlesView.swift
@@ -101,6 +101,10 @@ struct ArticlesView: View {
         return style == .inbox || style == .magazine || style == .compact
     }
 
+    private var hasHiddenReadArticles: Bool {
+        articles.contains { $0.isRead && !stagedReadIDs.contains($0.id) }
+    }
+
     private var visibleArticles: [Article] {
         guard stagingSupported else { return articles }
         return articles.filter { !$0.isRead || stagedReadIDs.contains($0.id) }
@@ -178,6 +182,16 @@ struct ArticlesView: View {
                                 )
                             }
                             .disabled(stagedReadIDs.isEmpty)
+
+                            Button {
+                                showViewedContent()
+                            } label: {
+                                Label(
+                                    String(localized: "ShowViewedContent", table: "Articles"),
+                                    systemImage: "eye"
+                                )
+                            }
+                            .disabled(!hasHiddenReadArticles)
                         }
                     }
                 } label: {
@@ -263,6 +277,12 @@ struct ArticlesView: View {
     private func hideViewedContent() {
         withAnimation(.smooth.speed(2.0)) {
             stagedReadIDs.removeAll()
+        }
+    }
+
+    private func showViewedContent() {
+        withAnimation(.smooth.speed(2.0)) {
+            stagedReadIDs = Set(articles.filter { $0.isRead }.map(\.id))
         }
     }
 

--- a/SakuraRSS/Views/Shared/Articles/ArticlesView.swift
+++ b/SakuraRSS/Views/Shared/Articles/ArticlesView.swift
@@ -35,8 +35,8 @@ struct ArticlesView: View {
     @Environment(\.hidesMarkAllReadToolbar) private var hidesMarkAllReadToolbar
     @State private var displayStyle: FeedDisplayStyle
     @State private var isShowingMarkAllReadConfirmation = false
-    @AppStorage("Articles.HideRead") private var hideRead = false
-    @AppStorage("Display.ScrollMarkAsRead") private var scrollMarkAsRead: Bool = false
+    @State private var stagedReadIDs: Set<Int64> = []
+    @State private var didStageInitial = false
     @AppStorage("Display.MarkAllReadPosition") private var markAllReadPosition: MarkAllReadPosition = .bottom
     private let viewStyleSwitcherTip = ViewStyleSwitcherTip()
 
@@ -96,20 +96,14 @@ struct ArticlesView: View {
         self._displayStyle = State(initialValue: raw.flatMap(FeedDisplayStyle.init(rawValue:)) ?? fallback)
     }
 
-    private var hideReadSupported: Bool {
-        // Hiding read items conflicts with mark-as-read-on-scroll: rows would
-        // disappear as they pass the viewport edge and yank the scroll
-        // position. Force the toggle off while that setting is enabled.
-        guard !scrollMarkAsRead else { return false }
+    private var stagingSupported: Bool {
         let style = effectiveDisplayStyle
         return style == .inbox || style == .magazine || style == .compact
     }
 
     private var visibleArticles: [Article] {
-        if hideRead && hideReadSupported {
-            return articles.filter { !$0.isRead }
-        }
-        return articles
+        guard stagingSupported else { return articles }
+        return articles.filter { !$0.isRead || stagedReadIDs.contains($0.id) }
     }
 
     var body: some View {
@@ -173,9 +167,17 @@ struct ArticlesView: View {
                         showVideo: isVideoFeed,
                         showPodcast: isPodcastFeed || hasAudioArticles
                     )
-                    if hideReadSupported {
+                    if stagingSupported {
                         Section {
-                            Toggle(String(localized: "HideRead", table: "Articles"), isOn: $hideRead)
+                            Button {
+                                hideViewedContent()
+                            } label: {
+                                Label(
+                                    String(localized: "HideViewedContent", table: "Articles"),
+                                    systemImage: "eye.slash"
+                                )
+                            }
+                            .disabled(stagedReadIDs.isEmpty)
                         }
                     }
                 } label: {
@@ -186,7 +188,31 @@ struct ArticlesView: View {
             }
         }
         .animation(.smooth.speed(2.0), value: displayStyle)
-        .animation(.smooth.speed(2.0), value: hideRead)
+        .animation(.smooth.speed(2.0), value: stagedReadIDs)
+        .onAppear {
+            if !didStageInitial {
+                stagedReadIDs = Set(articles.filter { $0.isRead }.map(\.id))
+                didStageInitial = true
+            }
+        }
+        .onChange(of: articles) { oldValue, newValue in
+            // Stage any articles whose read state flipped while the view was
+            // mounted so they don't vanish from under the user's finger.
+            let previouslyRead = Set(oldValue.filter { $0.isRead }.map(\.id))
+            let currentlyRead = Set(newValue.filter { $0.isRead }.map(\.id))
+            let newlyRead = currentlyRead.subtracting(previouslyRead)
+            if !newlyRead.isEmpty {
+                stagedReadIDs.formUnion(newlyRead)
+            }
+            // Drop staged IDs that have been removed from the article list.
+            let currentIDs = Set(newValue.map(\.id))
+            stagedReadIDs.formIntersection(currentIDs)
+        }
+        .onChange(of: feedManager.refreshRevision) { _, _ in
+            withAnimation(.smooth.speed(2.0)) {
+                stagedReadIDs.removeAll()
+            }
+        }
         .onChange(of: displayStyle) { _, newValue in
             UserDefaults.standard.set(newValue.rawValue, forKey: "Display.Style.\(feedKey)")
         }
@@ -222,7 +248,7 @@ struct ArticlesView: View {
                     } description: {
                         Text(String(localized: "Empty.Description", table: "Articles"))
                     }
-                } else if visibleArticles.isEmpty && hideRead {
+                } else if visibleArticles.isEmpty && stagingSupported {
                     ContentUnavailableView {
                         Label(String(localized: "AllRead.Title", table: "Articles"),
                               systemImage: "checkmark.circle")
@@ -231,6 +257,12 @@ struct ArticlesView: View {
                     }
                 }
             }
+        }
+    }
+
+    private func hideViewedContent() {
+        withAnimation(.smooth.speed(2.0)) {
+            stagedReadIDs.removeAll()
         }
     }
 

--- a/SakuraRSS/Views/Shared/Feed Display Styles/Compact/CompactStyleView.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/Compact/CompactStyleView.swift
@@ -50,6 +50,16 @@ struct CompactStyleView: View {
                             systemImage: article.isRead ? "envelope" : "envelope.open"
                         )
                     }
+                    Button {
+                        feedManager.toggleBookmark(article)
+                    } label: {
+                        Label(
+                            article.isBookmarked
+                                ? String(localized: "Article.RemoveBookmark", table: "Articles")
+                                : String(localized: "Article.Bookmark", table: "Articles"),
+                            systemImage: article.isBookmarked ? "bookmark.fill" : "bookmark"
+                        )
+                    }
                 }
             }
             if let onLoadMore {

--- a/SakuraRSS/Views/Shared/Feed Display Styles/Feed/CompactFeedArticleRow.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/Feed/CompactFeedArticleRow.swift
@@ -3,11 +3,9 @@ import SwiftUI
 struct CompactFeedArticleRow: View {
 
     @Environment(FeedManager.self) var feedManager
-    @Environment(\.openURL) var openURL
     @Environment(\.navigateToFeed) var navigateToFeed
     let article: Article
     var onShowYouTubePlayer: (() -> Void)?
-    @AppStorage("YouTube.OpenMode") private var youTubeOpenMode: YouTubeOpenMode = .inAppPlayer
     @State private var favicon: UIImage?
     @State private var feedName: String?
     @State private var acronymIcon: UIImage?
@@ -15,7 +13,7 @@ struct CompactFeedArticleRow: View {
     @State private var feed: Feed?
     @State private var showSafari = false
 
-    private var opensInExternalApp: Bool {
+    var opensInExternalApp: Bool {
         if feed?.isRedditFeed == true { return RedditHelper.isAppInstalled }
         if feed?.isXFeed == true { return XHelper.isAppInstalled }
         if feed?.isInstagramFeed == true { return InstagramHelper.isAppInstalled }
@@ -79,6 +77,33 @@ struct CompactFeedArticleRow: View {
             if !article.isRead {
                 UnreadDotView(isRead: article.isRead)
             }
+
+            CompactFeedArticleRowOverflowMenu(article: article)
+        }
+    }
+
+    @ViewBuilder
+    private var thumbnail: some View {
+        if let imageURL = article.imageURL, let url = URL(string: imageURL) {
+            CachedAsyncImage(url: url, alignment: .center, placeholder: {
+                Color.secondary.opacity(0.1)
+                    .frame(width: 72, height: 72)
+            })
+            .frame(width: 72, height: 72)
+            .clipShape(.rect(cornerRadius: 10))
+            .overlay {
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(.quaternary, lineWidth: 0.5)
+            }
+            .overlay {
+                if feed?.isVideoFeed == true || feed?.isPodcast == true {
+                    Image(systemName: "play.fill")
+                        .font(.caption)
+                        .foregroundStyle(.primary)
+                        .padding(8)
+                        .background(.ultraThinMaterial, in: .circle)
+                }
+            }
         }
     }
 
@@ -87,138 +112,24 @@ struct CompactFeedArticleRow: View {
             feedHeaderRow
 
             HStack(alignment: .top, spacing: 10) {
-                Text(article.title.trimmingCharacters(in: .whitespacesAndNewlines))
-                    .font(.subheadline)
-                    .foregroundStyle(.primary)
-                    .lineLimit(3)
-                    .truncationMode(.tail)
-                    .fixedSize(horizontal: false, vertical: true)
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(article.title.trimmingCharacters(in: .whitespacesAndNewlines))
+                        .font(.subheadline)
+                        .foregroundStyle(.primary)
+                        .lineLimit(3)
+                        .truncationMode(.tail)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .frame(maxWidth: .infinity, alignment: .leading)
 
-                if let imageURL = article.imageURL, let url = URL(string: imageURL) {
-                    CachedAsyncImage(url: url, alignment: .center, placeholder: {
-                        Color.secondary.opacity(0.1)
-                            .frame(width: 72, height: 72)
-                    })
-                    .frame(width: 72, height: 72)
-                    .clipShape(.rect(cornerRadius: 10))
-                    .overlay {
-                        RoundedRectangle(cornerRadius: 10)
-                            .stroke(.quaternary, lineWidth: 0.5)
-                    }
-                    .overlay {
-                        if feed?.isVideoFeed == true || feed?.isPodcast == true {
-                            Image(systemName: "play.fill")
-                                .font(.caption)
-                                .foregroundStyle(.primary)
-                                .padding(8)
-                                .background(.ultraThinMaterial, in: .circle)
-                        }
-                    }
+                    CompactFeedArticleRowActions(
+                        article: article,
+                        opensInExternalApp: opensInExternalApp,
+                        onShowYouTubePlayer: onShowYouTubePlayer,
+                        onShowSafari: { showSafari = true }
+                    )
                 }
-            }
 
-            HStack(spacing: 10) {
-                Button {
-                    if article.isYouTubeURL && youTubeOpenMode == .inAppPlayer {
-                        onShowYouTubePlayer?()
-                    } else if article.isYouTubeURL && youTubeOpenMode == .youTubeApp {
-                        YouTubeHelper.openInApp(url: article.url)
-                    } else if article.isYouTubeURL && youTubeOpenMode == .browser {
-                        showSafari = true
-                    } else if let url = URL(string: article.url) {
-                        openURL(url)
-                    }
-                } label: {
-                    HStack(spacing: 6) {
-                        Image(
-                            systemName: (
-                                article.isYouTubeURL && YouTubeHelper.isAppInstalled
-                                    ? "play.rectangle"
-                                    : (opensInExternalApp ? "arrow.up.forward.app" : "safari")
-                            )
-                        )
-                        Text(
-                            opensInExternalApp ? String(
-                                localized: "OpenInApp",
-                                table: "Articles"
-                            ) : String(localized: "OpenInBrowser", table: "Articles")
-                        )
-                            .lineLimit(1)
-                    }
-                    .font(.subheadline.weight(.semibold))
-                    .padding(.horizontal, 14)
-                    .frame(height: 36)
-                    .background(.secondary.opacity(0.15), in: .capsule)
-                }
-                .buttonStyle(.plain)
-                .foregroundStyle(.primary)
-
-                Button {
-                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
-                    feedManager.toggleRead(article)
-                } label: {
-                    HStack(spacing: 6) {
-                        Image(systemName: article.isRead ? "envelope" : "envelope.open")
-                            .offset(y: article.isRead ? 0 : -1)
-                        Text(
-                            article.isRead ? String(
-                                localized: "Article.MarkUnread",
-                                table: "Articles"
-                            ) : String(
-                                localized: "Article.MarkRead",
-                                table: "Articles"
-                            )
-                        )
-                            .lineLimit(1)
-                    }
-                    .font(.subheadline.weight(.semibold))
-                    .padding(.horizontal, 14)
-                    .frame(height: 36)
-                    .background(.secondary.opacity(0.15), in: .capsule)
-                }
-                .buttonStyle(.plain)
-                .foregroundStyle(.primary)
-
-                Spacer()
-
-                Menu {
-                    Button {
-                        UIImpactFeedbackGenerator(style: .light).impactOccurred()
-                        feedManager.toggleBookmark(article)
-                    } label: {
-                        Label(
-                            article.isBookmarked ? String(
-                                localized: "Article.RemoveBookmark",
-                                table: "Articles"
-                            ) : String(
-                                localized: "Article.Bookmark",
-                                table: "Articles"
-                            ),
-                            systemImage: article.isBookmarked ? "bookmark.fill" : "bookmark"
-                        )
-                    }
-
-                    if let shareURL = URL(string: article.url) {
-                        ShareLink(item: shareURL) {
-                            Label(
-                                String(
-                                    localized: "Article.Share",
-                                    table: "Articles"
-                                ),
-                                systemImage: "square.and.arrow.up"
-                            )
-                        }
-                    }
-                } label: {
-                    Image(systemName: "ellipsis")
-                        .font(.subheadline.weight(.semibold))
-                        .padding(.vertical, 8)
-                        .padding(.horizontal, 4)
-                        .contentShape(.rect)
-                }
-                .buttonStyle(.plain)
-                .foregroundStyle(.primary)
+                thumbnail
             }
         }
         .task {

--- a/SakuraRSS/Views/Shared/Feed Display Styles/Feed/CompactFeedArticleRowActions.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/Feed/CompactFeedArticleRowActions.swift
@@ -1,0 +1,88 @@
+import SwiftUI
+
+/// Inline "Open" and "Mark Read" buttons rendered under the article title
+/// in the Feed (Compact) style.
+struct CompactFeedArticleRowActions: View {
+
+    @Environment(FeedManager.self) private var feedManager
+    @Environment(\.openURL) private var openURL
+    @AppStorage("YouTube.OpenMode") private var youTubeOpenMode: YouTubeOpenMode = .inAppPlayer
+
+    let article: Article
+    let opensInExternalApp: Bool
+    var onShowYouTubePlayer: (() -> Void)?
+    var onShowSafari: () -> Void
+
+    var body: some View {
+        HStack(spacing: 8) {
+            openButton
+            markReadButton
+            Spacer(minLength: 0)
+        }
+    }
+
+    private var openButtonSystemName: String {
+        if article.isYouTubeURL && YouTubeHelper.isAppInstalled {
+            return "play.rectangle"
+        }
+        return opensInExternalApp ? "arrow.up.forward.app" : "safari"
+    }
+
+    private var openButtonTitle: String {
+        opensInExternalApp
+            ? String(localized: "OpenInApp", table: "Articles")
+            : String(localized: "OpenInBrowser", table: "Articles")
+    }
+
+    @ViewBuilder
+    private var openButton: some View {
+        Button {
+            if article.isYouTubeURL && youTubeOpenMode == .inAppPlayer {
+                onShowYouTubePlayer?()
+            } else if article.isYouTubeURL && youTubeOpenMode == .youTubeApp {
+                YouTubeHelper.openInApp(url: article.url)
+            } else if article.isYouTubeURL && youTubeOpenMode == .browser {
+                onShowSafari()
+            } else if let url = URL(string: article.url) {
+                openURL(url)
+            }
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: openButtonSystemName)
+                Text(openButtonTitle)
+                    .lineLimit(1)
+            }
+            .font(.footnote.weight(.semibold))
+            .padding(.horizontal, 12)
+            .frame(height: 30)
+            .background(.secondary.opacity(0.15), in: .capsule)
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(.primary)
+    }
+
+    @ViewBuilder
+    private var markReadButton: some View {
+        Button {
+            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            feedManager.toggleRead(article)
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: article.isRead ? "envelope" : "envelope.open")
+                    .offset(y: article.isRead ? 0 : -1)
+                Text(
+                    article.isRead
+                        ? String(localized: "Article.MarkUnread", table: "Articles")
+                        : String(localized: "Article.MarkRead", table: "Articles")
+                )
+                .lineLimit(1)
+            }
+            .font(.footnote.weight(.semibold))
+            .padding(.horizontal, 12)
+            .frame(height: 30)
+            .background(.secondary.opacity(0.15), in: .capsule)
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(.primary)
+    }
+}

--- a/SakuraRSS/Views/Shared/Feed Display Styles/Feed/CompactFeedArticleRowOverflowMenu.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/Feed/CompactFeedArticleRowOverflowMenu.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+/// Overflow menu shown at the right edge of the Feed (Compact) header row.
+struct CompactFeedArticleRowOverflowMenu: View {
+
+    @Environment(FeedManager.self) private var feedManager
+    let article: Article
+
+    var body: some View {
+        Menu {
+            Button {
+                UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                feedManager.toggleBookmark(article)
+            } label: {
+                Label(
+                    article.isBookmarked
+                        ? String(localized: "Article.RemoveBookmark", table: "Articles")
+                        : String(localized: "Article.Bookmark", table: "Articles"),
+                    systemImage: article.isBookmarked ? "bookmark.fill" : "bookmark"
+                )
+            }
+
+            if let shareURL = URL(string: article.url) {
+                ShareLink(item: shareURL) {
+                    Label(
+                        String(localized: "Article.Share", table: "Articles"),
+                        systemImage: "square.and.arrow.up"
+                    )
+                }
+            }
+        } label: {
+            Image(systemName: "ellipsis")
+                .font(.footnote.weight(.semibold))
+                .padding(.vertical, 6)
+                .padding(.horizontal, 4)
+                .contentShape(.rect)
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(.primary)
+    }
+}

--- a/SakuraRSS/Views/Shared/Feed Display Styles/Magazine/MagazineStyleView.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/Magazine/MagazineStyleView.swift
@@ -38,6 +38,17 @@ struct MagazineStyleView: View {
                                         ? "envelope" : "envelope.open"
                                 )
                             }
+                            Button {
+                                feedManager.toggleBookmark(article)
+                            } label: {
+                                Label(
+                                    article.isBookmarked
+                                        ? String(localized: "Article.RemoveBookmark", table: "Articles")
+                                        : String(localized: "Article.Bookmark", table: "Articles"),
+                                    systemImage: article.isBookmarked
+                                        ? "bookmark.fill" : "bookmark"
+                                )
+                            }
                         }
                     }
                 }

--- a/Shared/Strings/Articles.xcstrings
+++ b/Shared/Strings/Articles.xcstrings
@@ -3010,6 +3010,65 @@
         }
       }
     },
+    "ShowViewedContent": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gesehene Inhalte anzeigen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show Viewed Content"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afficher le contenu lu"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostra contenuti visti"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "閲覧済みを表示"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "읽은 콘텐츠 표시"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hiện nội dung đã xem"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示已查看的内容"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顯示已檢視的內容"
+          }
+        }
+      }
+    },
     "SimilarContent.People": {
       "extractionState": "manual",
       "localizations": {

--- a/Shared/Strings/Articles.xcstrings
+++ b/Shared/Strings/Articles.xcstrings
@@ -2302,61 +2302,61 @@
         }
       }
     },
-    "HideRead": {
+    "HideViewedContent": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Gelesene ausblenden"
+            "value": "Gesehene Inhalte ausblenden"
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Hide Read"
+            "value": "Hide Viewed Content"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Masquer les lus"
+            "value": "Masquer le contenu lu"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nascondi letti"
+            "value": "Nascondi contenuti visti"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "既読を非表示"
+            "value": "閲覧済みを非表示"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "읽은 항목 숨기기"
+            "value": "읽은 콘텐츠 숨기기"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ẩn đã đọc"
+            "value": "Ẩn nội dung đã xem"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "隐藏已读"
+            "value": "隐藏已查看的内容"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "隱藏已讀"
+            "value": "隱藏已檢視的內容"
           }
         }
       }


### PR DESCRIPTION
## Summary

- **Staging state for mark-as-read** — articles no longer disappear the instant they're marked read. A session-scoped staging buffer keeps read items visible until the user pulls to refresh or taps the new **Hide Viewed Content** button in the display-style menu. Replaces the previous *Hide Read* toggle (removed). Works across Inbox, Magazine, and Compact styles; now also compatible with mark-as-read-on-scroll without the old mutual-exclusion guard.
- **Feed (Compact) row redesign** — the Open / Mark Read buttons now sit inline beneath the title instead of on a dedicated third row. The overflow (ellipsis) menu moved to the right edge of the feed header, and the unread indicator sits to its left. Row split into `CompactFeedArticleRowActions` and `CompactFeedArticleRowOverflowMenu` to keep the file short.
- **Bookmark toggle** added to the context menus in Magazine and Compact display styles.
- **X embed polish** — removed the retired Twitter bird glyph and reworked the whole card into a tappable surface that opens the post in the default browser (`UIApplication.shared.open`).
- **Refresh signal** — `FeedManager` now exposes a `refreshRevision` counter bumped when any feed refresh completes, so views can flush UI-level staging without coupling to article reload internals.
- **Localization** — added `HideViewedContent` in `Articles.xcstrings` for de, en, fr, it, ja, ko, vi, zh-Hans, zh-Hant; removed the obsolete `HideRead` key.

## Test plan
- [ ] Mark an article as read in Inbox / Magazine / Compact; confirm it stays visible.
- [ ] Tap **Hide Viewed Content**; confirm staged read articles animate away.
- [ ] Pull to refresh; confirm staged read articles are cleaned up after the reload.
- [ ] Enable mark-as-read-on-scroll; confirm rows no longer yank the scroll position when they're marked read.
- [ ] In Feed (Compact), verify Open / Mark Read are inline under the title, with the overflow menu at the right edge of the header next to the unread dot.
- [ ] Long-press an item in Magazine and Compact; confirm both Mark Read/Unread and Bookmark/Remove Bookmark appear.
- [ ] Open an article containing an X embed; confirm no bird glyph and tapping opens the post in the default browser.
- [ ] Smoke-test the other eight supported locales (de, fr, it, ja, ko, vi, zh-Hans, zh-Hant) for the new *Hide Viewed Content* label.

https://claude.ai/code/session_01TU9JFv9qkFUQdFHde6Jog6

---
_Generated by [Claude Code](https://claude.ai/code/session_01TU9JFv9qkFUQdFHde6Jog6)_