### PR TITLE
Bump data revision on mark-as-read flush and fade in article images

### DIFF
--- a/SakuraRSS/Classes/Feed Manager/FeedManager+PendingReads.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+PendingReads.swift
@@ -19,9 +19,13 @@ extension FeedManager {
         guard !pendingReadIDs.isEmpty else { return }
         let ids = pendingReadIDs
         pendingReadIDs.removeAll()
+        let idArray = Array(ids)
 
-        // Collapse per-row observable writes into one notification per
-        // property so badge observers don't get invalidated N times.
+        // Persist before publishing observable changes so the next render
+        // of the article list views — which re-read from SQLite via
+        // `dataRevision` — sees the updated read state.
+        try? database.markArticlesRead(ids: idArray, read: true)
+
         var newArticles = articles
         var decrements: [Int64: Int] = [:]
         let indexByID = Dictionary(uniqueKeysWithValues: newArticles.enumerated().map { ($1.id, $0) })
@@ -32,12 +36,11 @@ extension FeedManager {
         }
         articles = newArticles
         applyUnreadDecrements(decrements)
+        bumpDataRevision()
         updateBadgeCount()
 
-        let idArray = Array(ids)
         let dbm = database
         Task.detached(priority: .utility) {
-            try? dbm.markArticlesRead(ids: idArray, read: true)
             try? dbm.updateLastAccessed(articleIDs: idArray)
         }
     }

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+Refresh.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+Refresh.swift
@@ -347,8 +347,8 @@ extension FeedManager {
             onBegin: { [weak self] total in
                 await MainActor.run { self?.nlpTotal = total }
             },
-            onProgress: { [weak self] in
-                await MainActor.run { self?.nlpCompleted += 1 }
+            onProgress: { [weak self] delta in
+                await MainActor.run { self?.nlpCompleted += delta }
             }
         )
     }

--- a/SakuraRSS/Structs/NLPProcessingCoordinator.swift
+++ b/SakuraRSS/Structs/NLPProcessingCoordinator.swift
@@ -14,10 +14,15 @@ enum NLPProcessingCoordinator {
     nonisolated private static let chunkSize = 20
 
     /// Processes unprocessed articles if Content Insights is enabled.
-    /// `onBegin` fires once with the total; `onProgress` fires per article.
+    /// `onBegin` fires once with the total; `onProgress` fires in batches
+    /// (aligned to each cooperative-yield boundary) with the number of
+    /// articles completed since the last call.  Coalescing the ticks keeps
+    /// the progress donut from hopping to the MainActor 200 times per
+    /// refresh, which is the source of the scroll hitches users see while
+    /// NLP runs.
     static func processNewArticlesIfEnabled(
         onBegin: @escaping @Sendable (Int) async -> Void = { _ in },
-        onProgress: @escaping @Sendable () async -> Void = { }
+        onProgress: @escaping @Sendable (Int) async -> Void = { _ in }
     ) async {
         let defaults = UserDefaults.standard
         let contentInsightsEnabled = defaults.bool(forKey: "Intelligence.ContentInsights.Enabled")
@@ -71,12 +76,15 @@ enum NLPProcessingCoordinator {
                         runEntities: pending.needsEntities
                     )
                 }
-                await onProgress()
                 processedSinceYield += 1
                 if processedSinceYield >= chunkSize {
+                    await onProgress(processedSinceYield)
                     processedSinceYield = 0
                     await Task.yield()
                 }
+            }
+            if processedSinceYield > 0 {
+                await onProgress(processedSinceYield)
             }
 
             #if DEBUG

--- a/SakuraRSS/Views/Search/DiscoverArticleCard.swift
+++ b/SakuraRSS/Views/Search/DiscoverArticleCard.swift
@@ -3,10 +3,10 @@ import SwiftUI
 struct DiscoverArticleCard: View {
 
     @Environment(FeedManager.self) var feedManager
-    @Environment(\.colorScheme) private var colorScheme
     @Environment(\.zoomNamespace) private var zoomNamespace
     let article: Article
     @State private var favicon: UIImage?
+    @State private var isSocialFeed = false
     @State private var shouldCenterImage = false
 
     private let cardWidth: CGFloat = 200
@@ -48,6 +48,7 @@ struct DiscoverArticleCard: View {
         .buttonStyle(.plain)
         .task {
             guard let feed = feedManager.feedsByID[article.feedID] else { return }
+            isSocialFeed = feed.isSocialFeed
             shouldCenterImage = CenteredImageDomains.shouldCenterImage(feedDomain: feed.domain)
             favicon = await FaviconCache.shared.favicon(for: feed)
         }
@@ -64,26 +65,14 @@ struct DiscoverArticleCard: View {
         }
     }
 
-    @ViewBuilder
     private var thumbnailBackground: some View {
-        let isDark = colorScheme == .dark
-        let bgColor = favicon?.cardBackgroundColor(isDarkMode: isDark)
-            ?? (isDark ? Color(white: 0.15) : Color(white: 0.9))
-
-        ZStack {
-            Rectangle()
-                .fill(bgColor)
-
-            if let favicon {
-                Image(uiImage: favicon)
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .frame(width: imageHeight * 0.5, height: imageHeight * 0.5)
-            } else {
-                Image(systemName: "doc.text")
-                    .font(.system(size: imageHeight * 0.35, weight: .light))
-                    .foregroundStyle(.tertiary)
-            }
-        }
+        FeedIconPlaceholder(
+            favicon: favicon,
+            acronymIcon: nil,
+            feedName: feedName,
+            isSocialFeed: isSocialFeed,
+            iconSize: imageHeight * 0.5,
+            fallback: .symbol("doc.text")
+        )
     }
 }

