### PR TITLE
Fix mark-as-read on scroll and defer commits until scroll settles

### DIFF
--- a/SakuraRSS/Classes/Feed Manager/FeedManager+PendingReads.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+PendingReads.swift
@@ -2,7 +2,9 @@ import Foundation
 
 extension FeedManager {
 
-    private static let debouncedReadFlushDelay: Duration = .milliseconds(400)
+    private static let debouncedReadFlushDelay: Duration = .milliseconds(500)
+    private static let scrollSettleRecheckDelay: Duration = .milliseconds(150)
+    private static let maxScrollSettleWaitCycles: Int = 40
 
     // MARK: - Debounced Mark As Read
 
@@ -44,8 +46,14 @@ extension FeedManager {
         debouncedReadFlushTask?.cancel()
         debouncedReadFlushTask = Task { @MainActor [weak self] in
             try? await Task.sleep(for: FeedManager.debouncedReadFlushDelay)
-            guard !Task.isCancelled else { return }
-            self?.flushDebouncedReads()
+            guard !Task.isCancelled, let self else { return }
+            var cycles = 0
+            while !self.isScrollSettled, cycles < FeedManager.maxScrollSettleWaitCycles {
+                try? await Task.sleep(for: FeedManager.scrollSettleRecheckDelay)
+                guard !Task.isCancelled else { return }
+                cycles += 1
+            }
+            self.flushDebouncedReads()
         }
     }
 

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+ScrollActivity.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+ScrollActivity.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+extension FeedManager {
+
+    static let scrollVelocityIdleThreshold: CGFloat = 120
+
+    /// True when the scroll view is idle and its velocity has decayed
+    /// below the threshold for committing mark-as-read writes.
+    var isScrollSettled: Bool {
+        guard currentScrollPhase == .idle else { return false }
+        return abs(currentScrollVelocity) < FeedManager.scrollVelocityIdleThreshold
+    }
+
+    func updateScrollPhase(_ phase: ScrollPhase) {
+        currentScrollPhase = phase
+        if phase == .idle {
+            currentScrollVelocity = 0
+        }
+    }
+
+    func updateScrollOffset(_ offset: CGFloat) {
+        let now = ProcessInfo.processInfo.systemUptime
+        let dt = now - lastScrollSampleTime
+        if lastScrollSampleTime > 0, dt > 0 {
+            let instantaneous = (offset - lastScrollOffset) / CGFloat(dt)
+            currentScrollVelocity = currentScrollVelocity * 0.5 + instantaneous * 0.5
+        }
+        lastScrollOffset = offset
+        lastScrollSampleTime = now
+    }
+
+}

--- a/SakuraRSS/Classes/Feed Manager/FeedManager.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager.swift
@@ -45,6 +45,13 @@ final class FeedManager {
     @ObservationIgnored var debouncedReadFlushTask: Task<Void, Never>?
     @ObservationIgnored var refreshTask: Task<Void, Never>?
 
+    /// Scroll state used to defer mark-as-read commits while the user
+    /// is scrolling fast. Updated by `TrackScrollActivityModifier`.
+    @ObservationIgnored var currentScrollPhase: ScrollPhase = .idle
+    @ObservationIgnored var currentScrollVelocity: CGFloat = 0
+    @ObservationIgnored var lastScrollOffset: CGFloat = 0
+    @ObservationIgnored var lastScrollSampleTime: CFTimeInterval = 0
+
     let database = DatabaseManager.shared
 
     init() {

--- a/SakuraRSS/Views/Shared/Feed Display Styles/Compact/CompactStyleView.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/Compact/CompactStyleView.swift
@@ -69,6 +69,7 @@ struct CompactStyleView: View {
             }
         }
         .listStyle(.plain)
+        .trackScrollActivity()
         .navigationDestination(item: $youTubeArticle) { article in
             YouTubePlayerView(article: article)
                 .zoomTransition(sourceID: article.id, in: zoomNamespace)

--- a/SakuraRSS/Views/Shared/Feed Display Styles/Feed/FeedStyleView.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/Feed/FeedStyleView.swift
@@ -58,6 +58,7 @@ struct FeedStyleView: View {
             }
         }
         .listStyle(.plain)
+        .trackScrollActivity()
         .navigationDestination(item: $youTubeArticle) { article in
             YouTubePlayerView(article: article)
                 .zoomTransition(sourceID: article.id, in: zoomNamespace)

--- a/SakuraRSS/Views/Shared/Feed Display Styles/Grid/GridStyleView.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/Grid/GridStyleView.swift
@@ -58,6 +58,7 @@ struct GridStyleView: View {
                     .padding(.vertical, 12)
             }
         }
+        .trackScrollActivity()
         .navigationDestination(item: $youTubeArticle) { article in
             YouTubePlayerView(article: article)
                 .zoomTransition(sourceID: article.id, in: zoomNamespace)

--- a/SakuraRSS/Views/Shared/Feed Display Styles/Inbox/InboxStyleView.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/Inbox/InboxStyleView.swift
@@ -50,6 +50,7 @@ struct InboxStyleView: View {
             }
         }
         .listStyle(.plain)
+        .trackScrollActivity()
         .navigationLinkIndicatorVisibility(.hidden)
         .navigationDestination(item: $youTubeArticle) { article in
             YouTubePlayerView(article: article)

--- a/SakuraRSS/Views/Shared/Feed Display Styles/Magazine/MagazineStyleView.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/Magazine/MagazineStyleView.swift
@@ -61,6 +61,7 @@ struct MagazineStyleView: View {
             .padding(.bottom)
         }
         .animation(.smooth.speed(2.0), value: articles)
+        .trackScrollActivity()
         .navigationDestination(item: $youTubeArticle) { article in
             YouTubePlayerView(article: article)
                 .zoomTransition(sourceID: article.id, in: zoomNamespace)

--- a/SakuraRSS/Views/Shared/Feed Display Styles/Photos/PhotosStyleView.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/Photos/PhotosStyleView.swift
@@ -23,6 +23,7 @@ struct PhotosStyleView: View {
                 }
             }
         }
+        .trackScrollActivity()
         .navigationDestination(item: $youTubeArticle) { article in
             YouTubePlayerView(article: article)
                 .zoomTransition(sourceID: article.id, in: zoomNamespace)

--- a/SakuraRSS/Views/Shared/Feed Display Styles/Podcast/PodcastStyleView.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/Podcast/PodcastStyleView.swift
@@ -90,5 +90,6 @@ struct PodcastStyleView: View {
             }
         }
         .listStyle(.plain)
+        .trackScrollActivity()
     }
 }