--- a/SakuraRSS/Views/Shared/Article Detail/ArticleDetailView+SimilarContent.swift
+++ b/SakuraRSS/Views/Shared/Article Detail/ArticleDetailView+SimilarContent.swift
@@ -4,6 +4,7 @@ struct SimilarArticleItem: Identifiable {
     let id: Int64
     let article: Article
     let feedName: String
+    let isSocialFeed: Bool
     let sentiment: Double?
     let favicon: UIImage?
 }
@@ -226,6 +227,7 @@ extension ArticleDetailView {
                         id: match.article.id,
                         article: match.article,
                         feedName: match.feedName,
+                        isSocialFeed: match.feed?.isSocialFeed ?? false,
                         sentiment: match.sentiment,
                         favicon: favicon
                     ))
@@ -356,7 +358,6 @@ private struct SimilarMatchData: Sendable {
 
 private struct SimilarArticleCard: View {
 
-    @Environment(\.colorScheme) private var colorScheme
     @Environment(\.zoomNamespace) private var zoomNamespace
     let item: SimilarArticleItem
 
@@ -403,26 +404,14 @@ private struct SimilarArticleCard: View {
         }
     }
 
-    @ViewBuilder
     private var thumbnailBackground: some View {
-        let isDark = colorScheme == .dark
-        let bgColor = item.favicon?.cardBackgroundColor(isDarkMode: isDark)
-            ?? (isDark ? Color(white: 0.15) : Color(white: 0.9))
-
-        ZStack {
-            Rectangle()
-                .fill(bgColor)
-
-            if let favicon = item.favicon {
-                Image(uiImage: favicon)
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .frame(width: imageHeight * 0.5, height: imageHeight * 0.5)
-            } else {
-                Image(systemName: "doc.text")
-                    .font(.system(size: imageHeight * 0.35, weight: .light))
-                    .foregroundStyle(.tertiary)
-            }
-        }
+        FeedIconPlaceholder(
+            favicon: item.favicon,
+            acronymIcon: nil,
+            feedName: item.feedName,
+            isSocialFeed: item.isSocialFeed,
+            iconSize: imageHeight * 0.5,
+            fallback: .symbol("doc.text")
+        )
     }
 }