--- a/SakuraRSS/Views/Shared/Feed Display Styles/Timeline/TimelineStyleView.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/Timeline/TimelineStyleView.swift
@@ -53,6 +53,7 @@ struct TimelineStyleView: View {
             }
         }
         .listStyle(.plain)
+        .trackScrollActivity()
         .navigationDestination(item: $youTubeArticle) { article in
             YouTubePlayerView(article: article)
                 .zoomTransition(sourceID: article.id, in: zoomNamespace)

--- a/SakuraRSS/Views/Shared/Feed Display Styles/Video/VideoStyleView.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/Video/VideoStyleView.swift
@@ -81,6 +81,7 @@ struct VideoStyleView: View {
                     .padding(.bottom)
             }
         }
+        .trackScrollActivity()
         .navigationDestination(item: $youTubePlayerArticle) { article in
             YouTubePlayerView(article: article)
                 .zoomTransition(sourceID: article.id, in: zoomNamespace)

--- a/SakuraRSS/Views/Shared/MarkReadOnScrollModifier.swift
+++ b/SakuraRSS/Views/Shared/MarkReadOnScrollModifier.swift
@@ -1,5 +1,8 @@
 import SwiftUI
 
+/// Marks an article as read once the user has seen it on screen and then
+/// scrolled it past the top of the list. Driven by the
+/// `Display.ScrollMarkAsRead` setting.
 struct MarkReadOnScrollModifier: ViewModifier {
 
     @Environment(FeedManager.self) private var feedManager
@@ -8,7 +11,7 @@ struct MarkReadOnScrollModifier: ViewModifier {
     let article: Article
 
     @State private var hasBeenVisible = false
-    @State private var hasScrolledPastTop = false
+    @State private var isPastTop = false
     @State private var hasQueued = false
 
     func body(content: Content) -> some View {
@@ -16,14 +19,18 @@ struct MarkReadOnScrollModifier: ViewModifier {
             .onGeometryChange(for: Bool.self) { proxy in
                 proxy.frame(in: .global).minY < 0
             } action: { newValue in
-                hasScrolledPastTop = newValue
+                isPastTop = newValue
             }
-            .onAppear {
-                hasBeenVisible = true
-            }
-            .onDisappear {
-                guard scrollMarkAsRead, hasBeenVisible, hasScrolledPastTop,
-                      !hasQueued, !article.isRead else { return }
+            .onScrollVisibilityChange(threshold: 0.01) { isVisible in
+                if isVisible {
+                    hasBeenVisible = true
+                    return
+                }
+                guard scrollMarkAsRead,
+                      hasBeenVisible,
+                      isPastTop,
+                      !hasQueued,
+                      !article.isRead else { return }
                 hasQueued = true
                 feedManager.markReadDebounced(article)
             }

--- a/SakuraRSS/Views/Shared/TrackScrollActivityModifier.swift
+++ b/SakuraRSS/Views/Shared/TrackScrollActivityModifier.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+/// Forwards scroll phase and offset updates from an enclosing scroll view
+/// to `FeedManager` so mark-as-read commits can wait until scrolling
+/// has slowed down.
+struct TrackScrollActivityModifier: ViewModifier {
+
+    @Environment(FeedManager.self) private var feedManager
+
+    func body(content: Content) -> some View {
+        content
+            .onScrollPhaseChange { _, newPhase in
+                feedManager.updateScrollPhase(newPhase)
+            }
+            .onScrollGeometryChange(for: CGFloat.self) { geo in
+                geo.contentOffset.y
+            } action: { _, newOffset in
+                feedManager.updateScrollOffset(newOffset)
+            }
+    }
+}
+
+extension View {
+    func trackScrollActivity() -> some View {
+        modifier(TrackScrollActivityModifier())
+    }
+}


### PR DESCRIPTION
## Summary
- Switches `MarkReadOnScrollModifier` from `onAppear`/`onDisappear` to `onScrollVisibilityChange`, which tracks visibility within the enclosing scroll view more reliably than lifecycle callbacks in a recycling `List`. The `onGeometryChange` direction check (row minY < 0) is preserved so only rows scrolled past the **top** get queued.
- Bumps the pending-read debounce to **500ms** and adds a scroll-settle gate: after the debounce expires, the flush waits until `ScrollPhase == .idle` *and* velocity has decayed below a low threshold before it writes to SQLite, so fast flicks don't commit mid-flight.
- Adds `TrackScrollActivityModifier` that forwards `onScrollPhaseChange` and `onScrollGeometryChange` into `FeedManager`, and applies it to all nine feed display styles that participate in mark-as-read (Inbox, Feed, Compact, Magazine, Grid, Photos, Podcast, Timeline, Video).

## Test plan
- [ ] With **Display → ScrollMarkAsRead** on, open a feed with unread items and scroll downward. Articles that pass above the top should turn read once scrolling settles.
- [ ] Flick fast through a long feed and lift your finger. No DB write should occur while the list is still decelerating; the write should land ~500ms after the scroll stops.
- [ ] Scroll an article above the top, then scroll back before it has been marked read — it should remain unread.
- [ ] Verify in every display style (Inbox, Feed, Feed Compact, Compact, Magazine, Grid, Photos, Podcast, Timeline, Video).
- [ ] Toggle `Display.ScrollMarkAsRead` off and confirm nothing is marked read on scroll.
- [ ] Background the app mid-scroll and reopen — pending reads should have flushed via `willResignActive`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HuFm9ZR49HMshoSZQ4Ma5f)_