--- a/SakuraRSS/Views/Shared/Feed Display Styles/Cards/CardView.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/Cards/CardView.swift
@@ -14,6 +14,7 @@ struct CardView: View {
     @State private var favicon: UIImage?
     @State private var cardImage: UIImage?
     @State private var shouldCenterImage = false
+    @State private var isSocialFeed = false
 
     private var rotation: Double {
         Double(offset.width) / 20.0
@@ -106,6 +107,7 @@ struct CardView: View {
         .task {
             if let feed = feedManager.feed(forArticle: article) {
                 shouldCenterImage = CenteredImageDomains.shouldCenterImage(feedDomain: feed.domain)
+                isSocialFeed = feed.isSocialFeed
                 favicon = await FaviconCache.shared.favicon(for: feed)
             }
         }
@@ -135,14 +137,21 @@ struct CardView: View {
 
             // Favicon displayed large and slightly rotated
             if let favicon {
-                Image(uiImage: favicon)
+                let iconImage = Image(uiImage: favicon)
                     .resizable()
-                    .aspectRatio(contentMode: .fit)
+                    .aspectRatio(contentMode: isSocialFeed ? .fill : .fit)
                     .frame(width: geometry.size.width * 0.4,
                            height: geometry.size.width * 0.4)
-                    .opacity(isDark ? 0.6 : 0.4)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .offset(y: -geometry.size.height * 0.1)
+                Group {
+                    if isSocialFeed {
+                        iconImage.clipShape(Circle())
+                    } else {
+                        iconImage
+                    }
+                }
+                .opacity(isDark ? 0.6 : 0.4)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .offset(y: -geometry.size.height * 0.1)
             }
 
             // Bottom gradient for text readability

--- a/SakuraRSS/Views/Shared/Feed Display Styles/Cards/CardView.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/Cards/CardView.swift
@@ -12,7 +12,7 @@ struct CardView: View {
     @State private var hasPassedThreshold = false
     @State private var isDismissing = false
     @State private var favicon: UIImage?
-    @State private var hideImage = false
+    @State private var cardImage: UIImage?
     @State private var shouldCenterImage = false
 
     private var rotation: Double {
@@ -37,37 +37,25 @@ struct CardView: View {
         return String(localized: "Cards.ReadLater", table: "Articles")
     }
 
-    private var hasArticleImage: Bool {
-        article.imageURL != nil && !hideImage
-    }
-
     var body: some View {
         GeometryReader { geometry in
             ZStack(alignment: .bottomLeading) {
-                if hasArticleImage {
-                    // Background image
-                    if let imageURL = article.imageURL, let url = URL(string: imageURL) {
-                        CachedAsyncImage(url: url, alignment: shouldCenterImage ? .center : .top, onImageLoaded: { image in
-                            let pixelWidth = image.size.width * image.scale
-                            let pixelHeight = image.size.height * image.scale
-                            if pixelWidth <= 100 && pixelHeight <= 100 {
-                                hideImage = true
-                            }
-                        }) {
-                            Rectangle()
-                                .fill(.secondary.opacity(0.2))
+                faviconCardBackground(geometry: geometry)
+
+                if let cardImage {
+                    Color.clear
+                        .overlay(alignment: shouldCenterImage ? .center : .top) {
+                            Image(uiImage: cardImage)
+                                .resizable()
+                                .aspectRatio(contentMode: .fill)
                         }
                         .frame(width: geometry.size.width, height: geometry.size.height)
                         .clipped()
-                    }
+                        .transition(.opacity)
 
-                    // Progressive blur over the bottom portion of the card
                     ProgressiveBlurView()
                         .frame(height: geometry.size.height * 0.5)
                         .frame(maxHeight: .infinity, alignment: .bottom)
-                } else {
-                    // Favicon-based card background
-                    faviconCardBackground(geometry: geometry)
                 }
 
                 // Swipe indicator overlays
@@ -119,6 +107,17 @@ struct CardView: View {
             if let feed = feedManager.feed(forArticle: article) {
                 shouldCenterImage = CenteredImageDomains.shouldCenterImage(feedDomain: feed.domain)
                 favicon = await FaviconCache.shared.favicon(for: feed)
+            }
+        }
+        .task(id: article.imageURL) {
+            guard let imageURL = article.imageURL, let url = URL(string: imageURL) else { return }
+            let image = await CachedAsyncImage<EmptyView>.loadImage(from: url)
+            guard !Task.isCancelled, let image else { return }
+            let pixelWidth = image.size.width * image.scale
+            let pixelHeight = image.size.height * image.scale
+            guard pixelWidth > 100 || pixelHeight > 100 else { return }
+            withAnimation(.easeOut(duration: 0.3)) {
+                cardImage = image
             }
         }
     }

--- a/SakuraRSS/Views/Shared/Feed Display Styles/Feed/CompactFeedArticleRow.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/Feed/CompactFeedArticleRow.swift
@@ -121,6 +121,8 @@ struct CompactFeedArticleRow: View {
                         .fixedSize(horizontal: false, vertical: true)
                         .frame(maxWidth: .infinity, alignment: .leading)
 
+                    Spacer(minLength: 0)
+
                     CompactFeedArticleRowActions(
                         article: article,
                         opensInExternalApp: opensInExternalApp,
@@ -128,6 +130,7 @@ struct CompactFeedArticleRow: View {
                         onShowSafari: { showSafari = true }
                     )
                 }
+                .frame(maxHeight: .infinity)
 
                 thumbnail
             }

--- a/SakuraRSS/Views/Shared/Feed Display Styles/Feed/FeedArticleRow.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/Feed/FeedArticleRow.swift
@@ -16,7 +16,7 @@ struct FeedArticleRow: View {
     @State private var feed: Feed?
     @State private var showSafari = false
     @State private var imageAspectRatio: CGFloat?
-    @State private var hideImage = false
+    @State private var loadedImage: UIImage?
 
     private var imageHeight: CGFloat {
         if UIDevice.current.userInterfaceIdiom == .pad {
@@ -118,43 +118,36 @@ struct FeedArticleRow: View {
                         .contentMargins(.horizontal, 0)
                         .padding(.top, 4)
                     }
-                } else if !hideImage, let imageURL = article.imageURL, let url = URL(string: imageURL) {
+                } else if let loadedImage {
                     let shouldCenter = feed.map {
                         CenteredImageDomains.shouldCenterImage(feedDomain: $0.domain)
                     } ?? false
-                    CachedAsyncImage(
-                        url: url,
-                        alignment: shouldCenter ? .center : (imageAspectRatio ?? 0 > 1 ? .leading : .top),
-                        onImageLoaded: { image in
-                            imageAspectRatio = image.size.height / image.size.width
-                            let pixelWidth = image.size.width * image.scale
-                            let pixelHeight = image.size.height * image.scale
-                            if pixelWidth <= 100 && pixelHeight <= 100 {
-                                hideImage = true
-                            }
-                        },
-                        placeholder: {
-                        Color.secondary.opacity(0.1)
-                            .frame(height: imageHeight)
-                    })
-                    .frame(maxWidth: imageAspectRatio ?? 0 > 1 ? nil : .infinity)
-                    .frame(height: imageHeight)
-                    .clipShape(.rect(cornerRadius: 12))
-                    .overlay {
-                        RoundedRectangle(cornerRadius: 12)
-                            .stroke(.quaternary, lineWidth: 0.5)
-                    }
-                    .overlay {
-                        if feed?.isVideoFeed == true || feed?.isPodcast == true {
-                            Image(systemName: "play.fill")
-                                .font(.title)
-                                .foregroundStyle(.primary)
-                                .padding(16)
-                                .background(.ultraThinMaterial, in: .circle)
-                                .glassEffect(.regular.interactive(), in: .circle)
+                    Color.clear
+                        .frame(maxWidth: imageAspectRatio ?? 0 > 1 ? nil : .infinity)
+                        .frame(height: imageHeight)
+                        .overlay(alignment: shouldCenter ? .center : (imageAspectRatio ?? 0 > 1 ? .leading : .top)) {
+                            Image(uiImage: loadedImage)
+                                .resizable()
+                                .aspectRatio(contentMode: .fill)
                         }
-                    }
-                    .padding(.top, 4)
+                        .clipped()
+                        .clipShape(.rect(cornerRadius: 12))
+                        .overlay {
+                            RoundedRectangle(cornerRadius: 12)
+                                .stroke(.quaternary, lineWidth: 0.5)
+                        }
+                        .overlay {
+                            if feed?.isVideoFeed == true || feed?.isPodcast == true {
+                                Image(systemName: "play.fill")
+                                    .font(.title)
+                                    .foregroundStyle(.primary)
+                                    .padding(16)
+                                    .background(.ultraThinMaterial, in: .circle)
+                                    .glassEffect(.regular.interactive(), in: .circle)
+                            }
+                        }
+                        .padding(.top, 4)
+                        .transition(.opacity)
                 }
 
                 HStack {
@@ -234,6 +227,23 @@ struct FeedArticleRow: View {
                     || FaviconNoInsetDomains.shouldUseFullImage(feedDomain: loadedFeed.domain)
                 preferTitle = TitleOnlyDomains.shouldPreferTitle(feedDomain: loadedFeed.domain)
                 favicon = await FaviconCache.shared.favicon(for: loadedFeed)
+            }
+        }
+        .task(id: article.imageURL) {
+            guard let imageURL = article.imageURL, let url = URL(string: imageURL) else {
+                loadedImage = nil
+                imageAspectRatio = nil
+                return
+            }
+            let image = await CachedAsyncImage<EmptyView>.loadImage(from: url)
+            guard !Task.isCancelled, let image else { return }
+            let pixelWidth = image.size.width * image.scale
+            let pixelHeight = image.size.height * image.scale
+            guard pixelWidth > 100 || pixelHeight > 100 else { return }
+            let aspect = image.size.height / image.size.width
+            withAnimation(.easeOut(duration: 0.2)) {
+                imageAspectRatio = aspect
+                loadedImage = image
             }
         }
         .sheet(isPresented: $showSafari) {

--- a/SakuraRSS/Views/Shared/Feed Display Styles/Inbox/InboxArticleRow.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/Inbox/InboxArticleRow.swift
@@ -3,7 +3,6 @@ import SwiftUI
 struct InboxArticleRow: View {
 
     @Environment(FeedManager.self) var feedManager
-    @Environment(\.colorScheme) private var colorScheme
     let article: Article
     @State private var favicon: UIImage?
     @State private var acronymIcon: UIImage?
@@ -23,7 +22,15 @@ struct InboxArticleRow: View {
                 .frame(width: 48, height: 48)
                 .clipShape(RoundedRectangle(cornerRadius: 8))
             } else {
-                feedIconFallback
+                FeedIconPlaceholder(
+                    favicon: favicon,
+                    acronymIcon: acronymIcon,
+                    feedName: feedName,
+                    isSocialFeed: isSocialFeed,
+                    iconSize: 30,
+                    cornerRadius: 8
+                )
+                .frame(width: 48, height: 48)
             }
 
             VStack(alignment: .leading, spacing: 4) {
@@ -78,32 +85,5 @@ struct InboxArticleRow: View {
                 favicon = await FaviconCache.shared.favicon(for: feed)
             }
         }
-    }
-
-    @ViewBuilder
-    private var feedIconFallback: some View {
-        let isDark = colorScheme == .dark
-        let bgColor = favicon?.cardBackgroundColor(isDarkMode: isDark)
-            ?? (isDark ? Color(white: 0.15) : Color(white: 0.9))
-        ZStack {
-            RoundedRectangle(cornerRadius: 8)
-                .fill(bgColor)
-            if let favicon {
-                Image(uiImage: favicon)
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .frame(width: 30, height: 30)
-            } else if let acronymIcon {
-                Image(uiImage: acronymIcon)
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .frame(width: 30, height: 30)
-            } else if let feedName {
-                Text(feedName.prefix(1).uppercased())
-                    .font(.headline)
-                    .foregroundStyle(.secondary)
-            }
-        }
-        .frame(width: 48, height: 48)
     }
 }

--- a/SakuraRSS/Views/Shared/Feed Display Styles/Inbox/InboxArticleRow.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/Inbox/InboxArticleRow.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct InboxArticleRow: View {
 
     @Environment(FeedManager.self) var feedManager
+    @Environment(\.colorScheme) private var colorScheme
     let article: Article
     @State private var favicon: UIImage?
     @State private var acronymIcon: UIImage?
@@ -21,12 +22,8 @@ struct InboxArticleRow: View {
                 }
                 .frame(width: 48, height: 48)
                 .clipShape(RoundedRectangle(cornerRadius: 8))
-            } else if let favicon {
-                FaviconImage(favicon, size: 48, cornerRadius: 8)
-            } else if let acronymIcon {
-                FaviconImage(acronymIcon, size: 48, cornerRadius: 8, skipInset: true)
-            } else if let feedName {
-                InitialsAvatarView(feedName, size: 48, cornerRadius: 8)
+            } else {
+                feedIconFallback
             }
 
             VStack(alignment: .leading, spacing: 4) {
@@ -81,5 +78,32 @@ struct InboxArticleRow: View {
                 favicon = await FaviconCache.shared.favicon(for: feed)
             }
         }
+    }
+
+    @ViewBuilder
+    private var feedIconFallback: some View {
+        let isDark = colorScheme == .dark
+        let bgColor = favicon?.cardBackgroundColor(isDarkMode: isDark)
+            ?? (isDark ? Color(white: 0.15) : Color(white: 0.9))
+        ZStack {
+            RoundedRectangle(cornerRadius: 8)
+                .fill(bgColor)
+            if let favicon {
+                Image(uiImage: favicon)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 30, height: 30)
+            } else if let acronymIcon {
+                Image(uiImage: acronymIcon)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 30, height: 30)
+            } else if let feedName {
+                Text(feedName.prefix(1).uppercased())
+                    .font(.headline)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .frame(width: 48, height: 48)
     }
 }

--- a/SakuraRSS/Views/Shared/Feed Display Styles/Magazine/MagazineArticleCard.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/Magazine/MagazineArticleCard.swift
@@ -3,13 +3,13 @@ import SwiftUI
 struct MagazineArticleCard: View {
 
     @Environment(FeedManager.self) var feedManager
-    @Environment(\.colorScheme) private var colorScheme
     let article: Article
     @State private var favicon: UIImage?
     @State private var feedName: String?
     @State private var acronymIcon: UIImage?
     @State private var skipFaviconInset = false
     @State private var isVideoFeed = false
+    @State private var isSocialFeed = false
     @State private var shouldCenterImage = false
 
     var body: some View {
@@ -75,6 +75,7 @@ struct MagazineArticleCard: View {
                     acronymIcon = UIImage(data: data)
                 }
                 isVideoFeed = feed.isVideoFeed || feed.isXFeed || feed.isInstagramFeed
+                isSocialFeed = feed.isSocialFeed
                 skipFaviconInset = feed.isVideoFeed || feed.isXFeed || feed.isInstagramFeed
                     || FaviconNoInsetDomains.shouldUseFullImage(feedDomain: feed.domain)
                 shouldCenterImage = CenteredImageDomains.shouldCenterImage(feedDomain: feed.domain)
@@ -83,32 +84,16 @@ struct MagazineArticleCard: View {
         }
     }
 
-    @ViewBuilder
     private var magazineFallbackBackground: some View {
-        let isDark = colorScheme == .dark
-        let bgColor = favicon?.cardBackgroundColor(isDarkMode: isDark)
-            ?? (isDark ? Color(white: 0.15) : Color(white: 0.9))
-
-        ZStack {
-            RoundedRectangle(cornerRadius: 12)
-                .fill(bgColor)
-
-            if let favicon {
-                Image(uiImage: favicon)
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .frame(width: 40, height: 40)
-            } else if let acronymIcon {
-                Image(uiImage: acronymIcon)
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .frame(width: 40, height: 40)
-            } else {
-                Image(systemName: "doc.text")
-                    .font(.system(size: 30, weight: .light))
-                    .foregroundStyle(.tertiary)
-            }
-        }
+        FeedIconPlaceholder(
+            favicon: favicon,
+            acronymIcon: acronymIcon,
+            feedName: feedName,
+            isSocialFeed: isSocialFeed,
+            iconSize: 40,
+            cornerRadius: 12,
+            fallback: .symbol("doc.text")
+        )
         .frame(height: 120)
     }
 }

--- a/SakuraRSS/Views/Shared/Feed Display Styles/Photos/PhotosArticleCard.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/Photos/PhotosArticleCard.swift
@@ -13,7 +13,6 @@ struct PhotosArticleCard: View {
     @State private var imageAspectRatio: CGFloat?
     @State private var feed: Feed?
     @State private var currentPage: Int = 0
-    @State private var hideImage = false
 
     @ViewBuilder
     private var feedAvatarView: some View {
@@ -127,45 +126,35 @@ struct PhotosArticleCard: View {
                     }
                     .padding(.bottom, 10)
                 }
-            } else if !hideImage, let imageURL = article.imageURL, let url = URL(string: imageURL) {
+            } else if let photoImage, article.imageURL != nil {
                 let effectiveRatio = max(imageAspectRatio ?? 4.0/5.0, 4.0/5.0)
-                CachedAsyncImage(url: url) {
-                    Rectangle()
-                        .fill(.secondary.opacity(0.1))
-                        .aspectRatio(4.0/5.0, contentMode: .fit)
-                }
-                .aspectRatio(effectiveRatio, contentMode: .fit)
-                .frame(maxWidth: .infinity)
-                .clipped()
-                .allowsHitTesting(false)
-                .overlay {
-                    if article.url.contains("/reel/") {
-                        ArticleLink(article: article, onShowYouTubePlayer: {
-                            youTubeArticle = $0
-                        }, label: {
-                            Image(systemName: "play.fill")
-                                .font(.title)
-                                .foregroundStyle(.primary)
-                                .padding(16)
-                                .background(.ultraThinMaterial, in: .circle)
-                                .glassEffect(.regular.interactive(), in: .circle)
-                        })
-                        .buttonStyle(.plain)
+                Color.clear
+                    .aspectRatio(effectiveRatio, contentMode: .fit)
+                    .overlay {
+                        Image(uiImage: photoImage)
+                            .resizable()
+                            .aspectRatio(contentMode: .fill)
                     }
-                }
-                .task {
-                    let loaded = await CachedAsyncImage<EmptyView>.loadImage(from: url)
-                    photoImage = loaded
-                    if let loaded, loaded.size.height > 0 {
-                        imageAspectRatio = loaded.size.width / loaded.size.height
-                        let pixelWidth = loaded.size.width * loaded.scale
-                        let pixelHeight = loaded.size.height * loaded.scale
-                        if pixelWidth <= 100 && pixelHeight <= 100 {
-                            hideImage = true
+                    .frame(maxWidth: .infinity)
+                    .clipped()
+                    .allowsHitTesting(false)
+                    .overlay {
+                        if article.url.contains("/reel/") {
+                            ArticleLink(article: article, onShowYouTubePlayer: {
+                                youTubeArticle = $0
+                            }, label: {
+                                Image(systemName: "play.fill")
+                                    .font(.title)
+                                    .foregroundStyle(.primary)
+                                    .padding(16)
+                                    .background(.ultraThinMaterial, in: .circle)
+                                    .glassEffect(.regular.interactive(), in: .circle)
+                            })
+                            .buttonStyle(.plain)
                         }
                     }
-                }
-                .padding(.bottom, 10)
+                    .padding(.bottom, 10)
+                    .transition(.opacity)
             }
 
             // Article caption / title (tapping opens the article)
@@ -251,6 +240,21 @@ struct PhotosArticleCard: View {
                 skipFaviconInset = loadedFeed.isVideoFeed || loadedFeed.isXFeed || loadedFeed.isInstagramFeed
                     || FaviconNoInsetDomains.shouldUseFullImage(feedDomain: loadedFeed.domain)
                 favicon = await FaviconCache.shared.favicon(for: loadedFeed)
+            }
+        }
+        .task(id: article.imageURL) {
+            guard article.carouselImageURLs.count <= 1,
+                  let imageURL = article.imageURL,
+                  let url = URL(string: imageURL) else { return }
+            let loaded = await CachedAsyncImage<EmptyView>.loadImage(from: url)
+            guard !Task.isCancelled, let loaded, loaded.size.height > 0 else { return }
+            let pixelWidth = loaded.size.width * loaded.scale
+            let pixelHeight = loaded.size.height * loaded.scale
+            guard pixelWidth > 100 || pixelHeight > 100 else { return }
+            let aspect = loaded.size.width / loaded.size.height
+            withAnimation(.easeOut(duration: 0.2)) {
+                imageAspectRatio = aspect
+                photoImage = loaded
             }
         }
     }

--- a/SakuraRSS/Views/Shared/Feed Display Styles/Scroll/ScrollArticlePage.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/Scroll/ScrollArticlePage.swift
@@ -21,6 +21,7 @@ struct ScrollArticlePage: View {
     @State private var acronymIcon: UIImage?
     @State private var feedName: String?
     @State private var isVideoFeed = false
+    @State private var isSocialFeed = false
     @State private var backgroundImage: UIImage?
     @State private var showSafari = false
 
@@ -76,6 +77,7 @@ struct ScrollArticlePage: View {
                 feed = loadedFeed
                 feedName = loadedFeed.title
                 isVideoFeed = loadedFeed.isVideoFeed || loadedFeed.isXFeed || loadedFeed.isInstagramFeed
+                isSocialFeed = loadedFeed.isSocialFeed
                 if let data = loadedFeed.acronymIcon {
                     acronymIcon = UIImage(data: data)
                 }
@@ -118,12 +120,19 @@ struct ScrollArticlePage: View {
             Rectangle()
                 .fill(bgColor)
             if let favicon {
-                Image(uiImage: favicon)
+                let iconImage = Image(uiImage: favicon)
                     .resizable()
-                    .aspectRatio(contentMode: .fit)
+                    .aspectRatio(contentMode: isSocialFeed ? .fill : .fit)
                     .frame(width: pageSize.width * 0.5, height: pageSize.width * 0.5)
-                    .opacity(isDark ? 0.6 : 0.4)
-                    .offset(y: -pageSize.height * 0.1)
+                Group {
+                    if isSocialFeed {
+                        iconImage.clipShape(Circle())
+                    } else {
+                        iconImage
+                    }
+                }
+                .opacity(isDark ? 0.6 : 0.4)
+                .offset(y: -pageSize.height * 0.1)
             }
             LinearGradient(
                 colors: [bgColor.opacity(0), bgColor],

--- a/SakuraRSS/Views/Shared/Feed Display Styles/Scroll/ScrollArticlePage.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/Scroll/ScrollArticlePage.swift
@@ -21,14 +21,10 @@ struct ScrollArticlePage: View {
     @State private var acronymIcon: UIImage?
     @State private var feedName: String?
     @State private var isVideoFeed = false
-    @State private var hideImage = false
+    @State private var backgroundImage: UIImage?
     @State private var showSafari = false
 
     @Namespace private var headerNamespace
-
-    private var hasArticleImage: Bool {
-        article.imageURL != nil && !hideImage
-    }
 
     var body: some View {
         ZStack(alignment: .bottom) {
@@ -86,25 +82,31 @@ struct ScrollArticlePage: View {
                 favicon = await FaviconCache.shared.favicon(for: loadedFeed)
             }
         }
+        .task(id: article.imageURL) {
+            guard let urlString = article.imageURL, let url = URL(string: urlString) else { return }
+            let image = await CachedAsyncImage<EmptyView>.loadImage(from: url)
+            guard !Task.isCancelled, let image else { return }
+            let pixelWidth = image.size.width * image.scale
+            let pixelHeight = image.size.height * image.scale
+            guard pixelWidth > 100 || pixelHeight > 100 else { return }
+            withAnimation(.easeOut(duration: 0.3)) {
+                backgroundImage = image
+            }
+        }
     }
 
     // MARK: Background
 
     @ViewBuilder
     private var backgroundLayer: some View {
-        if hasArticleImage, let urlString = article.imageURL, let url = URL(string: urlString) {
-            CachedAsyncImage(url: url, alignment: .center) { image in
-                let pixelWidth = image.size.width * image.scale
-                let pixelHeight = image.size.height * image.scale
-                if pixelWidth <= 100 && pixelHeight <= 100 {
-                    hideImage = true
-                }
-            } placeholder: {
-                faviconBackground
-            }
-            .scaledToFill()
-        } else {
+        ZStack {
             faviconBackground
+            if let backgroundImage {
+                Image(uiImage: backgroundImage)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .transition(.opacity)
+            }
         }
     }
 

--- a/SakuraRSS/Views/Shared/FeedIconPlaceholder.swift
+++ b/SakuraRSS/Views/Shared/FeedIconPlaceholder.swift
@@ -1,0 +1,78 @@
+import SwiftUI
+
+/// Placeholder tile drawn wherever an article has no cover image.
+/// Fills the tile with the favicon's average color and centers the
+/// feed icon (favicon, acronym icon, or first-letter fallback).
+/// Social-feed favicons, which are usually profile photos, are
+/// clipped into a circle so they read as avatars rather than squares.
+struct FeedIconPlaceholder: View {
+
+    enum Fallback {
+        case initials
+        case symbol(String)
+    }
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    let favicon: UIImage?
+    let acronymIcon: UIImage?
+    let feedName: String?
+    let isSocialFeed: Bool
+    let iconSize: CGFloat
+    var cornerRadius: CGFloat = 0
+    var fallback: Fallback = .initials
+
+    var body: some View {
+        let isDark = colorScheme == .dark
+        let bgColor = favicon?.cardBackgroundColor(isDarkMode: isDark)
+            ?? (isDark ? Color(white: 0.15) : Color(white: 0.9))
+
+        ZStack {
+            if cornerRadius > 0 {
+                RoundedRectangle(cornerRadius: cornerRadius).fill(bgColor)
+            } else {
+                Rectangle().fill(bgColor)
+            }
+            iconView
+                .frame(width: iconSize, height: iconSize)
+        }
+    }
+
+    @ViewBuilder
+    private var iconView: some View {
+        if let favicon {
+            if isSocialFeed {
+                Image(uiImage: favicon)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .clipShape(Circle())
+            } else {
+                Image(uiImage: favicon)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+            }
+        } else if let acronymIcon {
+            Image(uiImage: acronymIcon)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+        } else {
+            fallbackView
+        }
+    }
+
+    @ViewBuilder
+    private var fallbackView: some View {
+        switch fallback {
+        case .initials:
+            if let feedName, let letter = feedName.first {
+                Text(String(letter).uppercased())
+                    .font(.system(size: iconSize * 0.6, weight: .semibold))
+                    .foregroundStyle(.secondary)
+            }
+        case .symbol(let name):
+            Image(systemName: name)
+                .font(.system(size: iconSize * 0.75, weight: .light))
+                .foregroundStyle(.tertiary)
+        }
+    }
+}

--- a/Shared/Database Manager/DatabaseManager.swift
+++ b/Shared/Database Manager/DatabaseManager.swift
@@ -110,6 +110,7 @@ nonisolated final class DatabaseManager: @unchecked Sendable {
     private init() {
         do {
             database = try Connection(Self.databasePath)
+            try Self.applyConnectionPragmas(database)
             try createTables()
             fixupIfVersionChanged()
             invalidateStaleParserCache()
@@ -124,7 +125,19 @@ nonisolated final class DatabaseManager: @unchecked Sendable {
     /// Used after restoring a backup file to the database path.
     func reconnect() throws {
         database = try Connection(Self.databasePath)
+        try Self.applyConnectionPragmas(database)
         try createTables()
+    }
+
+    /// Switches the connection to WAL mode and raises the busy timeout so
+    /// main-thread reads from view bodies don't stall while background
+    /// NLP or refresh tasks hold a write transaction. Rollback-journal
+    /// mode locks the whole file; WAL lets readers progress concurrently
+    /// with a single writer, which is the access pattern this app has.
+    private static func applyConnectionPragmas(_ connection: Connection) throws {
+        try connection.run("PRAGMA journal_mode = WAL")
+        try connection.run("PRAGMA synchronous = NORMAL")
+        connection.busyTimeout = 5.0
     }
 
     private func invalidateStaleParserCache() {


### PR DESCRIPTION
## Summary

- Fix mark-as-read on scroll not updating the views. Article list views query through `feedManager.articles(for:limit:)` and similar methods that touch `dataRevision`, so mutating the in-memory `articles` array alone did not trigger a re-render, and the DB write was running on a detached task so any other refetch would still see stale rows. Persist the batched mark-as-read write synchronously and bump `dataRevision` so the next render sees the flipped rows.
- Replace the `hideImage` collapse-after-load pattern in `FeedArticleRow`, `CardView`, `PhotosArticleCard`, and `ScrollArticlePage` with a preload `.task` that publishes a `UIImage` state only once the pixel size clears the tiny threshold. The image now fades in over the favicon/placeholder layer via an opacity transition; articles with no image, a failed load, or a too-small image never reveal the image layer and no longer flash a placeholder.

## Test plan

- [ ] Turn on Display → Scroll Mark As Read, scroll down past a handful of unread items, stop, and verify those rows redraw as read (title color/weight updates, unread dot hides) without needing to refresh or navigate away.
- [ ] Pull to refresh — staged read rows should clear as before.
- [ ] Scroll a feed containing a mix of image-bearing, image-less, and tiny-favicon-as-image articles. Rows without valid images should render without a placeholder flash or collapse; valid images should fade in smoothly.
- [ ] Open the Cards, Photos, and Scroll styles against a feed with a broken/small `imageURL` and confirm the fallback favicon-tinted background stays stable (no brief gray placeholder).


---
_Generated by [Claude Code](https://claude.ai/code/session_018SuKwNukt8Uj654pzm7zku)_