### PR TITLE
Remove verbose comments and trim docstrings across source

### DIFF
--- a/Add Feed/ActionViewController.swift
+++ b/Add Feed/ActionViewController.swift
@@ -163,7 +163,6 @@ struct ActionExtensionView: View {
 
         model.status = .searchingDomain(host)
 
-        // Try page URL discovery first (handles social media profiles and page-level feeds)
         let pageFeeds = await FeedDiscovery.shared.discoverFeeds(fromPageURL: url)
         if !pageFeeds.isEmpty {
             model.discoveredFeeds = pageFeeds
@@ -171,7 +170,6 @@ struct ActionExtensionView: View {
             return
         }
 
-        // Fall back to domain-level discovery
         let feeds = await FeedDiscovery.shared.discoverFeeds(forDomain: host)
 
         if feeds.isEmpty {

--- a/Feeds/Article Extractor/ArticleExtractor+AMP.swift
+++ b/Feeds/Article Extractor/ArticleExtractor+AMP.swift
@@ -6,9 +6,7 @@ extension ArticleExtractor {
     private static let googleAMPHosts: Set<String> = ["google.com", "www.google.com"]
     private static let googleAMPPathPrefix = "/amp/s/"
 
-    /// Unwraps Google AMP viewer URLs (`https://www.google.com/amp/s/<host>/<path>`)
-    /// to the canonical URL they wrap.  Returns the input unchanged for
-    /// non-AMP URLs.
+    /// Unwraps `google.com/amp/s/<host>/<path>` to the canonical URL.
     static func unwrapGoogleAMPURL(_ url: URL) -> URL {
         guard let host = url.host?.lowercased(),
               googleAMPHosts.contains(host) else {
@@ -17,15 +15,11 @@ extension ArticleExtractor {
         let path = url.path
         guard path.hasPrefix(googleAMPPathPrefix) else { return url }
         let trimmed = String(path.dropFirst(googleAMPPathPrefix.count))
-        // trimmed is "<host>/<path>" — prepend scheme.
         let candidate = "https://\(trimmed)"
         return URL(string: candidate) ?? url
     }
 
-    /// Scans the document for `<link rel="amphtml" href="…">` and returns
-    /// the first such URL resolved against the base URL.  AMP pages have
-    /// mechanically cleaner markup that extracts better when the canonical
-    /// page is JS-heavy.
+    /// Returns the first `<link rel="amphtml">` URL resolved against baseURL.
     static func amphtmlURL(from html: String, baseURL: URL) -> URL? {
         guard let doc = try? SwiftSoup.parse(html, baseURL.absoluteString),
               let link = try? doc.select("link[rel=amphtml]").first(),
@@ -35,9 +29,7 @@ extension ArticleExtractor {
         return URL(string: href, relativeTo: baseURL)?.absoluteURL
     }
 
-    /// Treats `<amp-video>` and `<amp-youtube>` elements as regular `<video>`
-    /// and YouTube embeds by rewriting them in-place.  Call before
-    /// `promoteInlineEmbeds`.
+    /// Rewrites `<amp-*>` elements as their regular HTML counterparts. Call before `promoteInlineEmbeds`.
     static func normalizeAMPElements(in doc: Document) {
         if let ampYouTubes = try? doc.select("amp-youtube") {
             for element in ampYouTubes {

--- a/Feeds/Article Extractor/ArticleExtractor+BlockCollection.swift
+++ b/Feeds/Article Extractor/ArticleExtractor+BlockCollection.swift
@@ -45,8 +45,6 @@ extension ArticleExtractor {
         if paragraphs.isEmpty {
             let text = try textContent(of: element, baseURL: baseURL)
             if text.isEmpty { return [] }
-            // If the text contains paragraph breaks (e.g. Markdown content
-            // or text with <br><br>), split into separate paragraphs.
             let split = text.components(separatedBy: "\n\n")
                 .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
                 .filter { !$0.isEmpty }
@@ -56,10 +54,7 @@ extension ArticleExtractor {
         return paragraphs
     }
 
-    /// Attempts to extract and resolve an image URL from an element.
-    /// Handles `<img>`, `<amp-img>`, and `<picture>` tags, and uses
-    /// `bestImageURL` to honor `srcset` / `data-src` / `data-lazy-src`.
-    /// Returns the resolved URL string, or nil if the image should be skipped.
+    /// Extracts and resolves the best image URL from an `<img>`, `<amp-img>`, or `<picture>`.
     static func extractImageSrc(
         from element: Element, tag: String, baseURL: URL?
     ) -> String? {
@@ -90,10 +85,7 @@ extension ArticleExtractor {
     }
 
     // swiftlint:disable function_body_length cyclomatic_complexity
-    /// Walks the DOM tree collecting text from block-level elements.
-    /// Recurses into non-block wrappers (div, section, etc.) so that
-    /// nested blocks like `<div><p>…</p></div>` don't produce duplicates.
-    /// Treats leaf divs (divs with no block-level children) as paragraphs.
+    /// Walks the DOM collecting text from block-level elements and leaf wrappers.
     static func collectBlocks(
         from element: Element,
         into paragraphs: inout [String],
@@ -125,7 +117,6 @@ extension ArticleExtractor {
                 }
             } else if tag == "figure" {
                 if let resolved = extractImageSrc(from: child, tag: tag, baseURL: baseURL) {
-                    // Check if the image inside the figure is wrapped in a link
                     let linkHref = try? child.select("a[href]").first()?.attr("href")
                     let suffix = linkSuffix(for: linkHref, baseURL: baseURL)
                     #if DEBUG
@@ -172,9 +163,8 @@ extension ArticleExtractor {
                     #endif
                 }
             } else if blockElements.contains(tag) || isLeafBlock(child) {
-                // Fast-path: paragraphs injected by `promoteInlineEmbeds`
-                // contain only an embed marker.  Skip `textContent` so
-                // `ArticleMarker.escape` doesn't mangle the marker delimiters.
+                // Skip textContent for embed-marker paragraphs so
+                // ArticleMarker.escape doesn't mangle the delimiters.
                 if let rawText = try? child.text(),
                    let marker = embedMarkerParagraph(rawText) {
                     paragraphs.append(marker)
@@ -219,8 +209,7 @@ extension ArticleExtractor {
     }
     // swiftlint:enable function_body_length cyclomatic_complexity
 
-    /// Builds the `{{IMGLINK}}…{{/IMGLINK}}` suffix for an image block when
-    /// the image is wrapped in a link.
+    /// Builds an `{{IMGLINK}}` suffix when an image is wrapped in a link.
     static func linkSuffix(for href: String?, baseURL: URL?) -> String {
         guard let href, !href.isEmpty,
               let resolved = resolveURL(href, against: baseURL) else {
@@ -229,8 +218,7 @@ extension ArticleExtractor {
         return "{{IMGLINK}}\(resolved){{/IMGLINK}}"
     }
 
-    /// Detects non-`<pre>` code block containers (e.g. Code Hike's
-    /// `<div class="ch-codeblock">` or GitHub's `<div class="highlight">`).
+    /// Detects non-`<pre>` code block containers like `.ch-codeblock` or `.highlight`.
     static func isCodeBlockWrapper(_ element: Element) -> Bool {
         let className = (try? element.className()) ?? ""
         let codeBlockClasses = [
@@ -243,8 +231,7 @@ extension ArticleExtractor {
         return false
     }
 
-    /// A wrapper element (div, section, span, etc.) that contains no nested
-    /// block-level or structural children should be treated as a leaf paragraph.
+    /// True when a wrapper has no block-level or structural children and should be a paragraph.
     static func isLeafBlock(_ element: Element) -> Bool {
         let structuralTags: Set<String> = ["div", "section", "article", "main", "aside"]
         for child in element.children() {

--- a/Feeds/Article Extractor/ArticleExtractor+CodeContent.swift
+++ b/Feeds/Article Extractor/ArticleExtractor+CodeContent.swift
@@ -3,10 +3,8 @@ import SwiftSoup
 
 extension ArticleExtractor {
 
-    /// Extracts the raw text content from a code block element (`<pre>`,
-    /// or a code block wrapper div), preserving whitespace and newlines.
+    /// Extracts raw text from a code block element, preserving whitespace and newlines.
     static func codeContent(of element: Element) throws -> String {
-        // Find the innermost code element, or use the element itself
         let source: Element
         if let codeChild = try? element.select("code").first() {
             source = codeChild
@@ -16,8 +14,8 @@ extension ArticleExtractor {
             source = element
         }
 
-        // For elements with line-oriented children (e.g. Code Hike uses
-        // <div> per line inside <code>), extract text line by line.
+        // Code Hike-style blocks use one <div> per line inside <code>,
+        // so extract line-by-line when children are line divs.
         let directDivs = source.children().filter {
             $0.tagName().lowercased() == "div"
         }
@@ -29,7 +27,6 @@ extension ArticleExtractor {
             return ArticleMarker.escape(decoded)
         }
 
-        // Standard <pre>/<pre><code> - use inner HTML
         var html = try source.html()
         html = html.replacingOccurrences(
             of: #"<br\s*/?>"#, with: "\n", options: .regularExpression

--- a/Feeds/Article Extractor/ArticleExtractor+Embeds.swift
+++ b/Feeds/Article Extractor/ArticleExtractor+Embeds.swift
@@ -3,11 +3,8 @@ import SwiftSoup
 
 extension ArticleExtractor {
 
-    /// Pre-processes the document to convert supported social embeds
-    /// (YouTube, X/Twitter) into plain-text marker paragraphs that survive
-    /// noise removal and text extraction.  Must run *before* `removeNoise`
-    /// because the noise selectors would otherwise strip twitter-tweet
-    /// blockquotes and YouTube iframes entirely.
+    /// Converts supported social embeds into marker paragraphs.
+    /// Must run before `removeNoise` so embed elements aren't stripped.
     static func promoteInlineEmbeds(in doc: Document, baseURL: URL? = nil) {
         promoteYouTubeEmbeds(in: doc)
         promoteXEmbeds(in: doc)
@@ -17,7 +14,6 @@ extension ArticleExtractor {
     // MARK: - YouTube
 
     private static func promoteYouTubeEmbeds(in element: Element) {
-        // <iframe src=".../embed/VIDEO_ID"> - canonical YouTube embed
         if let iframes = try? element.select("iframe[src]") {
             for iframe in iframes {
                 guard let src = try? iframe.attr("src"),
@@ -29,7 +25,6 @@ extension ArticleExtractor {
             }
         }
 
-        // <lite-youtube videoid="..."> - lazy-loader custom element
         if let liteElements = try? element.select("lite-youtube[videoid]") {
             for lite in liteElements {
                 guard let videoID = try? lite.attr("videoid"),
@@ -39,15 +34,12 @@ extension ArticleExtractor {
             }
         }
 
-        // <div data-youtube-id="..."> / <div data-video-id="..."> on
-        // YouTube-hosted player shells
         if let ytShells = try? element.select(
             "div[data-youtube-id], div[data-youtube-video-id]"
         ) {
             for shell in ytShells {
                 // SwiftSoup's `attr` returns "" for missing attributes, so
-                // we can't use nil-coalescing to select the first non-empty
-                // attribute value.
+                // nil-coalescing cannot select the first non-empty value.
                 var videoID = (try? shell.attr("data-youtube-id")) ?? ""
                 if videoID.isEmpty {
                     videoID = (try? shell.attr("data-youtube-video-id")) ?? ""
@@ -58,12 +50,9 @@ extension ArticleExtractor {
             }
         }
 
-        // Bare <a href=".../watch?v=ID"> that's the sole content of a
-        // paragraph (common in blog posts) - treat as an embed too.
         if let anchors = try? element.select("p > a[href], figure > a[href]") {
             for anchor in anchors {
                 guard let parent = anchor.parent() else { continue }
-                // Only one child, an anchor, with visible text == the href
                 let siblingCount = parent.children().size()
                 guard siblingCount == 1 else { continue }
                 guard let href = try? anchor.attr("href"),
@@ -72,8 +61,8 @@ extension ArticleExtractor {
                 }
                 let text = (try? anchor.text()) ?? ""
                 let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-                // Only collapse if the visible link text is the URL itself.
-                // Otherwise the link has meaningful anchor text and should stay.
+                // Only collapse when link text is the URL itself; otherwise
+                // the anchor text is meaningful and should remain.
                 guard trimmed == href || trimmed.isEmpty else { continue }
                 replaceWithMarker(element: parent,
                                   marker: "{{YOUTUBE}}\(videoID){{/YOUTUBE}}")
@@ -81,9 +70,7 @@ extension ArticleExtractor {
         }
     }
 
-    /// Extracts a YouTube video ID from an embed URL like
-    /// `https://www.youtube.com/embed/VIDEO_ID?...` or
-    /// `https://www.youtube-nocookie.com/embed/VIDEO_ID`.
+    /// Extracts a YouTube video ID from a `/embed/VIDEO_ID` style URL.
     static func youTubeVideoID(fromEmbedURL src: String) -> String? {
         let lowered = src.lowercased()
         let isYT = lowered.contains("youtube.com/embed/")
@@ -96,8 +83,7 @@ extension ArticleExtractor {
         return id.isEmpty ? nil : id
     }
 
-    /// Extracts a YouTube video ID from a watch or short URL like
-    /// `https://www.youtube.com/watch?v=ID` or `https://youtu.be/ID`.
+    /// Extracts a YouTube video ID from a watch, shorts, or youtu.be URL.
     static func youTubeVideoID(fromWatchURL src: String) -> String? {
         guard let url = URL(string: absoluteURLString(src)),
               let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
@@ -121,7 +107,6 @@ extension ArticleExtractor {
     // MARK: - X / Twitter
 
     private static func promoteXEmbeds(in element: Element) {
-        // <blockquote class="twitter-tweet"> with a trailing <a href="…/status/ID">
         if let blockquotes = try? element.select("blockquote.twitter-tweet") {
             for blockquote in blockquotes {
                 guard let anchor = xStatusAnchor(in: blockquote),
@@ -134,7 +119,6 @@ extension ArticleExtractor {
             }
         }
 
-        // Twitter/X iframe embeds (platform.twitter.com/embed/Tweet.html?id=…)
         if let iframes = try? element.select("iframe[src]") {
             for iframe in iframes {
                 guard let src = try? iframe.attr("src"),
@@ -156,8 +140,6 @@ extension ArticleExtractor {
             }
         }
 
-        // Bare <a href="https://x.com/user/status/ID"> that's the sole child
-        // of a paragraph - promote to inline embed.
         if let anchors = try? element.select("p > a[href], figure > a[href]") {
             for anchor in anchors {
                 guard let parent = anchor.parent() else { continue }
@@ -185,8 +167,7 @@ extension ArticleExtractor {
         return nil
     }
 
-    /// Returns a canonicalized x.com status URL string, or nil if the input
-    /// isn't a recognizable X/Twitter status URL.
+    /// Returns a canonicalized x.com status URL, or nil if unrecognizable.
     static func normalizedXStatusURL(_ src: String) -> String? {
         guard let url = URL(string: absoluteURLString(src)),
               let host = url.host?.lowercased() else {
@@ -196,7 +177,6 @@ extension ArticleExtractor {
             || host == "twitter.com" || host.hasSuffix(".twitter.com")
             || host == "mobile.twitter.com" || host == "mobile.x.com"
         guard isXHost else { return nil }
-        // Expect /user/status/ID or /i/status/ID (or /i/web/status/ID)
         let parts = url.path.split(separator: "/").map(String.init)
         guard let statusIndex = parts.firstIndex(of: "status"),
               statusIndex + 1 < parts.count else {
@@ -217,9 +197,7 @@ extension ArticleExtractor {
 
     // MARK: - Marker detection
 
-    /// Returns the sole embed marker (`{{YOUTUBE}}…{{/YOUTUBE}}` or
-    /// `{{XPOST}}…{{/XPOST}}`) if `text` contains only a single marker
-    /// and nothing else (ignoring surrounding whitespace).
+    /// Returns the marker if `text` is exactly a single embed marker.
     static func embedMarkerParagraph(_ text: String) -> String? {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
@@ -238,38 +216,28 @@ extension ArticleExtractor {
 
     // MARK: - Helpers
 
-    /// Ensures a URL string has a scheme.  Protocol-relative URLs (`//…`)
-    /// are resolved to `https:` so downstream parsing sees an absolute host.
+    /// Resolves protocol-relative URLs to `https:` so downstream parsing sees an absolute host.
     private static func absoluteURLString(_ src: String) -> String {
         if src.hasPrefix("//") { return "https:\(src)" }
         return src
     }
 
-    /// Replaces a DOM element with a `<p>` containing only a marker string.
-    /// Using `<p>` keeps the marker isolated as its own paragraph during
-    /// block collection, preventing surrounding text from merging in.
-    /// Walks up through common embed wrappers (`<figure>`, `<div>` etc.)
-    /// when the wrapper has no other meaningful content, so the marker
-    /// surfaces at the article-body level.
+    /// Replaces a DOM element with a `<p>` containing only the marker string.
+    /// Hoists through single-child wrapper elements so the marker surfaces at article level.
     private static func replaceWithMarker(element: Element, marker: String) {
         let target = outermostEmbedWrapper(for: element)
         do {
             try target.before("<p>\(marker)</p>")
             try target.remove()
         } catch {
-            // Best-effort: a failed promotion leaves the original element,
-            // which noise removal will likely strip anyway.
         }
     }
 
-    /// Walks up through wrapper elements (`<figure>`, `<div>`, `<aside>`,
-    /// `<p>`) that contain *only* the embed element (ignoring whitespace).
-    /// Stops as soon as the parent has other content.
+    /// Walks up through single-child wrapper elements around an embed.
     private static func outermostEmbedWrapper(for element: Element) -> Element {
         let wrapperTags: Set<String> = ["figure", "div", "aside", "p", "span"]
         var current: Element = element
         while let parent = current.parent(), wrapperTags.contains(parent.tagName().lowercased()) {
-            // Only hoist when current is the parent's sole significant child.
             let siblings = parent.children().filter { $0 !== current }
             let siblingHasText = siblings.contains { element in
                 let text = ((try? element.text()) ?? "")
@@ -277,7 +245,6 @@ extension ArticleExtractor {
                 return !text.isEmpty
             }
             if siblingHasText { break }
-            // Also check for raw text nodes on the parent.
             let ownText = parent.ownText()
                 .trimmingCharacters(in: .whitespacesAndNewlines)
             if !ownText.isEmpty { break }

--- a/Feeds/Article Extractor/ArticleExtractor+Heuristics.swift
+++ b/Feeds/Article Extractor/ArticleExtractor+Heuristics.swift
@@ -2,10 +2,7 @@ import Foundation
 
 extension ArticleExtractor {
 
-    /// Heuristic signal that an HTML payload is a JavaScript-rendered shell.
-    /// When this is true and the plain-HTTP extraction yielded very little
-    /// text, the caller should retry via the WebView extractor so hydration
-    /// has a chance to run.
+    /// True when the HTML looks like a JS-rendered shell (retry via WebView).
     static func looksJSRendered(_ html: String) -> Bool {
         let skeletonMarkers = [
             #"<div id="__next">\s*</div>"#,
@@ -42,9 +39,7 @@ extension ArticleExtractor {
         return false
     }
 
-    /// Returns `true` when the extracted text is short, has few paragraphs,
-    /// or is missing the usual structural signals of a real article body.
-    /// Used to decide whether to escalate from plain HTTP fetch to WebView.
+    /// True when extracted text is too short or sparse to trust; triggers WebView fallback.
     static func isWeakExtraction(_ text: String?) -> Bool {
         guard let text, !text.isEmpty else { return true }
         let paragraphCount = text.components(separatedBy: "\n\n").count

--- a/Feeds/Article Extractor/ArticleExtractor+Metadata.swift
+++ b/Feeds/Article Extractor/ArticleExtractor+Metadata.swift
@@ -3,9 +3,7 @@ import SwiftSoup
 
 extension ArticleExtractor {
 
-    /// Extracts structured metadata (author, publish date, lead image) from
-    /// a document.  Runs **before** noise removal so byline strippers don't
-    /// race us to the data.
+    /// Extracts author, publish date, and lead image. Call before `removeNoise`.
     static func extractMetadata(from doc: Document) -> ArticleMetadata {
         var metadata = ArticleMetadata()
 

--- a/Feeds/Article Extractor/ArticleExtractor+Noise.swift
+++ b/Feeds/Article Extractor/ArticleExtractor+Noise.swift
@@ -476,7 +476,6 @@ extension ArticleExtractor {
         "template"
     ]
 
-    /// Class/ID substrings that strongly indicate non-article content.
     private static let noiseClassPatterns = [
         "related", "recommend", "suggested", "popular",
         "trending", "sidebar", "widget", "promo",
@@ -547,19 +546,12 @@ extension ArticleExtractor {
         "entry-tags", "entry-categories", "category-links"
     ]
 
-    /// Noise-removal modes.  The aggressive `.global` pass runs on the
-    /// whole document and is free to strip broad selectors; `.local` runs
-    /// on the already-selected main content element and refuses to drop
-    /// selectors that might appear inside legitimate paragraphs.
+    /// `.global` strips broadly across the document; `.local` is conservative inside an already-selected article.
     enum NoiseScope {
         case global
         case local
     }
 
-    /// Class/ID substrings that would be too aggressive to remove once the
-    /// article container has been isolated.  Matches the bare tokens that
-    /// legitimate inline spans (`<span class="share">value</span>`) or
-    /// image captions might use.
     private static let unsafeInsideArticle: Set<String> = [
         "share-bar", "share-buttons", "share-tools",
         "share-this", "post-share", "entry-share",
@@ -597,10 +589,8 @@ extension ArticleExtractor {
 
         removeNoiseByClassPatterns(from: element, scope: scope)
         removeAdvertisementTextBlocks(from: element)
-        // Heuristic passes (see ArticleExtractor+NoiseHeuristics.swift).
-        // Aggressive list/section sweeps only run on the full document so
-        // scoped removal doesn't nuke legitimate inline content inside the
-        // already-isolated article body.
+        // Aggressive list/section sweeps only run on the full document to
+        // avoid nuking legitimate inline content inside isolated articles.
         if scope == .global {
             removeMenuLists(from: element)
             removeSuggestionSections(from: element)
@@ -610,7 +600,6 @@ extension ArticleExtractor {
         removeEmptyContainers(from: element)
     }
 
-    /// Removes elements whose class or id attribute contains known noise substrings.
     private static func removeNoiseByClassPatterns(
         from element: Element,
         scope: NoiseScope = .global
@@ -630,32 +619,26 @@ extension ArticleExtractor {
                 }
             }
         } catch {
-            // Best-effort; failures are non-critical
         }
     }
 
-    /// Returns true when the trimmed, lowercased text matches a known ad label.
     static func isAdvertisementText(_ text: String) -> Bool {
         AdvertisementTextFilter.isAdvertisementText(text)
     }
 
-    /// Removes block-level elements (`<p>`, `<div>`, `<span>`) whose only
-    /// text content is a known ad label such as "ADVERTISEMENT".
     private static func removeAdvertisementTextBlocks(from element: Element) {
         do {
             let candidates = try element.select("p, div, span")
             for element in candidates {
                 let text = try element.text()
                 guard isAdvertisementText(text) else { continue }
-                // Only remove if the element has no meaningful children
-                // (images, videos, etc.) - just the ad label text.
+                // Keep elements containing media; only strip pure-label blocks.
                 let hasMedia = !(try element.select("img, video, picture, iframe")).isEmpty()
                 if !hasMedia {
                     try element.remove()
                 }
             }
         } catch {
-            // Best-effort; failures are non-critical
         }
     }
 

--- a/Feeds/Article Extractor/ArticleExtractor+NoiseHeuristics.swift
+++ b/Feeds/Article Extractor/ArticleExtractor+NoiseHeuristics.swift
@@ -10,9 +10,8 @@ extension ArticleExtractor {
             for list in lists {
                 let items = try list.select("li")
                 guard items.size() > 2 else { continue }
-                // Count link-bearing items rather than total <a>s / total <li>s.
-                // A decorative <li> (close button, label, search box) alongside
-                // real link items would otherwise defeat a strict ratio check.
+                // Count link-bearing items instead of total <a>s so a
+                // decorative <li> won't defeat the ratio check.
                 var linkItems = 0
                 for item in items where (try? item.select("a").first()) != nil {
                     linkItems += 1
@@ -20,19 +19,16 @@ extension ArticleExtractor {
                 guard linkItems >= 3 else { continue }
                 let totalText = try list.text()
                 let avgTextPerLinkItem = totalText.count / max(linkItems, 1)
-                // Two signals: mostly-links, and short labels per link.
                 let linkDensity = Double(linkItems) / Double(items.size())
                 if linkDensity >= 0.6 && avgTextPerLinkItem < 50 {
                     try list.remove()
                 }
             }
         } catch {
-            // Menu detection is best-effort; failures are non-critical
         }
     }
 
-    /// Detects and removes "suggestion" sections: a heading like
-    /// "Related Articles" or "You May Also Like" followed by a link-heavy block.
+    /// Removes "Related Articles" / "You May Also Like" style suggestion sections.
     static func removeSuggestionSections(from element: Element) {
         let suggestionHeadingPatterns = [
             "related", "recommended", "suggested", "you may also",
@@ -74,13 +70,10 @@ extension ArticleExtractor {
                 }
             }
         } catch {
-            // Best-effort; failures are non-critical
         }
     }
 
-    /// Heuristic: a container whose children are overwhelmingly icon-only
-    /// links or buttons (tiny text payload, many links) is almost always a
-    /// share toolbar, floating action bar, or pagination strip.
+    /// Removes containers dominated by icon-only links or buttons (share toolbars, pagination).
     static func removeIconToolbars(from element: Element) {
         do {
             let candidates = try element.select("div, nav, section, ul")
@@ -92,27 +85,21 @@ extension ArticleExtractor {
 
                 let text = (try? candidate.text()) ?? ""
                 let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-                // Average visible characters per actionable element - share
-                // toolbars and pagination rows score <=4 (often 0 with SVG
-                // icons); real prose scores much higher.
+                // Icon toolbars score <=4 chars per action; prose scores higher.
                 let avgTextPerAction = trimmed.count / max(actionableCount, 1)
                 guard avgTextPerAction <= 4 else { continue }
 
-                // Only remove shallow containers: if they wrap long-form
-                // content alongside the toolbar, we'd nuke too much.
+                // Only strip shallow containers to avoid nuking prose alongside a toolbar.
                 let paragraphCount = (try? candidate.select("p").size()) ?? 0
                 guard paragraphCount == 0 else { continue }
 
                 try candidate.remove()
             }
         } catch {
-            // Best-effort; failures are non-critical
         }
     }
 
-    /// Heuristic: a short container containing only links/buttons whose
-    /// href or text references a sharing target (facebook.com/sharer,
-    /// twitter.com/intent, mailto:?subject=…, window.print, …).
+    /// Removes short containers of share links (facebook/sharer, twitter/intent, mailto, etc.).
     static func removeShareButtonClusters(from element: Element) {
         let shareTargetPatterns = [
             "facebook.com/sharer", "facebook.com/share",
@@ -141,27 +128,23 @@ extension ArticleExtractor {
                 }
                 let ratio = Double(sharers) / Double(anchors.size())
                 guard sharers >= 2 && ratio >= 0.5 else { continue }
-                // Only drop shallow wrappers - refuse to delete a sidebar
-                // that happens to include a couple of share links.
+                // Only drop shallow wrappers so sidebars with a few share
+                // links aren't deleted wholesale.
                 let paragraphCount = (try? candidate.select("p").size()) ?? 0
                 guard paragraphCount <= 1 else { continue }
                 try candidate.remove()
             }
         } catch {
-            // Best-effort; failures are non-critical
         }
     }
 
-    /// Removes wrapper `<div>`/`<section>`/`<aside>` elements that contain
-    /// no text, no images, and no video - usually leftover placeholder
-    /// shells after ads or share buttons were stripped.
+    /// Removes wrapper containers with no text or media (leftover placeholder shells).
     static func removeEmptyContainers(from element: Element) {
         do {
             let candidates = try element.select(
                 "div, section, aside, header, footer, span"
             )
-            // Iterate in reverse so deleting a parent doesn't invalidate
-            // positions of already-seen children.
+            // Reverse iteration so parent removal doesn't invalidate positions.
             for candidate in candidates.array().reversed() {
                 let text = ((try? candidate.text()) ?? "")
                     .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -173,7 +156,6 @@ extension ArticleExtractor {
                 }
             }
         } catch {
-            // Best-effort; failures are non-critical
         }
     }
 }

--- a/Feeds/Article Extractor/ArticleExtractor+Pagination.swift
+++ b/Feeds/Article Extractor/ArticleExtractor+Pagination.swift
@@ -5,11 +5,8 @@ extension ArticleExtractor {
 
     private static let maxAdditionalPages = 4
 
-    /// Finds "next page" links on a document and fetches up to
-    /// `maxAdditionalPages` additional pages, returning their extracted
-    /// text concatenated with `\n\n` separators.  Respects the feature
-    /// flag at `UserDefaults.standard.bool(forKey: "ArticleParser.followPagination")`
-    /// (defaults to enabled — returns `false` only when explicitly disabled).
+    /// Follows "next page" links and returns concatenated extracted text.
+    /// Respects `ArticleParser.followPagination` in UserDefaults.
     static func fetchPaginatedExtras(
         from html: String,
         baseURL: URL,
@@ -51,8 +48,7 @@ extension ArticleExtractor {
         return combined.isEmpty ? nil : combined.joined(separator: "\n\n")
     }
 
-    /// Locates candidate next-page URLs from rel=next links and common
-    /// "Next" anchors.  Returns unique URLs in DOM order.
+    /// Returns unique next-page URLs from rel=next and common "Next" anchors.
     static func nextPageURLs(from html: String, baseURL: URL) -> [URL] {
         guard let doc = try? SwiftSoup.parse(html, baseURL.absoluteString) else {
             return []

--- a/Feeds/Article Extractor/ArticleExtractor+TextContent.swift
+++ b/Feeds/Article Extractor/ArticleExtractor+TextContent.swift
@@ -22,25 +22,21 @@ extension ArticleExtractor {
     static let codeOpenPlaceholder = "{{SAKURA_CODE_OPEN}}"
     static let codeClosePlaceholder = "{{SAKURA_CODE_CLOSE}}"
 
-    /// Extracts text from a block element, preserving `<br>` tags as newlines
-    /// and `<a>` tags as Markdown links.
     static let doubleLFPlaceholder = "{{SAKURA_DOUBLE_LF}}"
     static let singleLFPlaceholder = "{{SAKURA_SINGLE_LF}}"
 
+    /// Extracts text from a block element, preserving `<br>` as newlines and `<a>` as Markdown links.
     static func textContent(of element: Element, baseURL: URL? = nil) throws -> String {
         promoteLazyImageSources(in: element)
         replaceImagesInDOM(in: element, baseURL: baseURL)
         var html = try element.html()
-        // Strip <svg>…</svg> entirely - icon SVGs inside anchors (share
-        // buttons, nav arrows) leave anchors with no meaningful text, and
-        // the link-replacement regex would otherwise capture the SVG markup
-        // as "link text" and serialize the href itself as visible text.
+        // Strip <svg> entirely so icon-only anchors don't leak SVG markup
+        // as "link text" through the link-replacement regex.
         html = html.replacingOccurrences(
             of: "<svg\\b[^>]*>[\\s\\S]*?</svg>",
             with: "",
             options: [.regularExpression, .caseInsensitive]
         )
-        // Consecutive <br> tags indicate a paragraph break in poorly-structured HTML.
         html = html.replacingOccurrences(
             of: "<br\\s*/?>(\\s*<br\\s*/?>)+",
             with: doubleLFPlaceholder,
@@ -51,8 +47,7 @@ extension ArticleExtractor {
             with: singleLFPlaceholder,
             options: .regularExpression
         )
-        // Preserve literal newlines in the HTML source (e.g. Markdown content
-        // that has no <br> or <p> tags) before SwiftSoup's .text() strips them.
+        // Preserve literal newlines before SwiftSoup's .text() strips them.
         html = html.replacingOccurrences(of: "\n\n", with: doubleLFPlaceholder)
         html = html.replacingOccurrences(of: "\n", with: singleLFPlaceholder)
         html = replaceLinkedImgTags(in: html, baseURL: baseURL)
@@ -74,9 +69,7 @@ extension ArticleExtractor {
         return text.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
-    /// Rewrites lazy-loaded `<img>` and `<amp-img>` tags so their `src`
-    /// attribute holds the best available URL.  Lets the regex-based
-    /// `replaceImgTags` keep working for sites using `data-src` / `srcset`.
+    /// Rewrites lazy-loaded `<img>`/`<amp-img>` so `src` holds the best URL.
     static func promoteLazyImageSources(in element: Element) {
         guard let images = try? element.select("img, amp-img") else { return }
         for image in images {
@@ -92,10 +85,7 @@ extension ArticleExtractor {
         }
     }
 
-    /// Replaces `<img>` / `<amp-img>` / `<picture>` elements with text-only
-    /// placeholders directly in the DOM.  Avoids regex fragility on malformed
-    /// markup, nested tags, and attributes with escaped quotes.  Preserves
-    /// wrapping `<a href>` by emitting an `{{IMGLINK}}` suffix.
+    /// Replaces image elements in the DOM with text-only placeholders, keeping wrapping anchors.
     static func replaceImagesInDOM(in element: Element, baseURL: URL?) {
         guard let images = try? element.select("img, amp-img, picture") else {
             return
@@ -131,8 +121,7 @@ extension ArticleExtractor {
 
     // MARK: - HTML Tag Replacement
 
-    /// Handles `<a href="..."><img src="..."></a>` patterns, converting them to
-    /// image placeholders with link info before the separate img/link replacements run.
+    /// Converts `<a><img></a>` patterns to image placeholders with link info.
     private static func replaceLinkedImgTags(in html: String, baseURL: URL? = nil) -> String {
         guard let regex = try? NSRegularExpression(
             pattern: "<a\\s[^>]*href=[\"']([^\"']+)[\"'][^>]*>\\s*<img\\s[^>]*src=[\"']([^\"']+)[\"'][^>]*/?>\\s*</a>",
@@ -183,18 +172,15 @@ extension ArticleExtractor {
     private static func replaceLinkTags(in html: String) -> String {
         var result = html
 
-        // Remove empty links first.
         result = result.replacingOccurrences(
             of: "<a\\s[^>]*>\\s*</a>",
             with: "",
             options: .regularExpression
         )
 
-        // Replace links using NSRegularExpression so we can collapse newline
-        // placeholders inside the captured link text.  A simple
-        // `replacingOccurrences(of:with:options:.regularExpression)` substitution
-        // would preserve the placeholders verbatim, producing broken Markdown
-        // like `[\nDJIA\n46504.67\n](\url)`.
+        // Use NSRegularExpression so newline placeholders inside link text
+        // can be collapsed; a plain regex substitution would preserve them
+        // and produce broken Markdown like `[\nText\n](url)`.
         guard let regex = try? NSRegularExpression(
             pattern: "<a\\s[^>]*href=[\"']([^\"']+)[\"'][^>]*>(.+?)</a>",
             options: .caseInsensitive
@@ -206,12 +192,9 @@ extension ArticleExtractor {
         for match in matches.reversed() {
             let href = nsResult.substring(with: match.range(at: 1))
             var linkText = nsResult.substring(with: match.range(at: 2))
-            // Collapse newline placeholders inside link text to a single space.
             linkText = linkText
                 .replacingOccurrences(of: doubleLFPlaceholder, with: " ")
                 .replacingOccurrences(of: singleLFPlaceholder, with: " ")
-            // Drop links whose visible text is empty or just the href itself -
-            // typically icon-only share buttons that leave nothing to render.
             let visibleText = linkText
                 .replacingOccurrences(of: "<[^>]+>", with: "", options: .regularExpression)
                 .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -301,7 +284,6 @@ extension ArticleExtractor {
     // MARK: - Utility
 
     static func isLikelyContentImage(_ url: String) -> Bool {
-        // Skip data URIs (inline SVG placeholders, base64 spacers, etc.)
         if url.hasPrefix("data:") {
             return false
         }
@@ -319,8 +301,7 @@ extension ArticleExtractor {
         return true
     }
 
-    /// Removes `{{SUP}}…{{/SUP}}` and `{{SUB}}…{{/SUB}}` markers whose
-    /// content contains an invalid URL (either as a Markdown link or raw URL).
+    /// Removes sup/sub markers whose content contains an invalid URL.
     static func stripInvalidURLSupSub(_ text: String) -> String {
         let pattern = #"\{\{(SUP|SUB)\}\}(.+?)\{\{/(SUP|SUB)\}\}"#
         guard let regex = try? NSRegularExpression(pattern: pattern) else { return text }
@@ -335,7 +316,7 @@ extension ArticleExtractor {
                 in: content, range: NSRange(location: 0, length: (content as NSString).length)
                ) {
                 let urlString = (content as NSString).substring(with: linkMatch.range(at: 2))
-                // Footnote anchors use fragment-only URLs like "#fn1" — let them through.
+                // Footnote anchors use fragment-only URLs like "#fn1"; keep them.
                 if urlString.hasPrefix("#") { continue }
                 if URL(string: urlString) == nil {
                     result = (result as NSString).replacingCharacters(in: match.range, with: "")
@@ -377,33 +358,24 @@ extension ArticleExtractor {
         return result
     }
 
-    /// Collapses runs of empty, formatting-only, or separator-only lines so
-    /// cleaned article text doesn't render with gaping vertical gaps.
-    /// Runs after paragraph collection so inter-paragraph blank lines survive.
+    /// Collapses empty, formatting-only, or separator-only lines in extracted text.
     static func compactWhitespace(in text: String) -> String {
         var result = text
-        // Drop Markdown horizontal rules that are alone on a line.  They
-        // almost always come from navigation separators or ad blocks.
         result = result.replacingOccurrences(
             of: #"(?m)^[ \t]*(?:-{3,}|={3,}|_{3,}|\*{3,})[ \t]*$"#,
             with: "",
             options: .regularExpression
         )
-        // Lines that contain only `|`, punctuation, or bullet-like glyphs
-        // (e.g. breadcrumb "› › ›" residue) are noise.
         result = result.replacingOccurrences(
             of: #"(?m)^[ \t]*[\|\·•‣▪▫◦▶›»→・、,]+[ \t]*$"#,
             with: "",
             options: .regularExpression
         )
-        // Lines with only bold/italic markers and no real content
-        // (e.g. `**  **` or `* *`) - typically empty share buttons.
         result = result.replacingOccurrences(
             of: #"(?m)^[ \t]*(?:\*{1,3}|_{1,3})[ \t]*(?:\*{1,3}|_{1,3})?[ \t]*$"#,
             with: "",
             options: .regularExpression
         )
-        // Collapse runs of 3+ newlines back to a paragraph break.
         result = result.replacingOccurrences(
             of: "\\n{3,}",
             with: "\n\n",

--- a/Feeds/Article Extractor/ArticleExtractor+URLResolution.swift
+++ b/Feeds/Article Extractor/ArticleExtractor+URLResolution.swift
@@ -2,29 +2,21 @@ import Foundation
 
 extension ArticleExtractor {
 
-    /// Resolves a potentially relative URL string against a base URL.
-    /// Returns the resolved absolute URL string, or nil if it can't be resolved.
-    /// Tracking parameters (utm_*, fbclid, gclid, ...) are stripped so images
-    /// that differ only in tracking tags share a cache entry.
+    /// Resolves a URL against a base and strips tracking query parameters.
     static func resolveURL(_ src: String, against baseURL: URL?) -> String? {
         let decoded = htmlEntityDecodedURL(src)
-        // Already absolute
         if decoded.hasPrefix("http://") || decoded.hasPrefix("https://") {
             return stripTrackingParameters(from: decoded)
         }
-        // Protocol-relative
         if decoded.hasPrefix("//"), let url = URL(string: "https:\(decoded)") {
             return stripTrackingParameters(from: url.absoluteString)
         }
-        // Relative - needs base URL
         if let baseURL, let resolved = URL(string: decoded, relativeTo: baseURL) {
             return stripTrackingParameters(from: resolved.absoluteString)
         }
         return nil
     }
 
-    /// Percent-decodes bare `&amp;` / `&#x26;` entity sequences commonly
-    /// left in raw attribute values before handing the string to `URL`.
     private static func htmlEntityDecodedURL(_ src: String) -> String {
         guard src.contains("&") else { return src }
         return src
@@ -39,9 +31,7 @@ extension ArticleExtractor {
         "spm", "sourceid", "gs_lcrp"
     ]
 
-    /// Strips known tracking query parameters while preserving everything
-    /// else.  Improves cache-hit rate for images that differ only in their
-    /// utm_* tags between pages.
+    /// Removes utm_*, fbclid, gclid and similar tracking query parameters.
     static func stripTrackingParameters(from absoluteString: String) -> String {
         guard var components = URLComponents(string: absoluteString),
               let queryItems = components.queryItems, !queryItems.isEmpty else {
@@ -55,8 +45,7 @@ extension ArticleExtractor {
         return components.string ?? absoluteString
     }
 
-    /// Resolves relative URLs inside Markdown links (`[text](url)`) against a base URL.
-    /// Also percent-encodes spaces in link URLs.
+    /// Resolves relative URLs inside Markdown links and percent-encodes spaces.
     static func resolveMarkdownLinks(in text: String, baseURL: URL?) -> String {
         guard let baseURL else { return text }
         let pattern = #"\[([^\]]*)\]\(([^)]+)\)"#

--- a/Feeds/Article Extractor/ArticleMarker.swift
+++ b/Feeds/Article Extractor/ArticleMarker.swift
@@ -1,10 +1,7 @@
 import Foundation
 
-/// Escapes literal `{{IMG}}`/`{{CODE}}`/etc. sequences in article text so
-/// `ContentBlock.parse` doesn't misinterpret them as extractor markers.
-/// Escaped form uses U+E000/U+E001 as delimiters so it contains no
-/// `{{TOKEN}}` substring - callers checking `text.contains("{{IMG}}")`
-/// keep matching only real markers.
+/// Escapes literal `{{TOKEN}}` sequences in article text using PUA
+/// delimiters so `ContentBlock.parse` only matches real markers.
 nonisolated enum ArticleMarker {
 
     private static let table: [(literal: String, escaped: String)] = [
@@ -50,8 +47,7 @@ nonisolated enum ArticleMarker {
         return result
     }
 
-    /// Runs `regex` against `text`, retrying on the unescaped form when
-    /// the as-is pass finds nothing but PUA delimiters are present.
+    /// Matches `regex` against `text`, retrying on the unescaped form if needed.
     static func regexMatches(
         of regex: NSRegularExpression, in text: String
     ) -> (nsText: NSString, matches: [NSTextCheckingResult]) {

--- a/Feeds/Article Extractor/BotChallengeDetector.swift
+++ b/Feeds/Article Extractor/BotChallengeDetector.swift
@@ -1,9 +1,6 @@
 import Foundation
 
-/// Recognizes HTML responses that are bot-challenge interstitials
-/// (Cloudflare, Akamai, PerimeterX, …) rather than real article content.
-/// Used by the extraction pipeline to short-circuit into WebView
-/// extraction, which has a better chance of completing the challenge.
+/// Recognizes Cloudflare / Akamai / PerimeterX bot-challenge pages so extraction can fall back to WebView.
 nonisolated enum BotChallengeDetector {
 
     static let markers: [String] = [

--- a/Feeds/Article Extractor/ExtractionResult.swift
+++ b/Feeds/Article Extractor/ExtractionResult.swift
@@ -1,8 +1,5 @@
 import Foundation
 
-/// Output of an article extraction.  `text` is the marker-laden
-/// article body; `metadata` holds author / publish date / lead image
-/// when discoverable.  `paywalled` flags recognized paywall gates.
 nonisolated struct ExtractionResult {
     var text: String?
     var metadata: ArticleMetadata

--- a/Feeds/Article Extractor/PaywallDetector.swift
+++ b/Feeds/Article Extractor/PaywallDetector.swift
@@ -1,11 +1,8 @@
 import Foundation
 
-/// Detects publisher paywalls so the UI can surface a "open in Safari"
-/// banner instead of caching a truncated teaser as if it were the article.
+/// Detects paywalled articles so the UI can prompt for Safari instead of caching a teaser.
 nonisolated enum PaywallDetector {
 
-    /// Minimal textual signals — matched against the lowercased first 2 KB
-    /// of extracted text.
     static let textPatterns: [String] = [
         "subscribe to continue",
         "subscribe to keep reading",
@@ -28,8 +25,7 @@ nonisolated enum PaywallDetector {
         "this content is reserved"
     ]
 
-    /// Returns `true` when the HTTP response or the extracted text contain
-    /// recognizable paywall signals.
+    /// True when the HTTP response status or extracted text matches paywall signals.
     static func detect(
         response: URLResponse?,
         extractedText: String?
@@ -43,8 +39,7 @@ nonisolated enum PaywallDetector {
         return textPatterns.contains(where: lowered.contains)
     }
 
-    /// Returns `true` when the raw HTML includes common markup signals
-    /// for a paywall gate (regwall overlay, subscriber-only metadata).
+    /// True when raw HTML contains paywall markup like `data-paywall` or subscriber-only meta tags.
     static func htmlSuggestsPaywall(_ html: String) -> Bool {
         let lowered = html.lowercased()
         let markers = [

--- a/Feeds/Article Extractor/SiteAdapter.swift
+++ b/Feeds/Article Extractor/SiteAdapter.swift
@@ -1,17 +1,11 @@
 import Foundation
 import SwiftSoup
 
-/// A site-specific override for the generic article extractor.  Adapters
-/// run before the generic pipeline; when one matches and returns a
-/// non-nil result, the generic path is skipped.
+/// Site-specific override invoked before the generic extractor.
 protocol SiteAdapter {
-    /// Called against the request URL (if available) and the document's
-    /// canonical URL (if any) before parsing.  Hosts are matched with
-    /// `hasSuffix` semantics so subdomains pass through by default.
     func canHandle(url: URL) -> Bool
 
-    /// Extracts text + metadata from the parsed document.  Return `nil` to
-    /// fall back to the generic pipeline.
+    /// Returns extracted content, or nil to fall back to the generic pipeline.
     func extract(
         document: Document,
         baseURL: URL,
@@ -26,7 +20,6 @@ extension SiteAdapter {
     }
 }
 
-/// Central registry of adapters consulted by `ArticleExtractor`.
 enum SiteAdapterRegistry {
 
     static let all: [SiteAdapter] = [

--- a/Feeds/Article Extractor/WebViewExtractor.swift
+++ b/Feeds/Article Extractor/WebViewExtractor.swift
@@ -59,8 +59,7 @@ final class WebViewExtractor: NSObject, WKNavigationDelegate {
     // MARK: - WKNavigationDelegate
 
     func webView(_: WKWebView, didFinish _: WKNavigation!) {
-        // Page loaded successfully - cancel the load timeout
-        // and give JS frameworks time to hydrate before extracting
+        // Give JS frameworks time to hydrate before snapshotting.
         timeoutTask?.cancel()
         timeoutTask = nil
         Task {
@@ -95,7 +94,6 @@ final class WebViewExtractor: NSObject, WKNavigationDelegate {
     (function() {
         document.querySelectorAll('.sosumi').forEach(el => el.remove());
 
-        // Dismiss common consent banners / modals before snapshotting.
         const consentSelectors = [
             '#onetrust-banner-sdk', '#onetrust-consent-sdk',
             '.osano-cm-window', '.qc-cmp2-container',
@@ -117,7 +115,7 @@ final class WebViewExtractor: NSObject, WKNavigationDelegate {
             } catch (_) {}
         }
 
-        // Defeat scroll locks some consent overlays leave behind.
+        // Some consent overlays leave scroll locks on <html>/<body>.
         try {
             document.documentElement.style.overflow = 'auto';
             document.body.style.overflow = 'auto';

--- a/Feeds/Article.swift
+++ b/Feeds/Article.swift
@@ -9,7 +9,7 @@ nonisolated struct Article: Identifiable, Hashable, Sendable {
     var summary: String?
     var content: String?
     var imageURL: String?
-    /// All image URLs for Instagram carousel posts. Empty for single-image posts.
+    /// All image URLs for Instagram carousel posts.
     var carouselImageURLs: [String] = []
     var publishedDate: Date?
     var isRead: Bool
@@ -22,13 +22,11 @@ nonisolated struct Article: Identifiable, Hashable, Sendable {
         return lowered.contains("youtube.com") || lowered.contains("youtu.be")
     }
 
-    /// Whether the article URL points to a specific X/Twitter post (status).
     var isXPostURL: Bool {
         guard let parsed = URL(string: url) else { return false }
         return XProfileScraper.isXPostURL(parsed)
     }
 
-    /// Whether the article URL points to a specific Instagram post.
     var isInstagramPostURL: Bool {
         guard let parsed = URL(string: url) else { return false }
         return InstagramProfileScraper.isInstagramPostURL(parsed)
@@ -38,8 +36,7 @@ nonisolated struct Article: Identifiable, Hashable, Sendable {
         audioURL != nil
     }
 
-    /// Whether the summary has enough meaningful content to display.
-    /// Filters out placeholder text like "Comments" from Hacker News feeds.
+    /// Filters out placeholder summaries (e.g. "Comments" from Hacker News).
     var hasMeaningfulSummary: Bool {
         guard let summary else { return false }
         return summary.count >= 20

--- a/Feeds/BatchingMode.swift
+++ b/Feeds/BatchingMode.swift
@@ -1,9 +1,6 @@
 import Foundation
 
-/// Controls how the Home / Feed / List views paginate older articles behind
-/// the "Show Older Content" affordance.  Date-based modes walk backwards in
-/// fixed-size day windows; count-based modes grow a running limit by a fixed
-/// number of items; `.off` loads everything up-front with no paging.
+/// Controls how views paginate older articles (by day windows, item count, or off).
 nonisolated enum BatchingMode: String, CaseIterable, Identifiable, Sendable {
     case off
     case day1
@@ -15,8 +12,7 @@ nonisolated enum BatchingMode: String, CaseIterable, Identifiable, Sendable {
 
     var id: String { rawValue }
 
-    /// Number of days covered by one date-based batch, or `nil` for
-    /// non-date-based modes.
+    /// Days per date-based batch, or `nil`.
     var chunkDays: Int? {
         switch self {
         case .day1: return 1
@@ -26,8 +22,7 @@ nonisolated enum BatchingMode: String, CaseIterable, Identifiable, Sendable {
         }
     }
 
-    /// Number of items added per count-based batch, or `nil` for
-    /// non-count-based modes.
+    /// Items per count-based batch, or `nil`.
     var batchSize: Int? {
         switch self {
         case .items25: return 25
@@ -40,9 +35,7 @@ nonisolated enum BatchingMode: String, CaseIterable, Identifiable, Sendable {
     var isDateBased: Bool { chunkDays != nil }
     var isCountBased: Bool { batchSize != nil }
 
-    /// Date at which the initial batch should begin for date-based modes.
-    /// Returns `.distantPast` for non-date-based modes so existing
-    /// `articles(since:)` callers keep working.
+    /// Start date for the initial date-based batch (epoch for non-date modes).
     func initialSinceDate() -> Date {
         guard let days = chunkDays else { return Date(timeIntervalSince1970: 0) }
         let startOfToday = Calendar.current.startOfDay(for: Date())
@@ -50,12 +43,9 @@ nonisolated enum BatchingMode: String, CaseIterable, Identifiable, Sendable {
             ?? startOfToday
     }
 
-    /// Initial item count for the first count-based batch.
     func initialCount() -> Int { batchSize ?? 0 }
 
-    /// The currently persisted mode, used to seed `@State` values so the
-    /// initial window matches the stored configuration rather than the
-    /// `@AppStorage` default.
+    /// Returns the currently persisted mode.
     static func current() -> BatchingMode {
         let raw = UserDefaults.standard.string(forKey: "Articles.BatchingMode")
         return raw.flatMap(BatchingMode.init(rawValue:)) ?? .day1

--- a/Feeds/Favicon Cache/FaviconCache+CustomIcons.swift
+++ b/Feeds/Favicon Cache/FaviconCache+CustomIcons.swift
@@ -22,7 +22,6 @@ extension FaviconCache {
             }
         }
 
-        // For X feeds without a cached photo, fetch the profile avatar via XProfileScraper
         if feed.isXFeed,
            let handle = XProfileScraper.handleFromFeedURL(feed.url),
            let image = await fetchXProfileAvatar(handle: handle) {
@@ -30,7 +29,6 @@ extension FaviconCache {
             return image
         }
 
-        // For Instagram feeds without a cached photo, fetch the profile avatar
         if feed.isInstagramFeed,
            let handle = InstagramProfileScraper.handleFromFeedURL(feed.url),
            let image = await fetchInstagramProfileAvatar(handle: handle) {
@@ -49,11 +47,7 @@ extension FaviconCache {
         if let pngData = finalImage.pngData() {
             try? pngData.write(to: filePath)
         }
-        // Persist metrics so the post-relaunch disk read produces the same
-        // rendering as the in-session image. Without this, FaviconImage
-        // re-samples the decoded PNG's corner alphas and may flip
-        // isFilledSquare, triggering the inset/tint heuristic for an icon
-        // that rendered edge-to-edge in-session.
+        // Persist metrics so post-relaunch disk reads match in-session rendering (avoids re-sampling flipping isFilledSquare).
         attachDerivedMetrics(cacheKey: key, to: finalImage)
     }
 

--- a/Feeds/Favicon Cache/FaviconCache+FailedLookups.swift
+++ b/Feeds/Favicon Cache/FaviconCache+FailedLookups.swift
@@ -2,25 +2,14 @@ import Foundation
 
 extension FaviconCache {
 
-    /// How long a failed favicon lookup is remembered before the host is
-    /// retried.  Favicons are cosmetic, so paying 3s of radio time per
-    /// cold launch on known-missing hosts is wasted energy — but a full
-    /// lifetime skip would never recover if the host later publishes an
-    /// icon.  One day strikes the balance.
     static let failedLookupTTL: TimeInterval = 24 * 60 * 60
-
-    /// Persisted map of `cacheKey → failure date`.  Lives alongside the
-    /// favicon PNGs so `clearCache()` removes it too.
     static let failedLookupsFileName = "failedLookups.json"
 
     var failedLookupsURL: URL {
         cacheDirectory.appendingPathComponent(Self.failedLookupsFileName)
     }
 
-    /// Loads and prunes the on-disk failure map.  Entries older than the
-    /// TTL are dropped; the caller is responsible for persisting the
-    /// pruned state.  `nonisolated` so `init` can call it before the
-    /// actor's properties are fully wired up.
+    /// Loads and prunes the on-disk failure map, dropping entries past the TTL.
     nonisolated static func loadFailedLookupsFromDisk(at url: URL) -> [String: Date] {
         guard let data = try? Data(contentsOf: url),
               let stored = try? JSONDecoder().decode([String: Double].self, from: data) else {
@@ -35,7 +24,6 @@ extension FaviconCache {
     }
 
     /// Returns true if `cacheKey` has failed within the TTL window.
-    /// Stale entries are evicted on check so they don't linger in memory.
     func isWithinFailureTTL(_ cacheKey: String) -> Bool {
         guard let failedAt = failedLookups[cacheKey] else { return false }
         if Date().timeIntervalSince(failedAt) < Self.failedLookupTTL {

--- a/Feeds/Favicon Cache/FaviconCache+Fetching.swift
+++ b/Feeds/Favicon Cache/FaviconCache+Fetching.swift
@@ -12,8 +12,6 @@ extension FaviconCache {
         if let pngData = result.pngData() {
             try? pngData.write(to: filePath)
         }
-        // Compute and persist the derived-metrics sidecar next to the PNG
-        // so subsequent launches don't need to re-sample the pixels.
         attachDerivedMetrics(cacheKey: cacheKey, to: result)
         memoryCache[cacheKey] = result
         return result
@@ -27,7 +25,6 @@ extension FaviconCache {
         debugPrint("[Favicon] Fetching favicon for domain: \(domain), cacheKey: \(cacheKey)")
         #endif
 
-        // For profile-based feeds, fetch the avatar from the profile page's og:image
         if Self.isProfileBased(domain: domain, siteURL: siteURL), let siteURL = siteURL,
            let image = await fetchProfileAvatar(from: siteURL) {
             #if DEBUG
@@ -36,7 +33,6 @@ extension FaviconCache {
             return await trimAndCache(image, cacheKey: cacheKey, filePath: filePath, domain: domain)
         }
 
-        // Map feed domains to their favicon domain (e.g. feeds.bbci.co.uk → bbc.co.uk)
         let faviconDomain = FaviconAlternateDomains.faviconDomain(for: domain)
         #if DEBUG
         if faviconDomain != domain {
@@ -52,10 +48,7 @@ extension FaviconCache {
             return nil
         }
 
-        // Some domains serve a pale favicon.ico / masked manifest icon but
-        // a vibrant apple-touch-icon.png at the well-known path. Force that
-        // path for allowlisted domains so we don't fall through to the
-        // lower-quality fallbacks.
+        // Some domains serve a pale favicon.ico but a vibrant apple-touch-icon.png; force that path for allowlisted hosts.
         if FaviconForceAppleTouchIconDomains.shouldForceAppleTouchIcon(feedDomain: faviconDomain),
            let touchURL = URL(string: "https://\(faviconDomain)/apple-touch-icon.png"),
            let (data, _) = try? await Self.urlSession.data(from: touchURL),
@@ -66,7 +59,6 @@ extension FaviconCache {
             return await trimAndCache(image, cacheKey: cacheKey, filePath: filePath, domain: domain)
         }
 
-        // Try PWA / apple-touch-icon first for higher quality
         if let image = await fetchPWAIcon(from: url) {
             #if DEBUG
             debugPrint("[Favicon] Found PWA/touch icon for \(domain)")
@@ -74,7 +66,6 @@ extension FaviconCache {
             return await trimAndCache(image, cacheKey: cacheKey, filePath: filePath, domain: domain)
         }
 
-        // Fall back to FaviconFinder
         do {
             let faviconURLs = try await FaviconFinder(url: url).fetchFaviconURLs()
             guard let bestFaviconURL = faviconURLs.first else {

--- a/Feeds/Favicon Cache/FaviconCache+PWA.swift
+++ b/Feeds/Favicon Cache/FaviconCache+PWA.swift
@@ -13,7 +13,6 @@ extension FaviconCache {
                 return nil
             }
 
-            // 1. Try web app manifest
             if let manifestHref = extractLinkHref(from: html, rel: "manifest"),
                let manifestURL = URL(string: manifestHref, relativeTo: siteURL),
                let icon = await fetchManifestIcon(from: manifestURL.absoluteURL) {
@@ -23,7 +22,6 @@ extension FaviconCache {
                 return icon
             }
 
-            // 2. Try apple-touch-icon (typically 180x180)
             if let touchIconHref = extractLinkHref(from: html, rel: "apple-touch-icon"),
                let iconURL = URL(string: touchIconHref, relativeTo: siteURL) {
                 let (iconData, _) = try await Self.urlSession.data(from: iconURL.absoluteURL)
@@ -57,7 +55,6 @@ extension FaviconCache {
             guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
                   let icons = json["icons"] as? [[String: Any]] else { return nil }
 
-            // Find the largest square icon
             var bestIcon: (url: String, size: Int)?
             for icon in icons {
                 guard let src = icon["src"] as? String else { continue }

--- a/Feeds/Favicon Cache/FaviconCache+Profiles.swift
+++ b/Feeds/Favicon Cache/FaviconCache+Profiles.swift
@@ -2,8 +2,7 @@ import UIKit
 
 extension FaviconCache {
 
-    /// Domains where each feed represents a unique profile and
-    /// the profile page's og:image should be used as the favicon.
+    /// Checks whether the domain's feeds represent unique profiles that use og:image as favicon.
     static func isProfileBasedDomain(_ domain: String) -> Bool {
         let host = domain.lowercased()
         if host.contains("youtube.com") || host.contains("youtu.be") { return true }
@@ -14,20 +13,16 @@ extension FaviconCache {
         return false
     }
 
-    /// Checks domain or siteURL pattern to detect profile-based feeds,
-    /// including Mastodon instances not in the allowlist.
+    /// Detects profile-based feeds including unlisted Mastodon instances.
     static func isProfileBased(domain: String, siteURL: String?) -> Bool {
         if isProfileBasedDomain(domain) { return true }
-        // Detect unlisted Mastodon instances by /@username path pattern
         if let siteURL, let url = URL(string: siteURL), url.path.hasPrefix("/@") {
             return true
         }
         return false
     }
 
-    /// Fetches an X (Twitter) profile avatar using the XProfileScraper API.
-    /// Uses a long request timeout since favicons are cosmetic and should
-    /// not fail when the network is slow.
+    /// Fetches an X (Twitter) profile avatar via XProfileScraper.
     nonisolated func fetchXProfileAvatar(handle: String) async -> UIImage? {
         let scraper = XProfileScraper()
         scraper.requestTimeoutInterval = 600
@@ -41,9 +36,7 @@ extension FaviconCache {
         return UIImage(data: data)
     }
 
-    /// Fetches an Instagram profile avatar using the InstagramProfileScraper API.
-    /// Uses a long request timeout since favicons are cosmetic and should
-    /// not fail when the network is slow.
+    /// Fetches an Instagram profile avatar via InstagramProfileScraper.
     nonisolated func fetchInstagramProfileAvatar(handle: String) async -> UIImage? {
         guard let profileURL = InstagramProfileScraper.profileURL(for: handle) else { return nil }
         let scraper = InstagramProfileScraper()
@@ -57,9 +50,7 @@ extension FaviconCache {
         return UIImage(data: data)
     }
 
-    /// Fetches a note.com creator's profile photo via the public v2
-    /// creators API. note.com doesn't expose a usable og:image on the
-    /// profile page, so we pull it from `/api/v2/creators/<urlname>`.
+    /// Fetches a note.com creator's profile photo via the public creators API.
     nonisolated func fetchNoteProfileAvatar(handle: String) async -> UIImage? {
         let scraper = NoteProfileScraper()
         let result = await scraper.scrapeProfile(handle: handle)
@@ -71,9 +62,7 @@ extension FaviconCache {
         return UIImage(data: data)
     }
 
-    /// Fetches a subreddit's community icon via the Reddit Community Scraper.
-    /// Reddit doesn't expose the styled community icon through og:image,
-    /// so we pull it from `/r/<name>/about.json`.
+    /// Fetches a subreddit's community icon via RedditCommunityScraper.
     nonisolated func fetchRedditCommunityIcon(subreddit: String) async -> UIImage? {
         let scraper = RedditCommunityScraper()
         let result = await scraper.scrapeCommunity(subreddit: subreddit)
@@ -85,9 +74,7 @@ extension FaviconCache {
         return UIImage(data: data)
     }
 
-    /// Fetches a profile avatar by scraping the profile page for the og:image meta tag.
-    /// Works for YouTube channels, Mastodon profiles, and Bluesky profiles.
-    /// Subreddits are handled via the Reddit Community Scraper instead.
+    /// Fetches a profile avatar by scraping the profile page's og:image meta tag.
     nonisolated func fetchProfileAvatar(from siteURL: String) async -> UIImage? {
         guard let url = URL(string: siteURL) else { return nil }
         if RedditCommunityScraper.isRedditSubredditURL(url),

--- a/Feeds/Favicon Cache/FaviconCache.swift
+++ b/Feeds/Favicon Cache/FaviconCache.swift
@@ -5,14 +5,7 @@ actor FaviconCache {
 
     static let shared = FaviconCache()
 
-    /// Dedicated URLSession used for every favicon-related network fetch.
-    /// Favicons are cosmetic, and hanging on a slow or unreachable host
-    /// keeps a request slot - and radio time - alive for far longer than
-    /// a missing icon is worth.  Keep the timeouts tight (3 seconds) and
-    /// disable `waitsForConnectivity` so we never sit on a request while
-    /// the device is offline.  `httpAdditionalHeaders` sets a Safari-parity
-    /// User-Agent on every request so the default `CFNetwork` UA (which
-    /// leaks the app bundle ID and iOS version) is never sent.
+    /// Dedicated short-timeout URLSession for favicon fetches.
     nonisolated static let urlSession: URLSession = {
         let config = URLSessionConfiguration.default
         config.timeoutIntervalForRequest = 3
@@ -24,8 +17,6 @@ actor FaviconCache {
 
     let cacheDirectory: URL
     var memoryCache: [String: UIImage] = [:]
-    /// Hosts whose favicon fetch most recently failed, keyed by cacheKey.
-    /// Persisted to disk with a 24h TTL — see `FaviconCache+FailedLookups`.
     var failedLookups: [String: Date] = [:]
 
     private init() {
@@ -94,8 +85,7 @@ actor FaviconCache {
         try? FileManager.default.createDirectory(at: cacheDirectory, withIntermediateDirectories: true)
     }
 
-    /// Removes specific entries from the failed-lookups set so they will be
-    /// retried on the next request.
+    /// Removes specific entries from the failed-lookups set to be retried.
     func clearFailedLookups(for entries: [(domain: String, siteURL: String?)]) {
         for entry in entries {
             let cacheKey = Self.cacheKey(domain: entry.domain, siteURL: entry.siteURL)
@@ -120,18 +110,12 @@ actor FaviconCache {
 
     // MARK: - Derived Metrics Sidecar
 
-    /// JSON sidecar URL holding FaviconDerivedMetrics for a cached favicon.
-    /// Stored next to the PNG so `refreshFavicons`/`clearCache` wipe both
-    /// together by iterating the directory.
+    /// Returns the JSON sidecar URL for a cached favicon's derived metrics.
     func metricsSidecarURL(for cacheKey: String) -> URL {
         cacheDirectory.appendingPathComponent(sanitizedFileName(cacheKey) + ".meta.json")
     }
 
-    /// Attaches the cached metrics to the image.  If the sidecar already
-    /// exists on disk it's decoded and attached as-is; otherwise the
-    /// metrics are computed from the pixels now and the sidecar is
-    /// written, so subsequent app launches avoid the pixel sampling
-    /// work entirely.
+    /// Attaches cached metrics to the image, computing and persisting them if missing.
     func attachDerivedMetrics(cacheKey: String, to image: UIImage) {
         let url = metricsSidecarURL(for: cacheKey)
         if let data = try? Data(contentsOf: url),

--- a/Feeds/Feed Discovery/FeedDiscovery+HTML.swift
+++ b/Feeds/Feed Discovery/FeedDiscovery+HTML.swift
@@ -22,7 +22,6 @@ extension FeedDiscovery {
     func extractFeedLinks(from html: String, baseURL: URL) -> [DiscoveredFeed] {
         var feeds: [DiscoveredFeed] = []
 
-        // 1. Standard <link> tags with RSS/Atom type
         let linkPattern = #"<link[^>]+type="application/(rss|atom)\+xml"[^>]*>"#
         if let linkRegex = try? NSRegularExpression(pattern: linkPattern, options: .caseInsensitive) {
             let matches = linkRegex.matches(in: html, range: NSRange(html.startIndex..., in: html))
@@ -44,7 +43,6 @@ extension FeedDiscovery {
             }
         }
 
-        // 2. <a> tags with "RSS Feed" or "RSS" in their link text
         let anchorPattern = #"<a\s[^>]*href="([^"]*)"[^>]*>(.*?)</a>"#
         let anchorOptions: NSRegularExpression.Options = [.caseInsensitive, .dotMatchesLineSeparators]
         if let anchorRegex = try? NSRegularExpression(pattern: anchorPattern, options: anchorOptions) {

--- a/Feeds/Feed Discovery/FeedDiscovery+Probing.swift
+++ b/Feeds/Feed Discovery/FeedDiscovery+Probing.swift
@@ -4,8 +4,7 @@ extension FeedDiscovery {
 
     // MARK: - RSS Suffix Probing
 
-    /// For non-root URLs, tries appending `.rss` to the path.
-    /// Works for sites like Reddit where /r/subreddit.rss is a valid feed.
+    /// Tries appending `.rss` to non-root URL paths (e.g. Reddit).
     func probeRSSSuffix(for url: URL) async -> DiscoveredFeed? {
         let path = url.path
         guard !path.isEmpty,
@@ -75,7 +74,6 @@ extension FeedDiscovery {
                 }
             }
         } catch {
-            // Probe failed, not a feed
         }
 
         return nil

--- a/Feeds/Feed Discovery/FeedDiscovery+SocialMedia.swift
+++ b/Feeds/Feed Discovery/FeedDiscovery+SocialMedia.swift
@@ -4,8 +4,7 @@ extension FeedDiscovery {
 
     // MARK: - Social Media Feed Detection
 
-    /// Detects Bluesky, Mastodon, X/Twitter, and Instagram profile URLs
-    /// and constructs their feed URLs.
+    /// Detects social media profile URLs and constructs their feed URLs.
     func detectSocialMediaFeed(url: URL) async -> DiscoveredFeed? {
         if let arXivFeed = detectArXivListFeed(url: url) {
             return arXivFeed
@@ -36,11 +35,7 @@ extension FeedDiscovery {
         return nil
     }
 
-    /// Detects arXiv subject listing URLs and rewrites them to the matching
-    /// RSS feed. arXiv publishes a standard RSS feed for each category
-    /// (e.g. `https://arxiv.org/list/cs.AI/recent` →
-    /// `https://rss.arxiv.org/rss/cs.AI`) so the normal RSS parser can handle
-    /// refreshes.
+    /// Rewrites arXiv subject listing URLs to their matching RSS feed.
     func detectArXivListFeed(url: URL) -> DiscoveredFeed? {
         guard let category = ArXivHelper.extractCategoryFromListURL(url) else {
             return nil
@@ -52,9 +47,7 @@ extension FeedDiscovery {
         )
     }
 
-    /// Detects X/Twitter profile URLs and returns a pseudo-feed entry.
-    /// The feed URL uses the `x-profile://` scheme so the app routes refresh
-    /// through XProfileScraper instead of RSSParser.
+    /// Returns a pseudo-feed for an X/Twitter profile URL (routed via XProfileScraper).
     func detectXProfileFeed(url: URL) -> DiscoveredFeed? {
         guard XProfileScraper.isXProfileURL(url),
               let handle = XProfileScraper.extractHandle(from: url) else {
@@ -68,9 +61,7 @@ extension FeedDiscovery {
         )
     }
 
-    /// Detects Instagram profile URLs and returns a pseudo-feed entry.
-    /// The feed URL uses the `instagram-profile://` scheme so the app routes
-    /// refresh through InstagramProfileScraper instead of RSSParser.
+    /// Returns a pseudo-feed for an Instagram profile URL (routed via InstagramProfileScraper).
     func detectInstagramProfileFeed(url: URL) -> DiscoveredFeed? {
         guard InstagramProfileScraper.isInstagramProfileURL(url),
               let handle = InstagramProfileScraper.extractHandle(from: url) else {
@@ -84,9 +75,7 @@ extension FeedDiscovery {
         )
     }
 
-    /// Detects YouTube playlist URLs and returns a pseudo-feed entry.
-    /// The feed URL uses the `youtube-playlist://` scheme so the app routes
-    /// refresh through YouTubePlaylistScraper instead of RSSParser.
+    /// Returns a pseudo-feed for a YouTube playlist URL (routed via YouTubePlaylistScraper).
     func detectYouTubePlaylistFeed(url: URL) -> DiscoveredFeed? {
         guard YouTubePlaylistScraper.isYouTubePlaylistURL(url),
               let playlistID = YouTubePlaylistScraper.extractPlaylistID(from: url) else {
@@ -100,11 +89,7 @@ extension FeedDiscovery {
         )
     }
 
-    /// Detects YouTube channel URLs (`/channel/UC...`, `/@handle`, `/user/<name>`,
-    /// `/c/<name>`) and returns a discovered feed that points at the public
-    /// Atom feed (`/feeds/videos.xml?channel_id=UC...`). The Atom feed works
-    /// directly with the generic RSS refresh pipeline, so the app fetches
-    /// title and videos on first refresh just like any other RSS feed.
+    /// Returns a discovered feed pointing at the channel's Atom feed.
     func detectYouTubeChannelFeed(url: URL) async -> DiscoveredFeed? {
         guard let host = url.host?.lowercased(),
               host == "youtube.com" || host == "www.youtube.com" || host == "m.youtube.com" else {
@@ -135,10 +120,7 @@ extension FeedDiscovery {
         return DiscoveredFeed(title: title, url: feedURL, siteURL: siteURL)
     }
 
-    /// Fetches a YouTube channel page and extracts the canonical channel ID
-    /// from `<meta itemprop="identifier">` / `<meta itemprop="channelId">` /
-    /// `<link rel="canonical">`. Returns `nil` on any failure - callers fall
-    /// through to generic discovery.
+    /// Extracts the canonical `UC...` channel ID from a YouTube channel page.
     static func resolveYouTubeChannelID(from url: URL) async -> String? {
         var request = URLRequest(url: url)
         request.setValue(sakuraUserAgent, forHTTPHeaderField: "User-Agent")
@@ -153,8 +135,7 @@ extension FeedDiscovery {
         }
     }
 
-    /// Pulls a `UC...` channel ID out of the YouTube channel page HTML using
-    /// any of the several stable markers YouTube embeds.
+    /// Pulls a `UC...` channel ID out of YouTube channel page HTML.
     static func extractYouTubeChannelID(from html: String) -> String? {
         let patterns = [
             #"<meta itemprop="identifier" content="(UC[\w-]+)""#,
@@ -175,10 +156,7 @@ extension FeedDiscovery {
         return nil
     }
 
-    /// Best-effort fetch of the YouTube Atom feed's `<title>` so the
-    /// discovered feed entry can show the real channel name immediately.
-    /// Returns `nil` on any failure; generic refresh will fill it in on
-    /// the subsequent initial refresh.
+    /// Best-effort fetch of the YouTube Atom feed's `<title>`.
     static func fetchYouTubeAtomTitle(feedURL: String) async -> String? {
         guard let url = URL(string: feedURL) else { return nil }
         var request = URLRequest(url: url)
@@ -200,8 +178,7 @@ extension FeedDiscovery {
         return nil
     }
 
-    /// Detects Bluesky profile URLs and constructs the RSS feed URL.
-    /// Format: bsky.app/profile/<handle> → bsky.app/profile/<handle>/rss
+    /// Constructs a Bluesky profile RSS feed URL.
     func detectBlueskyFeed(url: URL) async -> DiscoveredFeed? {
         guard let host = url.host?.lowercased(),
               host == "bsky.app" || host.hasSuffix(".bsky.app") else {
@@ -218,8 +195,7 @@ extension FeedDiscovery {
         return await probeFeedAt(domain: "bsky.app", path: "/profile/\(handle)/rss")
     }
 
-    /// Detects note.com creator profile URLs and constructs the RSS feed URL.
-    /// Format: note.com/<urlname> → note.com/<urlname>/rss
+    /// Constructs a note.com creator profile RSS feed URL.
     func detectNoteFeed(url: URL) async -> DiscoveredFeed? {
         guard NoteProfileScraper.isNoteProfileURL(url),
               let handle = NoteProfileScraper.extractHandle(from: url) else {
@@ -228,8 +204,7 @@ extension FeedDiscovery {
         return await probeFeedAt(domain: "note.com", path: "/\(handle)/rss")
     }
 
-    /// Detects Mastodon profile URLs and constructs the RSS feed URL.
-    /// Format: <instance>/@<username> → <instance>/@<username>.rss
+    /// Constructs a Mastodon profile RSS feed URL.
     func detectMastodonFeed(url: URL) async -> DiscoveredFeed? {
         guard let host = url.host?.lowercased() else { return nil }
 

--- a/Feeds/Feed.swift
+++ b/Feeds/Feed.swift
@@ -13,9 +13,7 @@ nonisolated struct Feed: Identifiable, Hashable, Sendable {
     var isMuted: Bool
     var customIconURL: String?
     var acronymIcon: Data?
-    /// `true` when the user has manually edited the feed's title.
-    /// Refreshes must not overwrite a customized title with whatever the
-    /// remote feed currently advertises.
+    /// `true` when the user has manually edited the feed's title; refreshes must not overwrite it.
     var isTitleCustomized: Bool
 
     var domain: String {
@@ -79,7 +77,6 @@ nonisolated struct Feed: Identifiable, Hashable, Sendable {
         isXFeed || isInstagramFeed || isYouTubePlaylistFeed || PetalRecipe.isPetalFeedURL(url)
     }
 
-    /// The feed category section for grouped display.
     var feedSection: FeedSection {
         if isPodcast { return .audio }
         if isVideoFeed { return .video }
@@ -87,7 +84,7 @@ nonisolated struct Feed: Identifiable, Hashable, Sendable {
         return .news
     }
 
-    /// Detects Mastodon feeds from unlisted instances by checking for the /@username.rss URL pattern.
+    /// Detects unlisted Mastodon instances via the /@username.rss URL pattern.
     private var hasMastodonFeedURL: Bool {
         guard let urlObj = URL(string: url) else { return false }
         let path = urlObj.path

--- a/Feeds/FeedRefreshCooldown.swift
+++ b/Feeds/FeedRefreshCooldown.swift
@@ -1,9 +1,6 @@
 import Foundation
 
-/// User-configurable cooldown between automatic per-feed refreshes.
-/// Applied when an automatic trigger (background refresh, app startup,
-/// foreground re-enter) asks to refresh every feed.  Does not affect
-/// explicit user-triggered refreshes such as pull-to-refresh.
+/// Cooldown between automatic per-feed refreshes (does not affect user-triggered pull-to-refresh).
 nonisolated enum FeedRefreshCooldown: String, CaseIterable, Sendable {
     case off
     case oneMinute

--- a/Feeds/FetchImagesMode.swift
+++ b/Feeds/FetchImagesMode.swift
@@ -1,8 +1,6 @@
 import Foundation
 
-/// Controls whether article images should be prefetched during feed
-/// refreshes, and whether the work is restricted to non-expensive
-/// (typically Wi-Fi) network paths.
+/// Controls article image prefetching during feed refreshes.
 nonisolated enum FetchImagesMode: String, CaseIterable, Sendable {
     case always
     case wifiOnly

--- a/Feeds/RSS Parser/HTMLMetadataImage.swift
+++ b/Feeds/RSS Parser/HTMLMetadataImage.swift
@@ -1,12 +1,8 @@
 import Foundation
 
-/// Fallback image lookup for RSS items that ship without any image tag.
-/// Fetches the article page's `<head>` and returns the first usable
-/// `og:image` / `twitter:image` / `image_src` / `itemprop=image`.
+/// Fallback image lookup for RSS items without image tags via `<head>` meta tags.
 nonisolated enum HTMLMetadataImage {
 
-    /// Cap the body read so a large article HTML can't be pulled down
-    /// just to find a meta tag near the top of `<head>`.
     private static let maxBytes = 128 * 1024
 
     static func fetchImageURL(
@@ -39,8 +35,7 @@ nonisolated enum HTMLMetadataImage {
     }
 
     static func extractImageURL(from html: String, baseURL: URL?) -> String? {
-        // Restrict scanning to <head> when possible so inline article
-        // images don't get picked up as false positives.
+        // Restrict scanning to <head> to avoid picking up inline article images.
         let headSlice: String = {
             if let range = html.range(of: "</head>", options: .caseInsensitive) {
                 return String(html[..<range.lowerBound])
@@ -48,7 +43,6 @@ nonisolated enum HTMLMetadataImage {
             return html
         }()
 
-        // Ordered best-to-worst; first hit wins.
         let metaNamePatterns = [
             "og:image:secure_url",
             "og:image:url",
@@ -83,7 +77,6 @@ nonisolated enum HTMLMetadataImage {
         in html: String, propertyOrName name: String
     ) -> String? {
         let escaped = NSRegularExpression.escapedPattern(for: name)
-        // Two attribute orderings - HTML doesn't fix the order.
         let patterns = [
             #"<meta\b[^>]*?\b(?:property|name)\s*=\s*["']\#(escaped)["'][^>]*?\bcontent\s*=\s*["']([^"']+)["']"#,
             #"<meta\b[^>]*?\bcontent\s*=\s*["']([^"']+)["'][^>]*?\b(?:property|name)\s*=\s*["']\#(escaped)["']"#

--- a/Feeds/RSS Parser/RSSParser+HTML.swift
+++ b/Feeds/RSS Parser/RSSParser+HTML.swift
@@ -88,8 +88,7 @@ nonisolated extension RSSParser {
         return decoded.isEmpty ? nil : decoded
     }
 
-    /// Converts HTML to plain text, preserving paragraph/heading structure as newlines
-    /// and rendering `<a>` links as Markdown `[text](url)` for tappable display.
+    /// Converts HTML to plain text, preserving structure with newlines and Markdown links.
     func cleanHTMLPreservingStructure(_ html: String, baseURL: URL? = nil) -> String? {
         guard html.contains("<") else {
             let decoded = decodeHTMLEntities(html).trimmingCharacters(in: .whitespacesAndNewlines)
@@ -128,8 +127,7 @@ nonisolated extension RSSParser {
         return result.isEmpty ? nil : result
     }
 
-    /// Converts `<a>` tags to Markdown links, stripping empty-text links.
-    /// Resolves relative URLs against `baseURL` when provided.
+    /// Converts `<a>` tags to Markdown links, resolving relative URLs against `baseURL`.
     private func convertLinksToMarkdown(_ text: String, baseURL: URL? = nil) -> String {
         guard let linkRegex = try? NSRegularExpression(
             pattern: #"<a\s[^>]*href=["']([^"']+)["'][^>]*>(.*?)</a>"#
@@ -148,9 +146,7 @@ nonisolated extension RSSParser {
             if linkText.isEmpty {
                 result = (result as NSString).replacingCharacters(in: match.range, with: "")
             } else {
-                // Percent-encode spaces in the URL for valid Markdown links
                 url = url.replacingOccurrences(of: " ", with: "%20")
-                // Resolve relative URLs against the base URL
                 if !url.hasPrefix("http://") && !url.hasPrefix("https://") {
                     if url.hasPrefix("//"), let abs = URL(string: "https:\(url)") {
                         url = abs.absoluteString
@@ -168,7 +164,7 @@ nonisolated extension RSSParser {
         return result
     }
 
-    /// Converts headers, bold, italic, superscript, and subscript HTML tags to Markdown.
+    /// Converts inline HTML tags (headers, bold, italic, sup, sub, code) to Markdown.
     private func convertInlineMarkup(_ text: String) -> String {
         var result = text
 
@@ -222,7 +218,6 @@ nonisolated extension RSSParser {
     }
 
     func extractImageFromHTML(_ html: String) -> String? {
-        // Try double-quoted src first, then single-quoted
         let patterns = [
             #"<img[^>]+src="([^"]+)""#,
             #"<img[^>]+src='([^']+)'"#
@@ -240,7 +235,6 @@ nonisolated extension RSSParser {
                 }
             }
         }
-        // No hero-quality image found, return first image as fallback
         for pattern in patterns {
             if let range = html.range(of: pattern, options: .regularExpression) {
                 let match = html[range]
@@ -254,9 +248,7 @@ nonisolated extension RSSParser {
         return nil
     }
 
-    /// Removes `{{SUP}}…{{/SUP}}` and `{{SUB}}…{{/SUB}}` markers whose
-    /// content contains an invalid URL (either as a Markdown link or raw URL).
-    /// Markers with no URL (e.g. plain numbers) are kept as-is.
+    /// Removes SUP/SUB markers whose content contains an invalid URL.
     func stripInvalidURLSupSub(_ text: String) -> String {
         let pattern = #"\{\{(SUP|SUB)\}\}(.+?)\{\{/(SUP|SUB)\}\}"#
         guard let regex = try? NSRegularExpression(pattern: pattern) else { return text }
@@ -284,7 +276,7 @@ nonisolated extension RSSParser {
         return result
     }
 
-    /// Converts `<pre>` blocks (optionally containing `<code>`) to `{{CODE}}…{{/CODE}}` markers.
+    /// Converts `<pre>` blocks to `{{CODE}}...{{/CODE}}` markers.
     private func replacePreTagsWithMarkers(_ text: String) -> String {
         guard let regex = try? NSRegularExpression(
             pattern: #"<pre(?:\s[^>]*)?>(?:\s*<code(?:\s[^>]*)?>)?(.*?)(?:</code>\s*)?</pre>"#,
@@ -295,7 +287,6 @@ nonisolated extension RSSParser {
         let matches = regex.matches(in: result, range: NSRange(location: 0, length: nsResult.length))
         for match in matches.reversed() {
             var content = nsResult.substring(with: match.range(at: 1))
-            // Strip any remaining inner HTML tags
             content = content.replacingOccurrences(of: "<[^>]+>", with: "", options: .regularExpression)
             content = content.trimmingCharacters(in: CharacterSet(charactersIn: "\n"))
             if !content.isEmpty {
@@ -327,7 +318,6 @@ nonisolated extension RSSParser {
 
     private func isLikelyHeroImage(_ url: String) -> Bool {
         let lowered = url.lowercased()
-        // Skip tracking pixels, icons, and spacers
         let skipPatterns = [
             "gravatar.com", "pixel", "spacer", "blank",
             "1x1", "transparent", "tracking", "beacon",

--- a/Feeds/RSS Parser/RSSParser.swift
+++ b/Feeds/RSS Parser/RSSParser.swift
@@ -238,15 +238,12 @@ nonisolated final class RSSParser: NSObject, XMLParserDelegate, @unchecked Senda
     // MARK: - Image Resolution
 
     private func resolveImageURL() -> String? {
-        // Prefer explicitly tagged image from feed elements
         if !currentImageURL.isEmpty {
             return currentImageURL
         }
-        // Try extracting from content:encoded (usually has full article HTML)
         if !currentContent.isEmpty, let url = extractImageFromHTML(currentContent) {
             return url
         }
-        // Try extracting from description/summary
         if !currentDescription.isEmpty, let url = extractImageFromHTML(currentDescription) {
             return url
         }

--- a/Integrations/Instagram/InstagramProfileScraper+Extraction.swift
+++ b/Integrations/Instagram/InstagramProfileScraper+Extraction.swift
@@ -29,7 +29,6 @@ extension InstagramProfileScraper {
 
         var posts: [ParsedInstagramPost] = []
 
-        // Format 1: GraphQL edge format (edge_owner_to_timeline_media.edges[].node)
         if let edgeMedia = user["edge_owner_to_timeline_media"] as? [String: Any],
            let edges = edgeMedia["edges"] as? [[String: Any]] {
             for edge in edges {
@@ -41,10 +40,7 @@ extension InstagramProfileScraper {
             }
         }
 
-        // Format 2: v1 API format (edge_owner_to_timeline_media.edges is empty,
-        // but items may be in a different location)
         if posts.isEmpty, let edgeMedia = user["edge_owner_to_timeline_media"] as? [String: Any] {
-            // Some responses nest count but no edges; check for items array
             if let items = edgeMedia["items"] as? [[String: Any]] {
                 for item in items {
                     if let post = parseV1Item(item: item, username: username,
@@ -55,7 +51,6 @@ extension InstagramProfileScraper {
             }
         }
 
-        // Format 3: Media object at top level of user
         if posts.isEmpty, let media = user["media"] as? [String: Any] {
             if let items = media["items"] as? [[String: Any]] {
                 for item in items {
@@ -88,7 +83,6 @@ extension InstagramProfileScraper {
 
         let shortcode = node["shortcode"] as? String ?? ""
 
-        // Caption text
         var captionText = ""
         if let edgeCaption = node["edge_media_to_caption"] as? [String: Any],
            let captionEdges = edgeCaption["edges"] as? [[String: Any]],
@@ -98,9 +92,6 @@ extension InstagramProfileScraper {
             captionText = text
         }
 
-        // Image URL - for video/reel posts, display_url is the poster frame.
-        // Fall back to thumbnail_resources (sorted by size) if the primary
-        // keys are absent.
         var imageURL = node["display_url"] as? String
             ?? node["thumbnail_src"] as? String
         if imageURL == nil,
@@ -111,7 +102,6 @@ extension InstagramProfileScraper {
             imageURL = sorted.first?["src"] as? String
         }
 
-        // Carousel images (edge_sidecar_to_children contains all slides)
         var carouselImageURLs: [String] = []
         if let sidecar = node["edge_sidecar_to_children"] as? [String: Any],
            let edges = sidecar["edges"] as? [[String: Any]] {
@@ -123,7 +113,6 @@ extension InstagramProfileScraper {
             }
         }
 
-        // Publish date
         var publishedDate: Date?
         if let timestamp = node["taken_at_timestamp"] as? TimeInterval {
             publishedDate = Date(timeIntervalSince1970: timestamp)
@@ -151,7 +140,6 @@ extension InstagramProfileScraper {
     private static func parseV1Item(
         item: [String: Any], username: String, displayName: String?
     ) -> ParsedInstagramPost? {
-        // ID can be "id", "pk", or "media_id"
         let id: String
         if let idStr = item["id"] as? String {
             id = idStr
@@ -166,14 +154,12 @@ extension InstagramProfileScraper {
 
         let code = item["code"] as? String ?? ""
 
-        // Caption
         var captionText = ""
         if let caption = item["caption"] as? [String: Any],
            let text = caption["text"] as? String {
             captionText = text
         }
 
-        // Image URL - carousel or single
         var imageURL: String?
         var carouselImageURLs: [String] = []
         if let carouselMedia = item["carousel_media"] as? [[String: Any]] {
@@ -188,7 +174,6 @@ extension InstagramProfileScraper {
             imageURL = bestImageURL(from: item)
         }
 
-        // Publish date
         var publishedDate: Date?
         if let timestamp = item["taken_at"] as? TimeInterval {
             publishedDate = Date(timeIntervalSince1970: timestamp)
@@ -216,7 +201,6 @@ extension InstagramProfileScraper {
 
     // MARK: - User ID Extraction
 
-    /// Extracts the user ID from the web_profile_info response data.
     static func extractUserID(from data: Data) -> String? {
         guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let dataObj = json["data"] as? [String: Any],
@@ -235,7 +219,6 @@ extension InstagramProfileScraper {
 
     // MARK: - Feed Endpoint Parsing
 
-    /// Parses the response from `/api/v1/feed/user/{id}/`.
     static func parseFeedResponse(
         data: Data, username: String, displayName: String?
     ) -> [ParsedInstagramPost] {
@@ -262,9 +245,7 @@ extension InstagramProfileScraper {
         return posts
     }
 
-    /// Extracts the best available image URL from a media item.
     private static func bestImageURL(from item: [String: Any]) -> String? {
-        // image_versions2.candidates[] sorted by width
         if let imageVersions = item["image_versions2"] as? [String: Any],
            let candidates = imageVersions["candidates"] as? [[String: Any]] {
             let sorted = candidates.sorted {
@@ -274,7 +255,6 @@ extension InstagramProfileScraper {
                 return url
             }
         }
-        // Fallback keys
         return item["display_url"] as? String
             ?? item["thumbnail_src"] as? String
             ?? item["image_url"] as? String

--- a/Integrations/Instagram/InstagramProfileScraper+Fetching.swift
+++ b/Integrations/Instagram/InstagramProfileScraper+Fetching.swift
@@ -9,7 +9,6 @@ extension InstagramProfileScraper {
     struct InstagramCookies {
         let csrfToken: String
         let sessionID: String
-        /// All Instagram HTTP cookies for injection into URLSession.
         let allCookies: [HTTPCookie]
     }
 
@@ -25,11 +24,6 @@ extension InstagramProfileScraper {
         print("[InstagramProfileScraper] Fetching profile for handle: \(handle)")
         #endif
 
-        // Enforce a human-like gap since the previous scrape.  When several
-        // feeds refresh at once they serialise through `activeScrape`, so
-        // without this wait they would fire back-to-back in a tight burst
-        // - a strong automation signal.  Spacing them out imitates a user
-        // navigating between profiles.
         await Self.awaitHumanPacing()
 
         guard let cookies = Self.getInstagramCookies() else {
@@ -44,24 +38,13 @@ extension InstagramProfileScraper {
               + "total cookies: \(cookies.allCookies.count)")
         #endif
 
-        // Session is created once and shared between the profile-info
-        // and feed/user requests so cookie rotations from Set-Cookie
-        // headers accumulate in a single jar that we can persist at
-        // the end of the scrape.
         let session = makeSession(cookies: cookies)
 
-        // Fetch profile info and recent posts
         let profileData = await fetchProfileInfo(
             username: handle, cookies: cookies, session: session
         )
 
-        // Persist any cookies Instagram rotated during the scrape,
-        // even if parsing failed - otherwise Keychain drifts stale
-        // and the user eventually gets silently signed out.
         Self.persistRotatedCookies(from: session)
-
-        // Record completion time so the next serialised scrape can space
-        // itself out relative to when this one finished.
         Self.markRequestCompleted()
 
         guard let profileData else {
@@ -79,9 +62,7 @@ extension InstagramProfileScraper {
         return profileData
     }
 
-    /// Writes rotated cookies from the URLSession jar back to Keychain
-    /// so subsequent scrapes pick up refreshed `sessionid` / `csrftoken`
-    /// / `mid` values that Instagram issued via `Set-Cookie`.
+    /// Writes rotated Instagram cookies from the URLSession jar back to Keychain.
     private static func persistRotatedCookies(from session: URLSession) {
         guard let storage = session.configuration.httpCookieStorage else { return }
         let updated = (storage.cookies ?? []).filter {
@@ -93,11 +74,6 @@ extension InstagramProfileScraper {
 
     // MARK: - Human-Like Pacing
 
-    /// Timestamp of the most recently completed Instagram network request.
-    /// Used to enforce a minimum inter-scrape gap so a burst of feed
-    /// refreshes does not fire back-to-back.  Wrapped in an
-    /// `OSAllocatedUnfairLock` because `NSLock.lock()`/`unlock()` are
-    /// unavailable from async contexts under Swift 6 strict concurrency.
     private static let lastRequestCompletedAt = OSAllocatedUnfairLock<Date?>(
         initialState: nil
     )
@@ -106,15 +82,10 @@ extension InstagramProfileScraper {
         lastRequestCompletedAt.withLock { $0 = Date() }
     }
 
-    /// Sleeps for a randomised interval so consecutive Instagram requests
-    /// look like a human navigating, not a script.  The delay combines a
-    /// baseline jitter (always applied) with an additional cool-down that
-    /// only kicks in when we have just finished a previous request.
+    /// Sleeps for a randomised interval so consecutive Instagram requests look human-paced.
     static func awaitHumanPacing() async {
         let lastCompleted = lastRequestCompletedAt.withLock { $0 }
 
-        // Minimum gap between any two serialised scrapes - picked from a
-        // fairly wide range so the cadence is not predictable.
         let minCooldown: TimeInterval = 3.5
         let maxCooldown: TimeInterval = 9.0
 
@@ -133,9 +104,7 @@ extension InstagramProfileScraper {
         try? await Task.sleep(for: .seconds(delay))
     }
 
-    /// Short randomised pause used between back-to-back API calls inside
-    /// a single scrape (e.g. `web_profile_info` → `feed/user`).  Mimics a
-    /// user briefly looking at the profile before scrolling the feed.
+    /// Short randomised pause between back-to-back API calls inside a single scrape.
     static func awaitIntraScrapePause() async {
         let delay = TimeInterval.random(in: 0.9...2.6)
         #if DEBUG
@@ -146,9 +115,7 @@ extension InstagramProfileScraper {
 
     // MARK: - Accept-Language
 
-    /// Accept-Language header value derived from the user's preferred
-    /// locales, in the format Safari sends (primary locale at q=1.0,
-    /// additional locales at decreasing q values).
+    /// Accept-Language header value derived from the user's preferred locales, Safari-style.
     static var acceptLanguageHeader: String {
         let preferred = Locale.preferredLanguages.prefix(5)
         guard !preferred.isEmpty else { return "en-US,en;q=0.9" }
@@ -164,12 +131,8 @@ extension InstagramProfileScraper {
     @MainActor
     private static var cookieStoreWarmed = false
 
-    /// Loads a WKWebView with instagram.com to force `WKWebsiteDataStore`
-    /// to restore its persisted cookie jar from disk.
-    ///
-    /// This is now only used during the one-time Keychain migration in
-    /// `migrateWebKitCookiesIfNeeded()` - normal scrapes read directly
-    /// from the Keychain store and do not touch WebKit.
+    /// Loads Instagram in a WKWebView to restore its persisted cookie jar from disk.
+    /// Used only during the one-time Keychain migration.
     @MainActor
     static func warmCookieStore() async {
         guard !cookieStoreWarmed else { return }
@@ -187,8 +150,7 @@ extension InstagramProfileScraper {
 
     // MARK: - Cookies
 
-    /// Reads the current Instagram session from the Keychain-backed
-    /// cookie jar.  Synchronous and thread-safe - no WebKit hop.
+    /// Reads the current Instagram session from the Keychain-backed cookie jar.
     static func getInstagramCookies() -> InstagramCookies? {
         guard let cookies = InstagramProfileScraper.cookieStore.load() else {
             return nil
@@ -208,16 +170,11 @@ extension InstagramProfileScraper {
 
     // MARK: - Session Building
 
-    /// Creates a URLSession with all Instagram cookies injected into its
-    /// cookie storage. This is necessary because Instagram's API performs
-    /// redirect-based authentication - the cookies must be present in
-    /// the URLSession's cookie jar, not just in request headers.
+    /// Creates a URLSession with Instagram cookies injected so redirects carry auth.
     private func makeSession(cookies: InstagramCookies) -> URLSession {
         let config = URLSessionConfiguration.ephemeral
         config.httpShouldSetCookies = true
         config.httpCookieAcceptPolicy = .always
-        // Ephemeral config creates its own empty cookie storage;
-        // inject all WKWebView cookies so redirects carry auth.
         if let storage = config.httpCookieStorage {
             for cookie in cookies.allCookies {
                 storage.setCookie(cookie)
@@ -230,7 +187,6 @@ extension InstagramProfileScraper {
 
     func buildRequest(url: URL, cookies: InstagramCookies,
                       referer: String = "https://www.instagram.com/") -> URLRequest {
-        // Jitter the timeout slightly so the fingerprint isn't a flat 15s.
         let jitteredTimeout = requestTimeoutInterval + TimeInterval.random(in: -1.5...2.5)
         var request = URLRequest(url: url, timeoutInterval: max(5, jitteredTimeout))
         request.setValue(sakuraUserAgent, forHTTPHeaderField: "User-Agent")
@@ -243,19 +199,13 @@ extension InstagramProfileScraper {
         request.setValue("empty", forHTTPHeaderField: "sec-fetch-dest")
         request.setValue(Self.webAppID, forHTTPHeaderField: "x-ig-app-id")
 
-        // Browser-parity headers.  Mobile Safari sends all of these on
-        // every XHR; omitting them makes the request fingerprint stick
-        // out against genuine web traffic.
         request.setValue("*/*", forHTTPHeaderField: "Accept")
         request.setValue(Self.acceptLanguageHeader, forHTTPHeaderField: "Accept-Language")
-        // NOTE: Do not set Accept-Encoding manually - URLSession sets its
-        // own supported value and transparently decodes the body.  Setting
-        // it here would disable that auto-decoding and break JSON parsing.
+        // Do not set Accept-Encoding manually; URLSession handles decoding.
         request.setValue("no-cache", forHTTPHeaderField: "Cache-Control")
         request.setValue("no-cache", forHTTPHeaderField: "Pragma")
         request.setValue("keep-alive", forHTTPHeaderField: "Connection")
 
-        // Build the full cookie header from all Instagram cookies
         let cookieHeader = HTTPCookie.requestHeaderFields(with: cookies.allCookies)
         for (key, value) in cookieHeader {
             request.setValue(value, forHTTPHeaderField: key)
@@ -309,15 +259,12 @@ extension InstagramProfileScraper {
             return nil
         }
 
-        // The web_profile_info endpoint often returns edges: [] even when
-        // posts exist. Fall back to the feed endpoint using the user ID.
+        // web_profile_info often returns empty edges even when posts exist; fall back to feed endpoint.
         if result.posts.isEmpty, let userId = Self.extractUserID(from: data) {
             #if DEBUG
             print("[InstagramProfileScraper] Profile had 0 posts, "
                   + "fetching feed for user ID: \(userId)")
             #endif
-            // Mimic a user briefly looking at the profile before the web
-            // client fires the follow-up feed XHR.
             await Self.awaitIntraScrapePause()
             let feedPosts = await fetchUserFeed(
                 userId: userId, username: username,
@@ -338,8 +285,7 @@ extension InstagramProfileScraper {
 
     // MARK: - User Feed Endpoint
 
-    /// Fetches posts from the `/api/v1/feed/user/{id}/` endpoint, which
-    /// reliably returns post data when `web_profile_info` edges are empty.
+    /// Fetches posts from the user feed endpoint when `web_profile_info` edges are empty.
     private func fetchUserFeed(
         userId: String, username: String, displayName: String?,
         cookies: InstagramCookies, session: URLSession
@@ -350,9 +296,6 @@ extension InstagramProfileScraper {
             return []
         }
 
-        // Use the profile page as the referer - that is what a real
-        // browser sends when the follow-up feed XHR fires from the
-        // profile page context.
         let profileReferer = "https://www.instagram.com/\(username)/"
         let request = buildRequest(url: url, cookies: cookies, referer: profileReferer)
 

--- a/Integrations/Instagram/InstagramProfileScraper.swift
+++ b/Integrations/Instagram/InstagramProfileScraper.swift
@@ -1,7 +1,6 @@
 import Foundation
 import WebKit
 
-/// Parsed post from an Instagram profile.
 struct ParsedInstagramPost: Sendable {
     let id: String
     let text: String
@@ -9,41 +8,27 @@ struct ParsedInstagramPost: Sendable {
     let authorHandle: String
     let url: String
     let imageURL: String?
-    /// All image URLs for carousel posts (includes the primary imageURL).
-    /// Empty for single-image posts.
+    /// Includes the primary imageURL; empty for single-image posts.
     let carouselImageURLs: [String]
     let publishedDate: Date?
 }
 
-/// Result of scraping an Instagram profile: posts and optional profile metadata.
 struct InstagramProfileScrapeResult: Sendable {
     let posts: [ParsedInstagramPost]
     let profileImageURL: String?
     let displayName: String?
 }
 
-/// Fetches posts from an Instagram profile using the web API.
-///
-/// Session cookies are kept in a Keychain-backed store (`cookieStore`)
-/// populated from the login WebView on success and, for users upgrading
-/// from older builds, by a one-time migration from `WKWebsiteDataStore`.
+/// Fetches Instagram profile posts via the web API using Keychain-stored session cookies.
 final class InstagramProfileScraper {
 
-    /// Per-request timeout used for every URLRequest this scraper builds.
-    /// Callers that perform cosmetic work (e.g. favicon avatar lookups)
-    /// can raise this value to effectively bypass the normal timeout.
-    /// Marked `nonisolated(unsafe)` so it can be configured from the
-    /// favicon cache's nonisolated avatar-fetching methods; the value
-    /// is only ever set before network calls start, so there is no
-    /// meaningful data race.
+    // `nonisolated(unsafe)` so favicon cache can raise this; only set before network calls.
     nonisolated(unsafe) var requestTimeoutInterval: TimeInterval = 15
 
-    /// Instagram's web application ID, embedded in their JS bundle.
     static let webAppID = "936619743392459"
 
     static let targetPostCount = 50
 
-    /// Serialises access so only one fetch runs at a time.
     private static var activeScrape: Task<InstagramProfileScrapeResult, Never>?
 
     static let cookieStore = KeychainCookieStore(
@@ -52,10 +37,7 @@ final class InstagramProfileScraper {
 
     // MARK: - Public
 
-    /// Fetches the most recent posts from the given profile URL.
-    /// Also extracts the profile photo URL and display name.
-    ///
-    /// Only one fetch runs at a time; concurrent calls are serialised.
+    /// Fetches the most recent posts plus profile metadata. Concurrent calls are serialised.
     func scrapeProfile(profileURL: URL) async -> InstagramProfileScrapeResult {
         if let existing = Self.activeScrape {
             _ = await existing.value
@@ -72,18 +54,15 @@ final class InstagramProfileScraper {
 
     // MARK: - Static Helpers
 
-    /// Returns true if the URL points to a specific Instagram post.
     nonisolated static func isInstagramPostURL(_ url: URL) -> Bool {
         guard let host = url.host?.lowercased() else { return false }
         let isInstagramDomain = host == "instagram.com" || host == "www.instagram.com"
         guard isInstagramDomain else { return false }
         let components = url.pathComponents
-        // /p/SHORTCODE/ or /reel/SHORTCODE/
         return components.count >= 3
             && (components[1] == "p" || components[1] == "reel")
     }
 
-    /// Returns true if the URL points to an Instagram profile.
     nonisolated static func isInstagramProfileURL(_ url: URL) -> Bool {
         guard let host = url.host?.lowercased() else { return false }
         let isInstagramDomain = host == "instagram.com" || host == "www.instagram.com"
@@ -104,7 +83,6 @@ final class InstagramProfileScraper {
         return !reserved.contains(handle.lowercased())
     }
 
-    /// Extracts the username handle from an Instagram profile URL.
     nonisolated static func extractHandle(from url: URL) -> String? {
         let path = url.path
         guard path.count > 1 else { return nil }
@@ -113,31 +91,24 @@ final class InstagramProfileScraper {
             .map(String.init)
     }
 
-    /// Constructs a canonical Instagram profile URL from a handle.
     nonisolated static func profileURL(for handle: String) -> URL? {
         URL(string: "https://www.instagram.com/\(handle)/")
     }
 
-    /// The pseudo-feed URL stored in the database for an Instagram profile.
     nonisolated static func feedURL(for handle: String) -> String {
         "instagram-profile://\(handle.lowercased())"
     }
 
-    /// Checks if a feed URL is an Instagram pseudo-feed.
     nonisolated static func isInstagramFeedURL(_ url: String) -> Bool {
         url.hasPrefix("instagram-profile://")
     }
 
-    /// Extracts the handle from an Instagram pseudo-feed URL.
     nonisolated static func handleFromFeedURL(_ url: String) -> String? {
         guard isInstagramFeedURL(url) else { return nil }
         return String(url.dropFirst("instagram-profile://".count))
     }
 
-    /// Checks if the user has Instagram cookies (i.e. is logged in).
-    ///
-    /// Kept `async` for API stability with the old WebKit-backed
-    /// implementation; the body is a synchronous Keychain read.
+    // `async` is kept for API stability with the old WebKit-backed implementation.
     static func hasInstagramSession() async -> Bool {
         guard let cookies = cookieStore.load() else { return false }
         return cookies.contains { cookie in
@@ -145,8 +116,7 @@ final class InstagramProfileScraper {
         }
     }
 
-    /// Clears Instagram session cookies from both Keychain and the
-    /// WebKit data store (so the login WebView starts fresh).
+    /// Clears Instagram cookies from Keychain and the WebKit data store.
     @MainActor
     static func clearInstagramSession() async {
         cookieStore.clear()
@@ -158,10 +128,7 @@ final class InstagramProfileScraper {
         }
     }
 
-    /// Exports any Instagram cookies present in the default
-    /// `WKWebsiteDataStore` into Keychain.  Called after the user
-    /// completes the login flow in `InstagramLoginView` so that the
-    /// scraper's Keychain-backed session check can find them.
+    /// Exports Instagram cookies from `WKWebsiteDataStore` into Keychain after login.
     @MainActor
     static func syncCookiesFromWebKit() async {
         let store = WKWebsiteDataStore.default()
@@ -178,21 +145,13 @@ final class InstagramProfileScraper {
         #endif
     }
 
-    /// One-time migration for users upgrading from the WebKit-only
-    /// storage model.  If Keychain is empty but the WebKit data store
-    /// holds Instagram cookies from a prior install, copy them over so
-    /// the user stays signed in without having to log in again.
-    ///
-    /// Safe to call repeatedly - the Keychain-empty check makes it a
-    /// no-op after the first successful migration.
+    /// One-time migration from WebKit-only storage to Keychain. Safe to call repeatedly.
     @MainActor
     static func migrateWebKitCookiesIfNeeded() async {
-        // Fast path: already migrated.
         if cookieStore.load() != nil { return }
 
-        // Force WebKit to restore its on-disk cookie store before we
-        // inspect it - on a cold launch `allCookies()` returns an empty
-        // array until a WKWebView has loaded a page from the domain.
+        // Force WebKit to restore its on-disk cookie store before inspection -
+        // on a cold launch `allCookies()` returns empty until a WKWebView loads the domain.
         await warmCookieStore()
         await syncCookiesFromWebKit()
     }

--- a/Integrations/Note/NoteProfileScraper+Fetching.swift
+++ b/Integrations/Note/NoteProfileScraper+Fetching.swift
@@ -2,10 +2,6 @@ import Foundation
 
 extension NoteProfileScraper {
 
-    /// Calls the v2 creators API and extracts the profile photo URL and
-    /// display name. Returns an empty result on any failure; the favicon
-    /// lookup path treats this as a miss and falls back to the generic
-    /// favicon fetch.
     func performFetch(url: URL) async -> NoteProfileScrapeResult {
         var request = URLRequest(url: url)
         request.setValue(sakuraUserAgent, forHTTPHeaderField: "User-Agent")

--- a/Integrations/Note/NoteProfileScraper.swift
+++ b/Integrations/Note/NoteProfileScraper.swift
@@ -1,17 +1,13 @@
 import Foundation
 
-/// Result of scraping a note.com creator via the public `/api/v2/creators`
-/// endpoint.
 struct NoteProfileScrapeResult: Sendable {
     let profileImageURL: String?
     let displayName: String?
 }
 
-/// Fetches note.com creator metadata (profile photo, display name) from the
-/// public v2 creators API. No login required.
+/// Fetches note.com creator metadata via the public v2 creators API.
 final class NoteProfileScraper {
 
-    /// Path segments that live under `note.com` but are not creator handles.
     nonisolated static let reservedHandles: Set<String> = [
         "api", "search", "magazine", "magazines", "circle", "login", "signup",
         "hashtag", "topic", "topics", "notifications", "settings", "m", "info",
@@ -20,8 +16,6 @@ final class NoteProfileScraper {
 
     // MARK: - Static Helpers
 
-    /// Returns true if the URL points to a note.com creator profile page
-    /// (e.g. `https://note.com/<urlname>`). Excludes RSS and article URLs.
     nonisolated static func isNoteProfileURL(_ url: URL) -> Bool {
         guard isNoteHost(url.host) else { return false }
         let components = url.pathComponents.filter { $0 != "/" }
@@ -29,7 +23,6 @@ final class NoteProfileScraper {
         return isValidHandle(components[0])
     }
 
-    /// Returns true if the feed URL points at note.com's `/rss` endpoint.
     nonisolated static func isNoteFeedURL(_ urlString: String) -> Bool {
         guard let url = URL(string: urlString) else { return false }
         guard isNoteHost(url.host) else { return false }
@@ -39,8 +32,6 @@ final class NoteProfileScraper {
         return isValidHandle(components[0])
     }
 
-    /// Extracts the creator's urlname from any note.com URL (profile, RSS,
-    /// article, etc.).
     nonisolated static func extractHandle(from url: URL) -> String? {
         guard isNoteHost(url.host) else { return nil }
         let components = url.pathComponents.filter { $0 != "/" }
@@ -48,17 +39,14 @@ final class NoteProfileScraper {
         return isValidHandle(first) ? first : nil
     }
 
-    /// Constructs the canonical RSS feed URL for a creator.
     nonisolated static func feedURL(for handle: String) -> String {
         "https://note.com/\(handle)/rss"
     }
 
-    /// Constructs the public profile URL for a creator.
     nonisolated static func profileURL(for handle: String) -> URL? {
         URL(string: "https://note.com/\(handle)")
     }
 
-    /// Constructs the v2 creators API URL used to fetch metadata.
     nonisolated static func creatorAPIURL(for handle: String) -> URL? {
         URL(string: "https://note.com/api/v2/creators/\(handle)")
     }
@@ -75,7 +63,6 @@ final class NoteProfileScraper {
 
     // MARK: - Public
 
-    /// Fetches metadata for the given creator handle.
     func scrapeProfile(handle: String) async -> NoteProfileScrapeResult {
         guard let url = Self.creatorAPIURL(for: handle) else {
             return NoteProfileScrapeResult(profileImageURL: nil, displayName: nil)

--- a/Integrations/Petal/PetalAutoDetect.swift
+++ b/Integrations/Petal/PetalAutoDetect.swift
@@ -1,38 +1,9 @@
 import Foundation
 import SwiftSoup
 
-/// Heuristic selector inference for Web Feed recipes.
-///
-/// When the user hits "Auto-Detect" in the builder, this inspects
-/// the fetched HTML for a repeating container pattern that looks
-/// like a feed index: three or more sibling-like elements that
-/// each wrap a link, a heading, and (optionally) an image.  If one
-/// is found, it returns a partially-filled `PetalRecipe` with
-/// suggested selectors the user can tweak.
-///
-/// The heuristic is intentionally conservative - it prefers
-/// **returning nothing** over returning selectors that match the
-/// wrong elements, because a bad auto-detect is a worse UX than
-/// no auto-detect at all.
-///
-/// Algorithm, in broad strokes:
-///
-/// 1. Collect every `<a href>` on the page and walk up to three
-///    ancestors to fingerprint the enclosing container (tag plus
-///    first CSS class).
-/// 2. Group the walk hits by fingerprint and score each one by
-///    how many distinct anchors it contains.  Prefer fingerprints
-///    with a class over bare tag names (class-less containers
-///    like `div` tend to match way too loosely).
-/// 3. Validate the winner by re-running the selector through
-///    SwiftSoup and making sure it actually matches ≥ 3 elements.
-/// 4. For the first matching container, probe common child
-///    selectors for title / link / image / date / summary and
-///    return whichever ones land.
+/// Heuristic selector inference for Web Feed recipes, used by the builder's Auto-Detect.
 nonisolated enum PetalAutoDetect {
 
-    /// Hands back a partial recipe seeded with guessed selectors,
-    /// or `nil` if no repeating pattern looks confident enough.
     static func detect(html: String, siteURL: String) -> PetalRecipe? {
         guard let document = try? SwiftSoup.parse(html, siteURL) else {
             return nil
@@ -41,9 +12,6 @@ nonisolated enum PetalAutoDetect {
         guard let itemSelector = findItemSelector(in: document) else {
             return nil
         }
-        // Re-select through the document so the first item we hand
-        // to the child-selector probes is the same one a subsequent
-        // `PetalEngine.parse` run would hit.
         guard let firstItem = try? document.select(itemSelector).first() else {
             return nil
         }
@@ -76,22 +44,11 @@ nonisolated enum PetalAutoDetect {
 
     // MARK: - Item selector
 
-    /// Scores candidate container fingerprints and picks the best.
-    /// Returns `nil` if no fingerprint matched enough repeating
-    /// elements to be worth surfacing.
     private static func findItemSelector(in document: Document) -> String? {
         guard let links = try? document.select("a[href]") else {
             return nil
         }
 
-        // Fingerprint → (anchor count, element count)
-        // `anchorCount` counts how many distinct `<a href>`s are
-        // reachable under the fingerprint; `elementCount` is how
-        // many siblings the fingerprint itself expands to when
-        // re-selected from the document root.  We pick using both
-        // because a fingerprint that matches 12 elements each
-        // containing 1 link beats one that matches 2 elements each
-        // containing 6 links.
         var anchorCounts: [String: Int] = [:]
         var seenAnchorsByFingerprint: [String: Set<Int>] = [:]
 
@@ -112,9 +69,6 @@ nonisolated enum PetalAutoDetect {
             }
         }
 
-        // Only keep fingerprints that wrap ≥ 3 distinct anchors.
-        // The cut-off rejects once-only nav bars and footer
-        // groups that happen to show up in the same DOM path.
         let ranked = anchorCounts
             .filter { $0.value >= 3 }
             .sorted { lhs, rhs in
@@ -129,8 +83,6 @@ nonisolated enum PetalAutoDetect {
                   matched.count >= 3 else {
                 continue
             }
-            // Avoid overly permissive matches like `div` alone
-            // that sweep in headers and sidebars.
             if matched.count > 60 && !candidate.key.contains(".") {
                 continue
             }
@@ -139,12 +91,6 @@ nonisolated enum PetalAutoDetect {
         return nil
     }
 
-    /// Builds a compact CSS selector for an element: `tag.class`
-    /// when it has a class, or just `tag` otherwise.  Multiple
-    /// classes collapse to the first non-empty one because (a)
-    /// chaining every class tends to produce brittle selectors
-    /// and (b) many sites decorate elements with utility classes
-    /// (Tailwind, Bootstrap) that don't survive layout changes.
     private static func fingerprintFor(_ element: Element) -> String {
         let tag = element.tagName().lowercased()
         let className = (try? element.className()) ?? ""
@@ -158,7 +104,6 @@ nonisolated enum PetalAutoDetect {
     // MARK: - Child selectors
 
     private static func findTitleSelector(in item: Element) -> String? {
-        // Order matters - the first one that hits wins.
         let candidates = ["h1", "h2", "h3", "h4", ".title", "[itemprop=headline]"]
         for selector in candidates {
             if let element = try? item.select(selector).first(),
@@ -171,14 +116,9 @@ nonisolated enum PetalAutoDetect {
     }
 
     private static func findLinkSelector(in item: Element) -> String? {
-        // If there's a single <a href> inside the item the engine's
-        // fallback already handles it - no need to lock a brittle
-        // selector in.  Only return a selector when there are
-        // multiple anchors (e.g. author bylines + main link).
         guard let anchors = try? item.select("a[href]"), anchors.count > 1 else {
             return nil
         }
-        // Prefer the anchor wrapping the title.
         if let titleLink = try? item.select("h1 a, h2 a, h3 a, h4 a").first(),
            (try? titleLink.attr("href"))?.isEmpty == false {
             return "h1 a, h2 a, h3 a, h4 a"
@@ -190,9 +130,6 @@ nonisolated enum PetalAutoDetect {
         guard let img = try? item.select("img[src]").first() else {
             return nil
         }
-        // If there are multiple imgs, stick with the first.  No
-        // selector tightening - the engine's default already picks
-        // the first `<img src>` inside an item.
         if (try? img.attr("src"))?.isEmpty == false {
             return "img"
         }
@@ -215,15 +152,11 @@ nonisolated enum PetalAutoDetect {
         in item: Element,
         excluding titleSelector: String?
     ) -> String? {
-        // The first paragraph inside the item is a reasonable
-        // summary candidate, as long as it isn't the same element
-        // we already picked for the title.
         guard let paragraph = try? item.select("p").first(),
               let text = try? paragraph.text(),
               !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             return nil
         }
-        // If the title selector is something like `p` we'd collide.
         if titleSelector == "p" { return nil }
         return "p"
     }

--- a/Integrations/Petal/PetalEngine/PetalEngine+Dates.swift
+++ b/Integrations/Petal/PetalEngine/PetalEngine+Dates.swift
@@ -4,13 +4,7 @@ nonisolated extension PetalEngine {
 
     // MARK: - Flexible date parsing
 
-    /// Parses timestamps using a handful of common formats.
-    /// Falls back to `ISO8601DateFormatter` and the system-locale
-    /// date parsers so the builder doesn't need a date-format
-    /// picker for the most common cases.
-    ///
-    /// Package-internal because `PetalEngine+Parsing` calls it
-    /// from across the file boundary.
+    /// Parses timestamps using ISO8601 and a handful of common fallback formats.
     static func parseFlexibleDate(_ raw: String) -> Date? {
         if let iso = isoFormatter.date(from: raw) {
             return iso
@@ -28,13 +22,8 @@ nonisolated extension PetalEngine {
 
     // MARK: - Formatter caches
 
-    // `ISO8601DateFormatter` and `DateFormatter` have been
-    // documented as thread-safe for read-only use since iOS 7/11
-    // respectively, but Foundation has never marked them
-    // `Sendable`.  These caches are only ever read - the setup
-    // closures configure the formatters once at first access and
-    // nothing mutates them afterwards - so `nonisolated(unsafe)`
-    // is the correct Swift 6 escape hatch.
+    // Foundation date formatters are thread-safe for read-only use but not Sendable,
+    // so `nonisolated(unsafe)` is used since these caches are never mutated after setup.
 
     nonisolated(unsafe) static let isoFormatter: ISO8601DateFormatter = {
         let formatter = ISO8601DateFormatter()

--- a/Integrations/Petal/PetalEngine/PetalEngine+Fetching.swift
+++ b/Integrations/Petal/PetalEngine/PetalEngine+Fetching.swift
@@ -4,10 +4,7 @@ nonisolated extension PetalEngine {
 
     // MARK: - Fetching
 
-    /// Dispatches to the right fetch path for the recipe's mode.
-    /// Package-internal (not `private`) because the main file's
-    /// public entry points call into it from across the file
-    /// boundary.
+    /// Dispatches to the static or rendered fetch path for the recipe.
     static func fetchHTML(
         for recipe: PetalRecipe,
         pageURL overrideURL: String?
@@ -26,9 +23,6 @@ nonisolated extension PetalEngine {
 
     // MARK: - Static HTML
 
-    /// Straight-through `URLSession` GET.  Uses the shared
-    /// `URLRequest.sakura(...)` helper so Web Feed requests look
-    /// identical to the rest of the app's RSS traffic.
     private static func fetchStaticHTML(from url: URL) async -> String? {
         do {
             let (data, response) = try await URLSession.shared.data(
@@ -47,15 +41,7 @@ nonisolated extension PetalEngine {
 
     // MARK: - Rendered HTML (WKWebView)
 
-    /// Loads the page in a `WKWebView` and waits for JS
-    /// hydration - needed for React / Vue / Next single-page
-    /// apps whose initial HTML response is a near-empty shell.
-    ///
-    /// The loader is `@MainActor` because `WKWebView` has to
-    /// live on the main thread, so construction *and* the
-    /// suspending `loadHTML` call are both wrapped in a single
-    /// main-actor `Task` to keep the reference from ever
-    /// escaping the main actor.
+    /// Loads the page in a `WKWebView` and waits for JS hydration.
     private static func fetchRenderedHTML(from url: URL) async -> String? {
         await Task { @MainActor in
             await PetalWebViewLoader().loadHTML(from: url)

--- a/Integrations/Petal/PetalEngine/PetalEngine+Parsing.swift
+++ b/Integrations/Petal/PetalEngine/PetalEngine+Parsing.swift
@@ -6,8 +6,6 @@ nonisolated extension PetalEngine {
     // MARK: - Parsing
 
     /// Runs the recipe's selectors against the given HTML.
-    /// Public so the builder can feed pre-fetched HTML in
-    /// without re-fetching on every keystroke.
     static func parse(html: String, recipe: PetalRecipe) -> [ParsedArticle] {
         let base = URL(string: recipe.baseURL ?? recipe.siteURL)
         do {
@@ -35,7 +33,6 @@ nonisolated extension PetalEngine {
         recipe: PetalRecipe,
         baseURL: URL?
     ) -> ParsedArticle? {
-        // Link - required.  Without a URL there's nothing to show.
         guard let linkString = extractLink(item: item, recipe: recipe),
               let resolvedURL = resolveURL(linkString, base: baseURL) else {
             return nil
@@ -80,7 +77,6 @@ nonisolated extension PetalEngine {
            !value.isEmpty {
             return value
         }
-        // Fall back to the first <a href> inside the item.
         if let anchor = try? item.select("a[href]").first(),
            let href = try? anchor.attr("href"), !href.isEmpty {
             return href
@@ -117,7 +113,6 @@ nonisolated extension PetalEngine {
                 return resolveURL(value, base: baseURL)
             }
         }
-        // Fall back to the first <img src> inside the item.
         if let img = try? item.select("img[src]").first(),
            let value = try? img.attr("src"), !value.isEmpty {
             return resolveURL(value, base: baseURL)
@@ -147,9 +142,6 @@ nonisolated extension PetalEngine {
     // MARK: - URL resolution
 
     /// Resolves a potentially relative URL against a base.
-    /// Mirrors `ArticleExtractor.resolveURL` but kept local so
-    /// the engine has no cross-module dependency beyond
-    /// Foundation + SwiftSoup.
     private static func resolveURL(_ href: String, base: URL?) -> String? {
         let trimmed = href.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }

--- a/Integrations/Petal/PetalEngine/PetalEngine.swift
+++ b/Integrations/Petal/PetalEngine/PetalEngine.swift
@@ -1,28 +1,6 @@
 import Foundation
 
-/// Runs a `PetalRecipe` against its source page and emits
-/// `ParsedArticle` values the feed-refresh pipeline already knows
-/// how to insert.
-///
-/// The engine intentionally re-uses `SwiftSoup` (already a dep for
-/// `ArticleExtractor`) and the same `URLRequest.sakura(...)` helper
-/// the rest of the app uses, so a Web Feed's network fingerprint
-/// is indistinguishable from a normal RSS fetch.
-///
-/// `PetalEngine` is `nonisolated` so it can run from any actor.
-/// The one exception is `fetchMode == .rendered`, which hops to
-/// the main actor inside `PetalEngine+Fetching` to drive a
-/// `WKWebView`.
-///
-/// Implementation lives across several files in this folder:
-///   - `PetalEngine.swift` - this file: type, nested values,
-///     and the two public entry points.
-///   - `PetalEngine+Fetching.swift` - HTML retrieval (static
-///     URLSession + rendered WKWebView).
-///   - `PetalEngine+Parsing.swift` - SwiftSoup selector runner
-///     and per-item extractors.
-///   - `PetalEngine+Dates.swift` - flexible date parsing with
-///     shared formatter caches.
+/// Runs a `PetalRecipe` against its source page and emits `ParsedArticle` values.
 nonisolated enum PetalEngine {
 
     struct PreviewResult: Sendable {
@@ -33,10 +11,8 @@ nonisolated enum PetalEngine {
 
     // MARK: - Public API
 
-    /// Runs the recipe and returns matching items as
-    /// `ParsedArticle`s.  `pageURL` overrides `recipe.siteURL`
-    /// (used by the builder preview when the user is editing the
-    /// source URL live).
+    /// Runs the recipe and returns matching items as `ParsedArticle`s.
+    /// `pageURL` overrides `recipe.siteURL` for live builder previews.
     static func fetchArticles(
         for recipe: PetalRecipe,
         pageURL overrideURL: String? = nil
@@ -48,9 +24,7 @@ nonisolated enum PetalEngine {
         return parse(html: html, recipe: recipe)
     }
 
-    /// Runs the recipe and returns a preview payload with a
-    /// small HTML sample the builder UI shows for debugging "why
-    /// didn't my selector match?".
+    /// Runs the recipe and returns a preview with an HTML sample for selector debugging.
     static func preview(
         for recipe: PetalRecipe,
         pageURL overrideURL: String? = nil

--- a/Integrations/Petal/PetalPackage/PetalPackage+Export.swift
+++ b/Integrations/Petal/PetalPackage/PetalPackage+Export.swift
@@ -4,9 +4,7 @@ nonisolated extension PetalPackage {
 
     // MARK: - Export
 
-    /// Serializes a recipe (plus optional icon) into a `.srss`
-    /// blob.  Recipes, metadata, and an optional PNG icon are
-    /// bundled together as a ZIP archive.
+    /// Serializes a recipe plus optional icon into a `.srss` ZIP archive.
     static func export(
         recipe: PetalRecipe,
         iconPNG: Data? = nil
@@ -34,19 +32,8 @@ nonisolated extension PetalPackage {
         return PetalZip.write(entries: entries)
     }
 
-    /// Convenience: exports straight to a temp file and returns
-    /// the URL so callers can hand it to `ShareLink` /
-    /// `fileExporter`.
-    ///
-    /// The output goes into a *fresh, UUID-named* subdirectory of
-    /// the temp directory rather than the temp directory itself.
-    /// Even though `sanitizedFilename` already strips path
-    /// separators, writing into a throwaway subdirectory makes
-    /// the trust barrier between the user-controlled `recipe.name`
-    /// and the real filesystem explicit - a malicious name can
-    /// only clobber files inside the one-use subfolder we just
-    /// created.  The resolved path is re-checked to guarantee it
-    /// lives under the sandbox folder before we write anything.
+    /// Exports to a temp file and returns the URL for `ShareLink` / `fileExporter`.
+    /// Writes into a fresh UUID-named subdirectory to sandbox the user-controlled name.
     static func exportToTempFile(
         recipe: PetalRecipe,
         iconPNG: Data? = nil
@@ -63,10 +50,7 @@ nonisolated extension PetalPackage {
         )
 
         let tempURL = sandbox.appendingPathComponent(filename)
-        // Defense in depth: reject any path that escapes the
-        // sandbox after normalization.  This can't happen with
-        // the current sanitizer, but the guard documents the
-        // invariant and keeps Sonar / future refactors honest.
+        // Defense in depth: reject any path that escapes the sandbox after normalization.
         let resolvedPath = tempURL.standardizedFileURL.path
         let sandboxPath = sandbox.standardizedFileURL.path
         guard resolvedPath.hasPrefix(sandboxPath + "/") else {

--- a/Integrations/Petal/PetalPackage/PetalPackage+Import.swift
+++ b/Integrations/Petal/PetalPackage/PetalPackage+Import.swift
@@ -4,15 +4,9 @@ nonisolated extension PetalPackage {
 
     // MARK: - Import
 
-    /// Parses a `.srss` package from raw bytes.  Use the URL
-    /// overload when you have a file URL; this one handles raw
-    /// `Data` for tests and share-extension pass-through.
+    /// Parses a `.srss` package from raw bytes.
     static func importPackage(from data: Data) throws -> ImportedPackage {
-        // Reject oversized payloads before even trying to unzip
-        // them.  Legitimate packages are a few KB; anything past
-        // the ZIP reader's total budget is rejected outright so
-        // the user sees a friendly error instead of a generic
-        // "malformed".
+        // Reject oversized payloads up front so users see `tooLarge` instead of `malformed`.
         guard data.count <= PetalZip.Limits.maxTotalUncompressedSize * 2 else {
             throw PackageError.tooLarge
         }
@@ -62,10 +56,7 @@ nonisolated extension PetalPackage {
         return recipe
     }
 
-    /// Decoding the metadata is best-effort: if the sidecar is
-    /// missing or unreadable we synthesise one rather than
-    /// failing the whole import, because a valid recipe alone is
-    /// still a usable package.
+    /// Best-effort metadata decode; synthesises a default if the sidecar is missing.
     private static func decodeMetadata(
         from entries: [PetalZip.Entry]
     ) -> Metadata {

--- a/Integrations/Petal/PetalPackage/PetalPackage.swift
+++ b/Integrations/Petal/PetalPackage/PetalPackage.swift
@@ -2,36 +2,11 @@ import Foundation
 import UniformTypeIdentifiers
 
 /// Import/export helpers for `.srss` (Sakura Web Feed) packages.
-///
-/// A `.srss` file is a small ZIP archive containing:
-///
-/// ```
-/// recipe.json    PetalRecipe JSON
-/// icon.png       optional feed icon
-/// metadata.json  { "formatVersion": 1, "exportedAt": ..., "appVersion": ... }
-/// ```
-///
-/// The format is intentionally simple so power users can hand-edit
-/// their recipes outside the app, and the metadata sidecar gives
-/// the importer somewhere to reject future incompatible formats.
-///
-/// Implementation lives across several files in this folder:
-///   - `PetalPackage.swift` - this file: type, nested values,
-///     UTType plumbing, and shared helpers.
-///   - `PetalPackage+Export.swift` - serialization / temp-file
-///     export.
-///   - `PetalPackage+Import.swift` - parsing / validation.
 nonisolated enum PetalPackage {
 
     static let fileExtension = "srss"
     static let mimeType = "application/x-sakura-rss"
 
-    /// UTType used by `fileImporter` and `fileExporter` to
-    /// recognize `.srss` packages.  The type is declared in
-    /// `Info.plist` as an exported type conforming to
-    /// `public.zip-archive`; here we resolve it at runtime and
-    /// fall back to a dynamic type built from the file extension
-    /// so a misconfigured plist can't break the importer sheet.
     static let contentType: UTType = {
         if let registered = UTType("com.tsubuzaki.SakuraRSS.petal") {
             return registered
@@ -43,8 +18,6 @@ nonisolated enum PetalPackage {
         return .zip
     }()
 
-    /// Current on-disk package format.  Bump whenever the contents
-    /// of `recipe.json` become non-forward-compatible.
     static let formatVersion = 1
 
     enum PackageError: LocalizedError {
@@ -82,10 +55,6 @@ nonisolated enum PetalPackage {
 
     // MARK: - Shared helpers
 
-    /// Builds a JSON encoder configured the way both `.srss`
-    /// metadata and the recipe use it - pretty-printed with
-    /// sorted keys so hand-diffs stay stable, and ISO8601 dates
-    /// so the format survives a trip through non-Apple tooling.
     static func makeJSONEncoder() -> JSONEncoder {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
@@ -99,10 +68,8 @@ nonisolated enum PetalPackage {
         return decoder
     }
 
-    /// Strips filesystem-hostile characters from a feed name so
-    /// it can safely become a filename.  Does **not** by itself
-    /// prevent path escapes - callers must still sandbox the
-    /// resulting write destination.  See `exportToTempFile`.
+    /// Strips filesystem-hostile characters from a feed name. Callers must
+    /// still sandbox the resulting write destination to prevent path escapes.
     static func sanitizedFilename(_ raw: String) -> String {
         let invalid = CharacterSet(charactersIn: "/\\:*?\"<>|")
         let sanitized = raw

--- a/Integrations/Petal/PetalRecipe.swift
+++ b/Integrations/Petal/PetalRecipe.swift
@@ -1,87 +1,44 @@
 import Foundation
 
 /// A user-defined recipe that turns a webpage into a feed.
-///
-/// Petals ship alongside the regular RSS/Atom plumbing: the feed's
-/// `url` is rewritten to `petal://<siteURL>` so `refreshFeed`
-/// dispatches to `PetalEngine` instead of `RSSParser`, mirroring the
-/// pattern already used for X / Instagram / YouTube pseudo-feeds.
-///
-/// Recipes are portable: exporting a Petal writes a `.srss` package
-/// (ZIP) containing the encoded recipe, an optional feed icon, and a
-/// small metadata blob identifying the app version that created it.
 nonisolated struct PetalRecipe: Codable, Sendable, Hashable {
 
-    /// Recipe format version. Bump when the decoder can no longer
-    /// read older payloads so imports can fail gracefully.
     static let currentVersion = 1
 
     var version: Int = PetalRecipe.currentVersion
 
-    /// Stable identifier.  Used to key the on-disk JSON and icon files.
     let id: UUID
 
-    /// Feed display title (also becomes the `Feed.title`).
     var name: String
 
-    /// Source page URL the recipe runs against on every refresh.
     var siteURL: String
 
-    /// How to fetch the page before running selectors.
-    ///
-    /// - `.staticHTML`: plain `URLSession` GET. Fast, but can't see
-    ///   content that's rendered by client-side JavaScript.
-    /// - `.rendered`: loads the page in a `WKWebView` and waits for the
-    ///   DOM to hydrate. Needed for React / Vue / Next-client-rendered
-    ///   pages like the Claude Blog or most modern SPAs.
     var fetchMode: FetchMode = .staticHTML
 
-    /// CSS selector matching each repeating article container on the
-    /// page (e.g. `"article.post"`, `"li.entry"`, `"[data-testid=card]"`).
-    /// All the other selectors are run *relative to* each match.
     var itemSelector: String
 
-    /// Selector for the item's title.  If `nil`, the engine falls back
-    /// to the item's own text content.
     var titleSelector: String?
 
-    /// Selector for the link to the article.  If `nil`, the engine
-    /// looks for a descendant `<a href>` inside the item.
     var linkSelector: String?
 
-    /// Attribute the link URL lives on (defaults to `href`).
     var linkAttribute: String = "href"
 
-    /// Selector for a short summary.  Optional.
     var summarySelector: String?
 
-    /// Selector for the item's hero image.  Optional.
     var imageSelector: String?
 
-    /// Attribute the image URL lives on (defaults to `src`).
-    /// Some lazy-loaded galleries use `data-src`, `data-lazy-src`, etc.
     var imageAttribute: String = "src"
 
-    /// Selector for the published date.  Optional.
     var dateSelector: String?
 
-    /// Attribute the date lives on (e.g. `datetime`).  `nil` means
-    /// use the element's text content.
     var dateAttribute: String?
 
-    /// Selector for the author.  Optional.
     var authorSelector: String?
 
-    /// Optional URL used to resolve *relative* hrefs/srcs when they
-    /// can't be resolved against `siteURL` directly (rare - only set
-    /// this if the feed items live under a different base path).
     var baseURL: String?
 
-    /// Maximum items to ingest per refresh. Guards against runaway
-    /// recipes that match hundreds of unrelated elements.
     var maxItems: Int = 50
 
-    /// ISO-8601 timestamp of last edit.  Shown in the management UI.
     var lastModified: Date = Date()
 
     init(
@@ -121,21 +78,16 @@ nonisolated struct PetalRecipe: Codable, Sendable, Hashable {
     }
 
     enum FetchMode: String, Codable, Sendable, CaseIterable {
-        /// Fetch the raw HTML with `URLSession`.
         case staticHTML
-        /// Load the page in a WKWebView and wait for JS hydration.
         case rendered
     }
 
-    /// URL scheme used in the feeds table (`petal://<siteURL>`).
     var feedURL: String { "petal://\(siteURL)" }
 
-    /// `true` when the given `Feed.url` string points at a Petal recipe.
     static func isPetalFeedURL(_ url: String) -> Bool {
         url.hasPrefix("petal://")
     }
 
-    /// Extracts the site URL from a `petal://<siteURL>` feed URL.
     static func siteURL(from feedURL: String) -> String? {
         guard feedURL.hasPrefix("petal://") else { return nil }
         return String(feedURL.dropFirst("petal://".count))

--- a/Integrations/Petal/PetalStore.swift
+++ b/Integrations/Petal/PetalStore.swift
@@ -1,19 +1,6 @@
 import Foundation
 
-/// On-disk store for `PetalRecipe` JSON files.
-///
-/// Recipes live in the shared app-group container alongside the SQLite
-/// database so widgets and the share extension can read them.  Each
-/// recipe is stored as a separate JSON file keyed by UUID, so editing
-/// a Petal is a single-file write and corrupting one file can't take
-/// the rest of the library with it.
-///
-/// ```
-/// group.com.tsubuzaki.SakuraRSS/
-///   Petals/
-///     <uuid>.json
-///     <uuid>.png       ← optional icon, imported from .srss packages
-/// ```
+/// On-disk store for `PetalRecipe` JSON files in the shared app-group container.
 nonisolated final class PetalStore: @unchecked Sendable {
 
     static let shared = PetalStore()
@@ -75,9 +62,6 @@ nonisolated final class PetalStore: @unchecked Sendable {
 
     // MARK: - Icons
 
-    /// Path where the optional imported PNG icon for a recipe lives.
-    /// Not every recipe has one - only those imported from `.srss`
-    /// packages that included a feed icon.
     func iconURL(for id: UUID) -> URL {
         iconDirectoryURL.appendingPathComponent("\(id.uuidString).png")
     }

--- a/Integrations/Petal/PetalWebViewLoader.swift
+++ b/Integrations/Petal/PetalWebViewLoader.swift
@@ -1,17 +1,7 @@
 import Foundation
 import WebKit
 
-/// Loads a URL in a `WKWebView` and returns the fully-hydrated HTML
-/// after client-side JavaScript has run.
-///
-/// Used by `PetalEngine` when a recipe's `fetchMode` is `.rendered`,
-/// which is the only way to extract content from React / Vue / Next
-/// SPAs whose initial HTML response contains little more than an
-/// empty `<div id="root">` shell.
-///
-/// Mirrors `WebViewExtractor` but lives next to the Petal code so
-/// tweaks to its waits-and-evals don't accidentally regress the
-/// article-extractor path.
+/// Loads a URL in a `WKWebView` and returns the fully-hydrated HTML after JS runs.
 @MainActor
 final class PetalWebViewLoader: NSObject, WKNavigationDelegate {
 
@@ -19,8 +9,6 @@ final class PetalWebViewLoader: NSObject, WKNavigationDelegate {
     private var continuation: CheckedContinuation<String?, Never>?
     private var timeoutTask: Task<Void, Never>?
 
-    /// Load the URL, wait for JS to settle, and return the final HTML.
-    /// Times out at 10 s to keep the refresh pipeline moving.
     func loadHTML(from url: URL) async -> String? {
         await withCheckedContinuation { continuation in
             self.continuation = continuation
@@ -64,7 +52,7 @@ final class PetalWebViewLoader: NSObject, WKNavigationDelegate {
         timeoutTask?.cancel()
         timeoutTask = nil
         Task {
-            // Give client-side hydration a moment to run.
+            // Let client-side hydration run before snapshotting the DOM.
             try? await Task.sleep(for: .seconds(2))
             self.extractHTML()
         }

--- a/Integrations/Petal/PetalZip/Data+LittleEndian.swift
+++ b/Integrations/Petal/PetalZip/Data+LittleEndian.swift
@@ -3,23 +3,11 @@ import Foundation
 // MARK: - Little-Endian Read/Write
 
 /// Byte-level helpers the ZIP writer and reader share.
-///
-/// `nonisolated` is required because the project builds with
-/// MainActor-as-default isolation inference - without it these
-/// helpers get implicitly annotated `@MainActor` and can't be
-/// called from the `nonisolated enum PetalZip` above.  Keeping the
-/// helpers file-internal (rather than exporting them as generic
-/// Foundation extensions) keeps the blast radius small: if future
-/// binary formats need similar helpers they should get their own
-/// copy rather than accidentally binding to these.
+/// `nonisolated` so they stay callable from the nonisolated `PetalZip` enum.
 nonisolated extension Data {
 
     /// Appends a 16-bit value in little-endian byte order.
-    ///
-    /// The global `Swift.withUnsafeBytes(of:_:)` is spelled out in
-    /// full because inside a `Data` extension the unqualified name
-    /// resolves to `Data.withUnsafeBytes`, which has the wrong
-    /// signature for a scalar temporary.
+    /// Uses `Swift.withUnsafeBytes` explicitly to avoid `Data.withUnsafeBytes`.
     mutating func appendLE(_ value: UInt16) {
         var little = value.littleEndian
         Swift.withUnsafeBytes(of: &little) { bytes in
@@ -35,12 +23,7 @@ nonisolated extension Data {
     }
 
     /// Reads a 16-bit little-endian value at the given byte offset.
-    ///
-    /// Uses `load(fromByteOffset:as: UInt8.self)` in preference to
-    /// `buffer[offset]`: the subscript is overloaded on both `Int`
-    /// and `Range<Int>`, and in a generic context Swift can't
-    /// always pick the right one without a type annotation.
-    /// Byte-by-byte loads sidestep alignment concerns entirely.
+    /// Loads byte-by-byte to sidestep alignment concerns.
     func readLE(_: UInt16.Type, at offset: Int) -> UInt16 {
         self.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) -> UInt16 in
             let b0 = UInt16(buffer.load(fromByteOffset: offset, as: UInt8.self))
@@ -55,8 +38,7 @@ nonisolated extension Data {
             let b1 = UInt32(buffer.load(fromByteOffset: offset + 1, as: UInt8.self))
             let b2 = UInt32(buffer.load(fromByteOffset: offset + 2, as: UInt8.self))
             let b3 = UInt32(buffer.load(fromByteOffset: offset + 3, as: UInt8.self))
-            // Keep the expression in two halves so the type checker
-            // doesn't time out trying to resolve a four-term OR.
+            // Split into two halves to avoid type-checker timeout on the four-term OR.
             let low: UInt32 = b0 | (b1 << 8)
             let high: UInt32 = (b2 << 16) | (b3 << 24)
             return low | high

--- a/Integrations/Petal/PetalZip/PetalZip+CRC32.swift
+++ b/Integrations/Petal/PetalZip/PetalZip+CRC32.swift
@@ -4,16 +4,8 @@ nonisolated extension PetalZip {
 
     // MARK: - CRC32
 
-    /// Table-driven CRC32 (polynomial 0xEDB88320, reflected).
-    ///
-    /// This is the checksum that PKZIP entries use to let readers
-    /// verify entry integrity; it is **not** a cryptographic hash
-    /// and must not be used for integrity-sensitive purposes.
-    ///
-    /// The table is built lazily on first access inside a static
-    /// `let` initializer - no thread-safety concerns because
-    /// static lets on top-level types are initialised exactly once
-    /// under `dispatch_once` semantics.
+    /// Table-driven CRC32 (polynomial 0xEDB88320, reflected) for PKZIP entries.
+    /// Not a cryptographic hash.
     static func crc32(_ data: Data) -> UInt32 {
         var crc: UInt32 = 0xFFFFFFFF
         for byte in data {
@@ -23,8 +15,6 @@ nonisolated extension PetalZip {
         return crc ^ 0xFFFFFFFF
     }
 
-    /// Precomputed 256-entry lookup table for the reflected
-    /// CRC32 polynomial 0xEDB88320.
     private static let crcTable: [UInt32] = {
         var table = [UInt32](repeating: 0, count: 256)
         for index in 0..<256 {

--- a/Integrations/Petal/PetalZip/PetalZip+Reader.swift
+++ b/Integrations/Petal/PetalZip/PetalZip+Reader.swift
@@ -4,14 +4,7 @@ nonisolated extension PetalZip {
 
     // MARK: - Reading
 
-    /// Reads the entries from a ZIP archive.  Supports STORE entries
-    /// and DEFLATE entries (via Foundation's built-in
-    /// `NSData.decompressed(using: .zlib)`).  Anything else surfaces
-    /// `ZipError.unsupportedCompression`.
-    ///
-    /// Enforces the caps declared in `Limits` so that importing a
-    /// maliciously-crafted `.srss` file can't blow up memory or
-    /// exhaust the device with a zip-bomb-style payload.
+    /// Reads entries from a ZIP archive (STORE or DEFLATE). Enforces `Limits`.
     static func read(data: Data) throws -> [Entry] {
         guard let eocd = findEndOfCentralDirectory(in: data) else {
             throw ZipError.malformed
@@ -35,9 +28,7 @@ nonisolated extension PetalZip {
             let payload = try readEntryPayload(in: data, header: header)
             let decoded = try decodePayload(payload, header: header)
 
-            // Trust-but-verify: a deflate entry whose header lied
-            // about its uncompressed size might still try to
-            // expand into more bytes than we budgeted.
+            // A deflate entry can expand past its declared size; re-check after decoding.
             guard decoded.count <= Limits.maxEntrySize else {
                 throw ZipError.tooLarge
             }
@@ -85,17 +76,12 @@ nonisolated extension PetalZip {
         header: CentralDirectoryEntry,
         runningTotal: inout Int
     ) throws {
-        // Size caps - check before doing any allocation or
-        // decompression so a malicious header can't force us to
-        // read a huge payload just to reject it afterwards.
         guard header.nameLength <= Limits.maxNameLength,
               header.compressedSize <= Limits.maxEntrySize,
               header.uncompressedSize <= Limits.maxEntrySize else {
             throw ZipError.tooLarge
         }
-        // Check total separately so overflow-adjacent sizes can't
-        // slip past the per-entry cap into a terabyte running
-        // total.
+        // Use overflow-reporting add so oversized sizes can't wrap past the total cap.
         let (newTotal, overflow) = runningTotal
             .addingReportingOverflow(header.uncompressedSize)
         guard !overflow, newTotal <= Limits.maxTotalUncompressedSize else {
@@ -123,7 +109,6 @@ nonisolated extension PetalZip {
         in data: Data,
         header: CentralDirectoryEntry
     ) throws -> Data {
-        // Local file header: 30 fixed bytes + file name + extra.
         guard header.localOffset + 30 <= data.count else {
             throw ZipError.truncated
         }
@@ -152,20 +137,14 @@ nonisolated extension PetalZip {
     // MARK: - Inflate
 
     /// Inflates a raw DEFLATE stream into `expectedSize` bytes.
-    ///
-    /// Apple's `NSData.decompressed(using: .zlib)` is a bit of a
-    /// misnomer: per Apple's docs it implements RFC 1951 (raw
-    /// DEFLATE, the format used inside ZIP entries) - *not* the
-    /// wrapped zlib format from RFC 1950 - so we can hand the
-    /// compressed blob straight over.
+    /// `NSData.decompressed(using: .zlib)` is actually raw DEFLATE (RFC 1951), not zlib-wrapped.
     private static func inflateDeflate(_ data: Data, expectedSize: Int) throws -> Data {
         guard let decompressed = try? (data as NSData)
             .decompressed(using: .zlib) as Data else {
             throw ZipError.malformed
         }
         if decompressed.count != expectedSize {
-            // Not fatal - some producers add padding - but drop
-            // anything past the declared size.
+            // Some producers pad; trim to the declared size.
             return decompressed.prefix(expectedSize)
         }
         return decompressed
@@ -175,7 +154,6 @@ nonisolated extension PetalZip {
 
     private static func findEndOfCentralDirectory(in data: Data) -> Int? {
         guard data.count >= 22 else { return nil }
-        // Scan backwards looking for the signature.
         var cursor = data.count - 22
         let minCursor = max(0, data.count - 65_557) // max comment 64 KB
         while cursor >= minCursor {

--- a/Integrations/Petal/PetalZip/PetalZip+Writer.swift
+++ b/Integrations/Petal/PetalZip/PetalZip+Writer.swift
@@ -4,14 +4,7 @@ nonisolated extension PetalZip {
 
     // MARK: - Writing
 
-    /// Packs entries into a STORED-only ZIP archive.  Returns the
-    /// archive bytes - caller writes to disk (or ships elsewhere).
-    ///
-    /// STORE (no compression) is intentional: the payloads are a
-    /// few KB of JSON plus a small PNG, so the space savings
-    /// wouldn't pay for the extra compression code.  The format we
-    /// emit is still a fully valid ZIP and any reader (including
-    /// our own `read(data:)`) can extract it.
+    /// Packs entries into a STORED-only ZIP archive and returns the bytes.
     static func write(entries: [Entry]) -> Data {
         var output = Data()
         var centralDirectory = Data()

--- a/Integrations/Petal/PetalZip/PetalZip.swift
+++ b/Integrations/Petal/PetalZip/PetalZip.swift
@@ -1,32 +1,7 @@
 import Foundation
 
-/// A deliberately tiny pure-Swift ZIP reader/writer that supports
-/// just enough of the PKZIP spec to move `.srss` packages around:
-///
-///   - STORE method only for writing; STORE + DEFLATE for reading
-///   - no ZIP64, no encryption, no data descriptors
-///   - short, ASCII filenames only
-///
-/// Shipping a minimal implementation keeps Sakura off a third-party
-/// archiving dependency.  The format it writes is a valid ZIP file
-/// that can be opened by Finder, `unzip`, and every other ZIP
-/// reader, and the reader handles files it produced plus any other
-/// STORED-or-DEFLATED-entry ZIP a user might hand-craft.
-///
-/// The layout is the classic PKZIP one:
-///
-/// ```
-/// [local file header + data] × N
-/// [central directory header] × N
-/// [end of central directory]
-/// ```
-///
-/// The implementation is split across several files in this folder
-/// by responsibility: `+Writer` produces archives, `+Reader` parses
-/// them, `+CRC32` provides the integrity checksum, and
-/// `Data+LittleEndian` hosts the byte-order helpers the other files
-/// lean on.  This file hosts only the public type, nested value
-/// types, and shared limits.
+/// Minimal pure-Swift ZIP reader/writer for `.srss` packages.
+/// Writes STORE only; reads STORE + DEFLATE. No ZIP64, encryption, or data descriptors.
 nonisolated enum PetalZip {
 
     struct Entry: Sendable {
@@ -38,29 +13,20 @@ nonisolated enum PetalZip {
         case malformed
         case unsupportedCompression
         case truncated
-        /// The archive - or a single entry inside it - exceeds the
-        /// hard caps we enforce on import to defend against "zip
-        /// bomb" payloads that try to exhaust memory by expanding
-        /// kilobytes of deflate into gigabytes of decoded output.
+        /// Archive or entry exceeds caps that guard against zip-bomb payloads.
         case tooLarge
     }
 
-    /// Hard caps enforced by `read(data:)` when importing a `.srss`
-    /// package.  Legitimate packages are a few KB of JSON plus a
-    /// small PNG icon, so these limits leave several orders of
-    /// magnitude of headroom while still bounding memory use to
-    /// something safe if a malicious package tries to fill it.
+    /// Hard caps enforced by `read(data:)` to defend against zip-bomb payloads.
     enum Limits {
         static let maxEntryCount = 16
-        static let maxEntrySize = 5 * 1024 * 1024              // 5 MB
-        static let maxTotalUncompressedSize = 10 * 1024 * 1024 // 10 MB
+        static let maxEntrySize = 5 * 1024 * 1024
+        static let maxTotalUncompressedSize = 10 * 1024 * 1024
         static let maxNameLength = 512
     }
 
     // MARK: - Shared signatures
 
-    /// ZIP header signatures in little-endian form.
-    /// Spelled out centrally so writer and reader agree.
     enum Signatures {
         static let localFileHeader: UInt32 = 0x04034b50
         static let centralDirectoryHeader: UInt32 = 0x02014b50

--- a/Integrations/Podcasts/Downloads/PodcastDownloadManager.swift
+++ b/Integrations/Podcasts/Downloads/PodcastDownloadManager.swift
@@ -32,13 +32,10 @@ final class PodcastDownloadManager: NSObject, URLSessionDownloadDelegate {
 
     private var urlSession: URLSession!
     private var downloadTasks: [Int64: URLSessionDownloadTask] = [:]
-    /// Maps URLSessionTask identifiers back to article IDs for delegate callbacks.
     private var taskArticleIDs: [Int: Int64] = [:]
-    /// Continuations waiting for download completion, keyed by article ID.
     private var downloadContinuations: [Int64: CheckedContinuation<URL, any Error>] = [:]
     private let fileManager = FileManager.default
 
-    /// Tracks pending transcription work so cancellation can reach it.
     private var transcriptionTasks: [Int64: Task<Void, Never>] = [:]
 
     private override init() {
@@ -113,9 +110,9 @@ final class PodcastDownloadManager: NSObject, URLSessionDownloadDelegate {
             do {
                 try await self?.performDownload(article: article, audioURL: audioURL)
             } catch is CancellationError {
-                // Cancelled by the user - cancelDownload() already cleaned up state.
+                // cancelDownload() already cleaned up state.
             } catch let urlError as URLError where urlError.code == .cancelled {
-                // URLSession task was cancelled - same as above.
+                // Same as above.
             } catch {
                 self?.markFailed(articleID: article.id, error: error.localizedDescription)
             }
@@ -131,7 +128,6 @@ final class PodcastDownloadManager: NSObject, URLSessionDownloadDelegate {
         let destination = episodeDir.appendingPathComponent(name)
         let articleID = article.id
 
-        // Prepare the directory on a background thread.
         let dir = episodeDir
         let dest = destination
         try await Task.detached(priority: .utility) {
@@ -144,7 +140,6 @@ final class PodcastDownloadManager: NSObject, URLSessionDownloadDelegate {
             }
         }.value
 
-        // Start a delegate-based download so we get per-byte progress.
         let tempURL: URL = try await withCheckedThrowingContinuation { continuation in
             let sessionTask = urlSession.downloadTask(with: audioURL)
             downloadTasks[articleID] = sessionTask
@@ -153,10 +148,8 @@ final class PodcastDownloadManager: NSObject, URLSessionDownloadDelegate {
             sessionTask.resume()
         }
 
-        // Clean up tracking state.
         downloadTasks[articleID] = nil
 
-        // Move the downloaded file to its final location.
         try await Task.detached(priority: .utility) {
             try FileManager.default.moveItem(at: tempURL, to: dest)
         }.value
@@ -165,9 +158,7 @@ final class PodcastDownloadManager: NSObject, URLSessionDownloadDelegate {
         let relativePath = "\(articleID)/\(name)"
         try DatabaseManager.shared.setDownloadPath(relativePath, for: articleID)
 
-        // Transition the donut into the transcribing phase so it stays visible
-        // while the model runs. Transcription failure is non-fatal - we always
-        // finish with `markCompleted` below so the check mark appears.
+        // Transcription failure is non-fatal; we still markCompleted below.
         if await PodcastTranscriber.isAvailable {
             activeDownloads[articleID] = DownloadProgress(state: .transcribing, progress: 0)
             let title = article.title
@@ -208,7 +199,7 @@ final class PodcastDownloadManager: NSObject, URLSessionDownloadDelegate {
         downloadTask: URLSessionDownloadTask,
         didFinishDownloadingTo location: URL
     ) {
-        // Copy to a stable temp location before the system deletes it.
+        // Copy before the system deletes `location`.
         let tempCopy = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString)
         try? FileManager.default.moveItem(at: location, to: tempCopy)
@@ -255,7 +246,6 @@ final class PodcastDownloadManager: NSObject, URLSessionDownloadDelegate {
             let segments = try await PodcastTranscriber.transcribe(audioFileURL: fileURL, title: title)
             try DatabaseManager.shared.cacheTranscript(segments, for: articleID)
         } catch {
-            // Transcription failure is non-fatal; download still succeeded.
             print("Transcription failed for article \(articleID): \(error)")
         }
     }
@@ -264,7 +254,6 @@ final class PodcastDownloadManager: NSObject, URLSessionDownloadDelegate {
         activeDownloads[articleID] = DownloadProgress(state: .completed, progress: 1.0)
         downloadTasks[articleID] = nil
         transcriptionTasks[articleID] = nil
-        // Fade out completed entry so views reflect the new "downloaded" state.
         Task { @MainActor [weak self] in
             try? await Task.sleep(for: .seconds(1))
             self?.activeDownloads[articleID] = nil
@@ -288,13 +277,10 @@ final class PodcastDownloadManager: NSObject, URLSessionDownloadDelegate {
         downloadTasks[articleID] = nil
         transcriptionTasks[articleID]?.cancel()
         transcriptionTasks[articleID] = nil
-        // If a continuation is still waiting, resume it with a cancellation error
-        // so the async chain unwinds cleanly.
         if let continuation = downloadContinuations.removeValue(forKey: articleID) {
             continuation.resume(throwing: CancellationError())
         }
         activeDownloads[articleID] = nil
-        // Clean partial file
         if let dir = episodeDirectory(for: articleID),
            fileManager.fileExists(atPath: dir.path) {
             try? fileManager.removeItem(at: dir)
@@ -328,8 +314,6 @@ final class PodcastDownloadManager: NSObject, URLSessionDownloadDelegate {
     // MARK: - Cleanup
 
     /// Removes download files whose article no longer exists in the database.
-    /// Static + nonisolated so callers on background queues don't need to hop
-    /// to the main actor just to clean up orphaned files.
     nonisolated static func cleanupOrphanedDownloads() {
         let fileManager = FileManager.default
         guard let container = fileManager.containerURL(

--- a/Integrations/Podcasts/Transcriber/Engines/FluidTranscriberEngine.swift
+++ b/Integrations/Podcasts/Transcriber/Engines/FluidTranscriberEngine.swift
@@ -2,10 +2,7 @@ import AVFoundation
 import FluidAudio
 import Foundation
 
-/// Transcription engine using FluidAudio (NVIDIA Parakeet TDT models via CoreML/ANE).
-///
-/// Models are downloaded on demand and stored in FluidAudio's managed cache.
-/// Runs in-process on the Neural Engine. 25+ European languages supported.
+/// Transcription engine using FluidAudio's Parakeet TDT models on the Neural Engine.
 struct FluidTranscriberEngine: TranscriptionEngine {
 
     static let requiresModelDownload = true
@@ -61,21 +58,14 @@ struct FluidTranscriberEngine: TranscriptionEngine {
             return Self.buildSegments(from: timings)
         }
 
-        // Fallback: no token timings returned (shouldn't happen for TDT models).
+        // Fallback: no token timings (shouldn't happen for TDT models).
         let duration = try await Self.audioDuration(of: audioFileURL)
         return Self.distributeTimestamps(text: result.text, totalDuration: duration)
     }
 
     // MARK: - Segment construction from token timings
 
-    /// Group per-token timings into sentence-level `TranscriptSegment`s using
-    /// real start/end times from the TDT decoder.
-    ///
-    /// FluidAudio normalizes tokens before returning them: the SentencePiece
-    /// word-boundary marker `▁` is already replaced with a space, so simply
-    /// concatenating `token` strings yields the natural transcript text.
-    /// Punctuation tokens (`.`, `!`, `?`) are attached to the preceding word
-    /// and mark sentence boundaries.
+    /// Groups per-token timings into sentence-level segments using the TDT decoder's timestamps.
     static func buildSegments(from timings: [TokenTiming]) -> [TranscriptSegment] {
         var segments: [TranscriptSegment] = []
         var buffer = ""
@@ -116,8 +106,7 @@ struct FluidTranscriberEngine: TranscriptionEngine {
         }
         flush()
 
-        // If no sentence punctuation was ever emitted, fall back to one segment
-        // covering the entire utterance.
+        // Fallback single-segment if no sentence punctuation was emitted.
         if segments.isEmpty, let first = timings.first, let last = timings.last {
             let text = timings
                 .map(\.token)
@@ -138,7 +127,6 @@ struct FluidTranscriberEngine: TranscriptionEngine {
         return segments
     }
 
-    /// Whether a token's trailing character ends a sentence.
     private static func endsSentence(_ token: String) -> Bool {
         guard let last = token.last else { return false }
         return last == "." || last == "!" || last == "?" || last == "。" || last == "？" || last == "！"
@@ -146,15 +134,13 @@ struct FluidTranscriberEngine: TranscriptionEngine {
 
     // MARK: - Helpers
 
-    /// Returns the duration of an audio file in seconds.
     private static func audioDuration(of url: URL) async throws -> TimeInterval {
         let asset = AVURLAsset(url: url)
         let duration = try await asset.load(.duration)
         return CMTimeGetSeconds(duration)
     }
 
-    /// Degraded fallback for the rare case where no token timings are returned.
-    /// Splits text into sentences and assigns evenly distributed timestamps.
+    /// Degraded fallback: splits text into sentences with evenly distributed timestamps.
     static func distributeTimestamps(text: String, totalDuration: TimeInterval) -> [TranscriptSegment] {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty, totalDuration > 0 else { return [] }

--- a/Integrations/Podcasts/Transcriber/PodcastTranscriber.swift
+++ b/Integrations/Podcasts/Transcriber/PodcastTranscriber.swift
@@ -1,13 +1,8 @@
 import Foundation
 
-/// Central dispatcher for podcast transcription.
-///
-/// Reads the user's "transcription enabled" preference from UserDefaults and
-/// delegates to the FluidAudio Parakeet engine. Skips transcription if the
-/// toggle is off or the model hasn't finished downloading.
+/// Dispatcher that gates transcription on user opt-in and model availability.
 enum PodcastTranscriber {
 
-    /// UserDefaults key for the Parakeet-on-off toggle.
     static let enabledKey = "Podcast.TranscriptionEnabled"
 
     static var isEnabled: Bool {
@@ -18,7 +13,6 @@ enum PodcastTranscriber {
 
     // MARK: - Public API
 
-    /// Whether transcription is enabled and the Parakeet model is downloaded.
     static var isAvailable: Bool {
         get async {
             guard isEnabled else { return false }
@@ -27,7 +21,6 @@ enum PodcastTranscriber {
         }
     }
 
-    /// Transcribes a local audio file using the Parakeet engine.
     static func transcribe(audioFileURL: URL, title: String) async throws -> [TranscriptSegment] {
         guard isEnabled else {
             throw TranscriptionEngineError.notAvailable

--- a/Integrations/Podcasts/Transcriber/TranscriptionEngine.swift
+++ b/Integrations/Podcasts/Transcriber/TranscriptionEngine.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-/// Errors that any transcription engine may throw.
 enum TranscriptionEngineError: Error {
     case notAvailable
     case audioFileUnreadable
@@ -8,23 +7,17 @@ enum TranscriptionEngineError: Error {
     case transcriptionFailed(String)
 }
 
-/// Protocol that all transcription engines conform to.
 protocol TranscriptionEngine: Sendable {
-    /// Whether this engine requires a separate model download.
     static var requiresModelDownload: Bool { get }
 
-    /// Whether the model is currently downloaded and ready to use.
     var isModelDownloaded: Bool { get }
 
-    /// Check if this engine is available and ready to use.
     var isAvailable: Bool { get async }
 
-    /// Transcribe a local audio file and return timed segments.
     func transcribe(audioFileURL: URL, title: String) async throws -> [TranscriptSegment]
 
-    /// Downloads the model. The progress callback reports fractional progress (0.0–1.0).
+    /// Progress callback reports fractional progress (0.0–1.0).
     func downloadModel(progress: (@Sendable (Double) -> Void)?) async throws
 
-    /// Deletes the downloaded model.
     func deleteModel() throws
 }

--- a/Integrations/Reddit/RedditCommunityScraper+Fetching.swift
+++ b/Integrations/Reddit/RedditCommunityScraper+Fetching.swift
@@ -2,9 +2,6 @@ import Foundation
 
 extension RedditCommunityScraper {
 
-    /// Fetches `about.json` for the subreddit and extracts `community_icon`.
-    /// The query string is stripped from the returned URL because Reddit's
-    /// signed params are not required for the image to load.
     func performFetch(url: URL) async -> RedditCommunityScrapeResult {
         var request = URLRequest(url: url)
         request.setValue(sakuraUserAgent, forHTTPHeaderField: "User-Agent")

--- a/Integrations/Reddit/RedditCommunityScraper.swift
+++ b/Integrations/Reddit/RedditCommunityScraper.swift
@@ -1,17 +1,14 @@
 import Foundation
 
-/// Result of scraping a subreddit's public `about.json` endpoint.
 struct RedditCommunityScrapeResult: Sendable {
     let communityIconURL: String?
 }
 
-/// Fetches subreddit metadata (currently just the community icon) from
-/// Reddit's public `/r/<name>/about.json` endpoint. No login required.
+/// Fetches subreddit metadata from `/r/<name>/about.json`.
 final class RedditCommunityScraper {
 
     // MARK: - Static Helpers
 
-    /// Returns true if the URL points to a subreddit on reddit.com.
     nonisolated static func isRedditSubredditURL(_ url: URL) -> Bool {
         guard let host = url.host?.lowercased() else { return false }
         let isRedditDomain = host == "reddit.com" || host.hasSuffix(".reddit.com")
@@ -19,8 +16,6 @@ final class RedditCommunityScraper {
         return extractSubredditName(from: url) != nil
     }
 
-    /// Extracts the subreddit name from a URL like
-    /// `https://www.reddit.com/r/iosbeta/` or `.../r/iosbeta/.rss`.
     nonisolated static func extractSubredditName(from url: URL) -> String? {
         let components = url.pathComponents.filter { $0 != "/" }
         guard let rIndex = components.firstIndex(where: { $0.lowercased() == "r" }),
@@ -30,14 +25,11 @@ final class RedditCommunityScraper {
         return cleaned.isEmpty ? nil : cleaned
     }
 
-    /// Constructs the `about.json` URL for a subreddit.
     nonisolated static func aboutURL(for subreddit: String) -> URL? {
         URL(string: "https://www.reddit.com/r/\(subreddit)/about.json")
     }
 
-    /// Removes the query string from a URL string, leaving scheme + host + path.
-    /// Reddit's `community_icon` includes signed query params that aren't
-    /// required for the image to load; stripping keeps cache keys stable.
+    /// Reddit's `community_icon` signed query params aren't needed; stripping keeps cache keys stable.
     nonisolated static func stripQuery(from urlString: String) -> String {
         let decoded = urlString.replacingOccurrences(of: "&amp;", with: "&")
         guard var components = URLComponents(string: decoded) else { return decoded }
@@ -47,7 +39,6 @@ final class RedditCommunityScraper {
 
     // MARK: - Public
 
-    /// Fetches the community icon URL for the given subreddit.
     func scrapeCommunity(subreddit: String) async -> RedditCommunityScrapeResult {
         guard let url = Self.aboutURL(for: subreddit) else {
             return RedditCommunityScrapeResult(communityIconURL: nil)

--- a/Integrations/Reddit/RedditPostScraper.swift
+++ b/Integrations/Reddit/RedditPostScraper.swift
@@ -5,8 +5,7 @@ enum RedditPostFetchResult: Sendable {
     case linkedArticle(URL)
 }
 
-/// Fetches Reddit posts via the public `/comments/{id}.json` endpoint and
-/// translates them into `ContentBlock` marker strings.
+/// Fetches Reddit posts and translates them into `ContentBlock` marker strings.
 final class RedditPostScraper: @unchecked Sendable {
 
     static let shared = RedditPostScraper()

--- a/Integrations/X/XProfileScraper+Extraction.swift
+++ b/Integrations/X/XProfileScraper+Extraction.swift
@@ -102,7 +102,6 @@ extension XProfileScraper {
             return nil
         }
 
-        // Handle TweetWithVisibilityResults wrapper
         let actualResult: [String: Any]
         if (tweetResult["__typename"] as? String) == "TweetWithVisibilityResults",
            let tweet = tweetResult["tweet"] as? [String: Any] {
@@ -113,7 +112,6 @@ extension XProfileScraper {
 
         guard let legacy = actualResult["legacy"] as? [String: Any] else { return nil }
 
-        // Skip retweets
         if legacy["retweeted_status_result"] != nil { return nil }
 
         let fullText = legacy["full_text"] as? String ?? ""
@@ -122,7 +120,6 @@ extension XProfileScraper {
 
         guard !idStr.isEmpty else { return nil }
 
-        // Author info from core.user_results.result
         let core = actualResult["core"] as? [String: Any]
         let userResults = core?["user_results"] as? [String: Any]
         let userResult = userResults?["result"] as? [String: Any]
@@ -130,7 +127,6 @@ extension XProfileScraper {
         let authorName = userCore?["name"] as? String ?? ""
         let authorHandle = userCore?["screen_name"] as? String ?? ""
 
-        // Media images - extract all photos for carousel support
         let extendedEntities = legacy["extended_entities"] as? [String: Any]
         let media = extendedEntities?["media"] as? [[String: Any]]
         let photoURLs = media?
@@ -141,7 +137,6 @@ extension XProfileScraper {
         let publishedDate = dateFormatter.date(from: createdAt)
         let tweetURL = "https://x.com/\(authorHandle)/status/\(idStr)"
 
-        // Replace t.co URLs with their expanded URLs from entities
         var cleanText = fullText
         let entities = legacy["entities"] as? [String: Any]
         if let urlEntities = entities?["urls"] as? [[String: Any]] {
@@ -153,7 +148,7 @@ extension XProfileScraper {
             }
         }
 
-        // Remove trailing t.co URLs (media links that have no expanded form)
+        // Strip trailing t.co media links that have no expanded form.
         cleanText = cleanText.replacingOccurrences(
             of: "\\s*https://t\\.co/\\S+$",
             with: "",
@@ -199,9 +194,6 @@ extension XProfileScraper {
         dateFormatter.locale = Locale(identifier: "en_US_POSIX")
         dateFormatter.dateFormat = "EEE MMM dd HH:mm:ss Z yyyy"
 
-        // TweetDetail entries have a different structure: the focal tweet is inside
-        // content.itemContent (for single-item entries) or content.items[] (for
-        // conversation thread entries).
         for entry in entries {
             guard let content = entry["content"] as? [String: Any] else { continue }
             let entryType = content["entryType"] as? String
@@ -213,7 +205,6 @@ extension XProfileScraper {
                     return tweet
                 }
             } else if entryType == "TimelineTimelineModule" {
-                // Thread modules contain an items array
                 guard let items = content["items"] as? [[String: Any]] else { continue }
                 for item in items {
                     guard let itemObj = item["item"] as? [String: Any] else { continue }

--- a/Integrations/X/XProfileScraper+Fetching.swift
+++ b/Integrations/X/XProfileScraper+Fetching.swift
@@ -38,7 +38,6 @@ extension XProfileScraper {
         print("[XProfileScraper] Got cookies - csrf: \(cookies.csrfToken.prefix(20))…")
         #endif
 
-        // Step 1: Look up user ID, display name, and avatar via UserByScreenName
         guard let userInfo = await fetchUserInfo(
             screenName: handle, cookies: cookies
         ) else {
@@ -54,7 +53,6 @@ extension XProfileScraper {
               + "avatar: \(userInfo.profileImageURL?.prefix(60) ?? "nil")")
         #endif
 
-        // Step 2: Fetch tweets via UserTweets
         let tweets = await fetchTweets(
             userId: userInfo.id, cookies: cookies
         )
@@ -63,8 +61,7 @@ extension XProfileScraper {
         print("[XProfileScraper] Fetched \(tweets.count) tweets total")
         #endif
 
-        // Persist any cookies X rotated during the scrape so Keychain
-        // tracks refreshed `ct0` / `auth_token` values.
+        // Persist any cookies X rotated during the scrape.
         Self.persistRotatedCookies()
 
         return XProfileScrapeResult(
@@ -76,21 +73,13 @@ extension XProfileScraper {
 
     // MARK: - Cookies
 
-    /// Reads the current X session from the Keychain-backed cookie jar.
-    ///
-    /// Also ensures GraphQL query IDs are loaded, because every caller of
-    /// this method is about to make an API request that depends on them.
-    /// The query ID fetch still needs a MainActor hop (WKWebView-backed
-    /// bundle extraction), so this method remains `@MainActor async`, but
-    /// the cookie read itself is a cheap synchronous Keychain lookup.
+    /// Reads the current X session and ensures GraphQL query IDs are loaded.
     @MainActor
     static func getXCookies() async -> XCookies? {
         await fetchQueryIDsIfNeeded()
         return readXCookiesFromKeychain()
     }
 
-    /// Synchronous Keychain-only read, for paths that already have query
-    /// IDs loaded (e.g. between back-to-back API calls inside a scrape).
     static func readXCookiesFromKeychain() -> XCookies? {
         guard let cookies = cookieStore.load() else { return nil }
 
@@ -106,11 +95,7 @@ extension XProfileScraper {
         return XCookies(csrfToken: csrf, authToken: auth)
     }
 
-    /// Writes any rotated X cookies from `HTTPCookieStorage.shared` back
-    /// to Keychain so subsequent scrapes pick up refreshed `ct0` /
-    /// `auth_token` values that X issued via `Set-Cookie`.  X API
-    /// requests use `URLSession.shared`, which deposits response cookies
-    /// into the shared jar by default.
+    /// Writes rotated X cookies from `HTTPCookieStorage.shared` back to Keychain.
     static func persistRotatedCookies() {
         let jar = HTTPCookieStorage.shared
         let xCookies = (jar.cookies ?? []).filter {
@@ -208,15 +193,12 @@ extension XProfileScraper {
         let restId = result["rest_id"] as? String ?? ""
         guard !restId.isEmpty else { return nil }
 
-        // Display name and screen name are in result.core
         let core = result["core"] as? [String: Any]
         let displayName = core?["name"] as? String
 
-        // Profile image is in result.avatar
         let avatar = result["avatar"] as? [String: Any]
         var profileImageURL = avatar?["image_url"] as? String
 
-        // Upgrade to high-res version
         if let url = profileImageURL {
             profileImageURL = url
                 .replacingOccurrences(of: "_normal.", with: "_400x400.")
@@ -234,8 +216,7 @@ extension XProfileScraper {
 
     // MARK: - Single Tweet
 
-    /// Fetches a single tweet by its ID using the TweetDetail GraphQL endpoint.
-    /// Returns the parsed tweet, or nil if the fetch fails.
+    /// Fetches a single tweet via the TweetDetail GraphQL endpoint.
     func fetchSingleTweet(tweetID: String) async -> ParsedTweet? {
         guard let cookies = await Self.getXCookies() else {
             #if DEBUG
@@ -303,7 +284,6 @@ extension XProfileScraper {
         var seenIDs = Set<String>()
         var cursor: String?
 
-        // Fetch up to 2 pages to reach targetTweetCount
         for page in 0..<2 {
             guard !Task.isCancelled else { break }
 

--- a/Integrations/X/XProfileScraper+QueryIDs.swift
+++ b/Integrations/X/XProfileScraper+QueryIDs.swift
@@ -5,8 +5,7 @@ import WebKit
 
 extension XProfileScraper {
 
-    /// Fetches x.com HTML, finds the main JS bundle, and extracts query IDs.
-    /// Also warms the WKWebView cookie store as a side effect.
+    /// Fetches x.com HTML, finds the main JS bundle, and extracts GraphQL query IDs.
     @MainActor
     static func fetchQueryIDsIfNeeded() async {
         guard !queryIDsFetched else { return }
@@ -14,14 +13,11 @@ extension XProfileScraper {
 
         print("[XProfileScraper:QueryIDs] Starting query ID fetch…")
 
-        // Warm cookie store (needed for API calls later)
         await warmCookieStore()
 
-        // Get cookies for the URLSession requests
         let cookies = await getHTTPCookies()
         print("[XProfileScraper:QueryIDs] Got \(cookies.count) cookies for x.com")
 
-        // Fetch query IDs from X's JS bundle
         await fetchQueryIDsFromBundle(cookies: cookies)
 
         if userByScreenNameQueryID == nil || userTweetsQueryID == nil
@@ -68,7 +64,6 @@ extension XProfileScraper {
     // MARK: - Bundle Parsing
 
     private static func fetchQueryIDsFromBundle(cookies: [HTTPCookie]) async {
-        // Step 1: Fetch x.com HTML to find the main JS bundle URL
         guard let pageURL = URL(string: "https://x.com") else { return }
 
         var request = URLRequest(url: pageURL)
@@ -92,8 +87,6 @@ extension XProfileScraper {
             return
         }
 
-        // Step 2: Find main bundle URL in HTML
-        // Pattern: https://abs.twimg.com/responsive-web/client-web/main.HASH.js
         guard let bundleURL = extractMainBundleURL(from: pageHTML) else {
             print("[XProfileScraper:QueryIDs] ERROR: Could not find main bundle URL in HTML")
             print("[XProfileScraper:QueryIDs] HTML preview: \(pageHTML.prefix(2000))")
@@ -102,7 +95,6 @@ extension XProfileScraper {
 
         print("[XProfileScraper:QueryIDs] Found main bundle: \(bundleURL)")
 
-        // Step 3: Fetch the bundle JS
         let bundleText: String
         do {
             let (data, _) = try await URLSession.shared.data(for: .sakura(url: bundleURL))
@@ -117,13 +109,10 @@ extension XProfileScraper {
             return
         }
 
-        // Step 4: Extract query IDs
-        // Pattern in bundle: queryId:"XXXX",operationName:"UserTweets"
         extractQueryIDs(from: bundleText)
     }
 
     private static func extractMainBundleURL(from html: String) -> URL? {
-        // Match src="...client-web/main.HASH.js"
         let pattern = #"(https://abs\.twimg\.com/responsive-web/client-web/main\.[a-zA-Z0-9]+\.js)"#
         guard let regex = try? NSRegularExpression(pattern: pattern),
               let match = regex.firstMatch(

--- a/Integrations/X/XProfileScraper.swift
+++ b/Integrations/X/XProfileScraper.swift
@@ -1,7 +1,6 @@
 import Foundation
 import WebKit
 
-/// Parsed tweet from an X profile page.
 struct ParsedTweet: Sendable {
     let id: String
     let text: String
@@ -9,12 +8,10 @@ struct ParsedTweet: Sendable {
     let authorHandle: String
     let url: String
     let imageURL: String?
-    /// All photo URLs when a tweet has multiple images. Empty for single-image tweets.
     let carouselImageURLs: [String]
     let publishedDate: Date?
 }
 
-/// Result of scraping an X profile: tweets and optional profile metadata.
 struct XProfileScrapeResult: Sendable {
     let tweets: [ParsedTweet]
     let profileImageURL: String?
@@ -22,21 +19,8 @@ struct XProfileScrapeResult: Sendable {
 }
 
 /// Fetches tweets from an X (Twitter) profile using GraphQL API calls.
-///
-/// Retweets are excluded.  Session cookies are kept in a Keychain-backed
-/// store (`cookieStore`) populated from the login WebView on success and,
-/// for users upgrading from older builds, by a one-time migration from
-/// `WKWebsiteDataStore`.  WebKit is still used for the JS-bundle query-ID
-/// fetch (which has no Keychain equivalent) but not for cookie storage.
 final class XProfileScraper {
 
-    /// Per-request timeout used for every URLRequest this scraper builds.
-    /// Callers that perform cosmetic work (e.g. favicon avatar lookups)
-    /// can raise this value to effectively bypass the normal timeout.
-    /// Marked `nonisolated(unsafe)` so it can be configured from the
-    /// favicon cache's nonisolated avatar-fetching methods; the value
-    /// is only ever set before network calls start, so there is no
-    /// meaningful data race.
     nonisolated(unsafe) var requestTimeoutInterval: TimeInterval = 15
 
     // swiftlint:disable line_length
@@ -66,14 +50,7 @@ final class XProfileScraper {
 
     static let targetTweetCount = 50
 
-    /// Keychain-backed persistent cookie jar.  Using Keychain (instead of
-    /// `WKWebsiteDataStore.default()` as the source of truth) removes the
-    /// MainActor WKWebView warming step from every cookie read, makes
-    /// `hasXSession()` a cheap synchronous call, and lets cold-launch
-    /// scrapes work without waiting for WebKit to restore cookies from
-    /// disk.  WebKit is still the target of the login UI - we export
-    /// cookies from it to Keychain on login success and on a one-time
-    /// migration.
+    /// Keychain-backed persistent cookie jar.
     static let cookieStore = KeychainCookieStore(
         service: "com.tsubuzaki.SakuraRSS.XCookies"
     )
@@ -83,10 +60,8 @@ final class XProfileScraper {
 
     // MARK: - Public
 
-    /// Fetches the most recent tweets (excluding retweets) from the given profile URL.
-    /// Also extracts the profile photo URL and display name.
-    ///
-    /// Only one fetch runs at a time; concurrent calls are serialised.
+    /// Fetches recent tweets (no retweets), profile photo and display name.
+    /// Serialised: only one fetch runs at a time.
     func scrapeProfile(profileURL: URL) async -> XProfileScrapeResult {
         if let existing = Self.activeScrape {
             _ = await existing.value
@@ -113,7 +88,6 @@ final class XProfileScraper {
             || host == "www.x.com" || host == "www.twitter.com"
             || host == "mobile.x.com" || host == "mobile.twitter.com"
         guard isXDomain else { return false }
-        // Path like /username/status/1234567890
         let components = url.pathComponents
         return components.count >= 4 && components[2] == "status"
     }
@@ -179,9 +153,6 @@ final class XProfileScraper {
     }
 
     /// Checks if the user has X cookies (i.e. is logged in).
-    ///
-    /// Kept `async` for API stability with the old WebKit-backed
-    /// implementation; the body is a synchronous Keychain read.
     static func hasXSession() async -> Bool {
         guard let cookies = cookieStore.load() else { return false }
         return cookies.contains { cookie in
@@ -206,10 +177,7 @@ final class XProfileScraper {
         queryIDsFetched = false
     }
 
-    /// Exports any X cookies present in the default `WKWebsiteDataStore`
-    /// into Keychain.  Called after the user completes the login flow in
-    /// `XLoginView` so that the scraper's Keychain-backed session check
-    /// can find them.
+    /// Exports X cookies from WKWebsiteDataStore to Keychain after login.
     @MainActor
     static func syncCookiesFromWebKit() async {
         let store = WKWebsiteDataStore.default()
@@ -227,21 +195,11 @@ final class XProfileScraper {
         #endif
     }
 
-    /// One-time migration for users upgrading from the WebKit-only
-    /// storage model.  If Keychain is empty but the WebKit data store
-    /// holds X cookies from a prior install, copy them over so the user
-    /// stays signed in without having to log in again.
-    ///
-    /// Safe to call repeatedly - the Keychain-empty check makes it a
-    /// no-op after the first successful migration.
+    /// Migrates cookies from WebKit to Keychain once for users upgrading from older builds.
     @MainActor
     static func migrateWebKitCookiesIfNeeded() async {
-        // Fast path: already migrated.
         if cookieStore.load() != nil { return }
 
-        // Force WebKit to restore its on-disk cookie store before we
-        // inspect it - on a cold launch `allCookies()` returns an empty
-        // array until a WKWebView has loaded a page from the domain.
         await warmCookieStore()
         await syncCookiesFromWebKit()
     }

--- a/Integrations/YouTube/SponsorBlock/SponsorBlockClient.swift
+++ b/Integrations/YouTube/SponsorBlock/SponsorBlockClient.swift
@@ -44,7 +44,6 @@ enum SponsorBlockClient {
 
         let host = components.host?.lowercased() ?? ""
 
-        // youtube.com/watch?v=ID
         if host.contains("youtube.com") {
             if components.path.hasPrefix("/shorts/") {
                 let parts = components.path.split(separator: "/")
@@ -55,7 +54,6 @@ enum SponsorBlockClient {
             return components.queryItems?.first(where: { $0.name == "v" })?.value
         }
 
-        // youtu.be/ID
         if host.contains("youtu.be") {
             let path = components.path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
             return path.isEmpty ? nil : path

--- a/Integrations/YouTube/YouTubePlaylistScraper+Extraction.swift
+++ b/Integrations/YouTube/YouTubePlaylistScraper+Extraction.swift
@@ -4,11 +4,8 @@ extension YouTubePlaylistScraper {
 
     // MARK: - JSON Extraction
 
-    /// Extracts the ytInitialData JSON blob from YouTube's HTML.
-    ///
-    /// YouTube serves two formats depending on the user agent:
-    /// - Desktop: `var ytInitialData = { ... };`  (raw JSON object)
-    /// - Mobile:  `var ytInitialData = '\x7b...';` (hex-escaped string in single quotes)
+    /// Extracts the ytInitialData JSON blob. Handles both desktop raw-object and
+    /// mobile hex-escaped single-quoted formats.
     static func extractYTInitialData(from html: String) -> [String: Any]? {
         let marker = "var ytInitialData = "
         guard let markerRange = html.range(of: marker) else {
@@ -23,14 +20,12 @@ extension YouTubePlaylistScraper {
 
         let jsonString: String
         if firstChar == "'" {
-            // Mobile format: hex-escaped JSON in single quotes
             guard let parsed = extractSingleQuotedValue(from: html, startIndex: startIndex) else {
                 print("[YouTubePlaylist] Failed to extract single-quoted ytInitialData.")
                 return nil
             }
             jsonString = parsed
         } else if firstChar == "{" {
-            // Desktop format: raw JSON object
             jsonString = extractBraceBalancedJSON(from: html, startIndex: startIndex)
         } else {
             print("[YouTubePlaylist] Unexpected ytInitialData format.")
@@ -45,22 +40,19 @@ extension YouTubePlaylistScraper {
         return json
     }
 
-    /// Extracts a single-quoted, hex-escaped string value starting at the opening quote.
     private static func extractSingleQuotedValue(
         from html: String, startIndex: String.Index
     ) -> String? {
-        // Skip the opening single quote
         let contentStart = html.index(after: startIndex)
         guard contentStart < html.endIndex else { return nil }
 
-        // Find the closing single quote followed by ; (to avoid matching escaped quotes)
+        // `';` avoids matching escaped quotes inside the payload.
         guard let endRange = html.range(of: "';", range: contentStart..<html.endIndex) else {
             return nil
         }
 
         let escaped = String(html[contentStart..<endRange.lowerBound])
 
-        // Decode JavaScript string escapes: \xHH, \uHHHH, \\, \/, \n, \r, \t, \'
         var result = ""
         var index = escaped.startIndex
         while index < escaped.endIndex {
@@ -73,7 +65,6 @@ extension YouTubePlaylistScraper {
                 }
                 switch escaped[next] {
                 case "x":
-                    // \xHH - two-digit hex
                     let hexStart = escaped.index(after: next)
                     if let hexEnd = escaped.index(
                         hexStart, offsetBy: 2, limitedBy: escaped.endIndex
@@ -86,7 +77,6 @@ extension YouTubePlaylistScraper {
                         index = next
                     }
                 case "u":
-                    // \uHHHH - four-digit unicode
                     let hexStart = escaped.index(after: next)
                     if let hexEnd = escaped.index(
                         hexStart, offsetBy: 4, limitedBy: escaped.endIndex
@@ -129,7 +119,6 @@ extension YouTubePlaylistScraper {
         return result
     }
 
-    /// Extracts a brace-balanced JSON object from HTML starting at the opening brace.
     private static func extractBraceBalancedJSON(
         from html: String, startIndex: String.Index
     ) -> String {
@@ -156,17 +145,7 @@ extension YouTubePlaylistScraper {
 
     // MARK: - Playlist Parsing
 
-    /// Extracts the channel owner's avatar URL from ytInitialData.
-    ///
-    /// YouTube serves two different structures:
-    /// - Mobile/new layout: `header.pageHeaderRenderer` contains an
-    ///   `avatarStackViewModel` with `avatarViewModel.image.sources`.
-    /// - Desktop layout: `sidebar.playlistSidebarRenderer` contains a
-    ///   `videoOwnerRenderer` with `thumbnail.thumbnails`.
-    ///
-    /// Returns the highest-resolution URL available. The URL is upscaled
-    /// by rewriting the `=sN-` size suffix (YouTube's standard avatar
-    /// URL convention) so the cached favicon isn't stuck at 48px.
+    /// Extracts the channel owner's avatar URL, upscaling the `=sN-` suffix to 176px.
     static func parseChannelAvatarURL(from ytData: [String: Any]) -> String? {
         var rawURL: String?
 
@@ -184,8 +163,6 @@ extension YouTubePlaylistScraper {
         return upscaleAvatarURL(url)
     }
 
-    /// Recursively searches for the first `avatarViewModel.image.sources[*].url`
-    /// (picking the largest source by `width`). Used by the mobile layout.
     private static func findAvatarViewModelURL(in node: Any) -> String? {
         if let dict = node as? [String: Any] {
             if let avatar = dict["avatarViewModel"] as? [String: Any],
@@ -208,8 +185,6 @@ extension YouTubePlaylistScraper {
         return nil
     }
 
-    /// Recursively searches for the first `videoOwnerRenderer.thumbnail.thumbnails[*].url`
-    /// (picking the largest). Used by the desktop layout.
     private static func findVideoOwnerThumbnailURL(in node: Any) -> String? {
         if let dict = node as? [String: Any] {
             if let owner = dict["videoOwnerRenderer"] as? [String: Any],
@@ -230,8 +205,6 @@ extension YouTubePlaylistScraper {
         return nil
     }
 
-    /// Rewrites YouTube's `=sN-` size suffix to request a larger avatar.
-    /// Avatars are served at 48/88/176 px; we always request 176.
     private static func upscaleAvatarURL(_ url: String) -> String {
         guard let regex = try? NSRegularExpression(pattern: "=s\\d+-") else { return url }
         let range = NSRange(url.startIndex..., in: url)
@@ -240,23 +213,19 @@ extension YouTubePlaylistScraper {
         )
     }
 
-    /// Extracts the playlist title from ytInitialData.
     static func parsePlaylistTitle(from ytData: [String: Any]) -> String? {
-        // Try header > pageHeaderRenderer > pageTitle (mobile)
         if let header = ytData["header"] as? [String: Any],
            let pageHeader = header["pageHeaderRenderer"] as? [String: Any],
            let pageTitle = pageHeader["pageTitle"] as? String {
             return pageTitle
         }
 
-        // Try metadata > playlistMetadataRenderer > title (desktop)
         if let metadata = ytData["metadata"] as? [String: Any],
            let playlistMeta = metadata["playlistMetadataRenderer"] as? [String: Any],
            let title = playlistMeta["title"] as? String {
             return title
         }
 
-        // Try microformat > microformatDataRenderer > title (strip " - YouTube" suffix)
         if let microformat = ytData["microformat"] as? [String: Any],
            let mfData = microformat["microformatDataRenderer"] as? [String: Any],
            let rawTitle = mfData["title"] as? String {
@@ -270,9 +239,6 @@ extension YouTubePlaylistScraper {
         return nil
     }
 
-    /// Walks the ytInitialData structure to extract playlist video entries.
-    /// Supports both mobile (singleColumnBrowseResultsRenderer) and
-    /// desktop (twoColumnBrowseResultsRenderer) layouts.
     static func parsePlaylistVideos(from ytData: [String: Any]) -> [ParsedPlaylistVideo] {
         guard let contents = ytData["contents"] as? [String: Any] else { return [] }
 
@@ -295,7 +261,6 @@ extension YouTubePlaylistScraper {
 
             guard let videoId = renderer["videoId"] as? String else { continue }
 
-            // Title: title.runs[0].text
             let title: String
             if let titleObj = renderer["title"] as? [String: Any],
                let runs = titleObj["runs"] as? [[String: Any]],
@@ -306,7 +271,6 @@ extension YouTubePlaylistScraper {
                 title = "(Unknown Title)"
             }
 
-            // Thumbnail: pick the highest-resolution thumbnail available
             let thumbnailURL: String
             if let thumbObj = renderer["thumbnail"] as? [String: Any],
                let thumbs = thumbObj["thumbnails"] as? [[String: Any]],
@@ -325,8 +289,6 @@ extension YouTubePlaylistScraper {
         return videos
     }
 
-    /// Navigates the tabs > sectionList > itemSection > playlistVideoList hierarchy
-    /// shared by both single- and two-column layouts.
     private static func extractVideoEntries(
         fromBrowseRenderer renderer: [String: Any]
     ) -> [[String: Any]]? {

--- a/Integrations/YouTube/YouTubePlaylistScraper+Fetching.swift
+++ b/Integrations/YouTube/YouTubePlaylistScraper+Fetching.swift
@@ -2,13 +2,8 @@ import Foundation
 
 extension YouTubePlaylistScraper {
 
-    /// Fetches the YouTube playlist page and parses the video list.
-    ///
-    /// Also fetches the public Atom feed
-    /// (`/feeds/videos.xml?playlist_id=...`) to enrich each video with its
-    /// actual upload date, which isn't present in the playlist page's
-    /// `ytInitialData` blob. The Atom feed is capped at ~15 entries, so
-    /// older videos may remain without a publish date.
+    /// Fetches the playlist page and enriches each video with the Atom feed's publish date.
+    /// Atom feed caps at ~15 entries, so older videos may lack a publish date.
     func performFetch(url: URL, playlistID: String) async -> YouTubePlaylistScrapeResult {
         var request = URLRequest(url: url)
         request.setValue(sakuraUserAgent, forHTTPHeaderField: "User-Agent")
@@ -55,9 +50,6 @@ extension YouTubePlaylistScraper {
         }
     }
 
-    /// Fetches the public Atom feed for a playlist and returns a
-    /// `[videoID: publishedDate]` lookup. Returns an empty dictionary on
-    /// any failure - upload dates are a best-effort enrichment.
     private func fetchAtomPublishDates(playlistID: String) async -> [String: Date] {
         guard let url = URL(
             string: "https://www.youtube.com/feeds/videos.xml?playlist_id=\(playlistID)"
@@ -76,10 +68,6 @@ extension YouTubePlaylistScraper {
         }
     }
 
-    /// Parses an Atom feed body for `<entry>` elements and extracts
-    /// `yt:videoId` → `published` pairs using simple string scanning.
-    /// Robust enough for YouTube's stable Atom format; avoids pulling in
-    /// an `XMLParser` delegate for a handful of fields.
     static func parseAtomPublishDates(xml: String) -> [String: Date] {
         var result: [String: Date] = [:]
         let formatter = ISO8601DateFormatter()

--- a/Integrations/YouTube/YouTubePlaylistScraper.swift
+++ b/Integrations/YouTube/YouTubePlaylistScraper.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-/// Parsed video from a YouTube playlist page.
 struct ParsedPlaylistVideo: Sendable {
     let videoId: String
     let title: String
@@ -8,20 +7,17 @@ struct ParsedPlaylistVideo: Sendable {
     var publishedDate: Date?
 }
 
-/// Result of scraping a YouTube playlist.
 struct YouTubePlaylistScrapeResult: Sendable {
     let videos: [ParsedPlaylistVideo]
     let playlistTitle: String?
     let channelAvatarURL: String?
 }
 
-/// Fetches videos from a YouTube playlist by scraping the playlist page HTML.
-/// No login required - playlists are public.
+/// Scrapes YouTube playlist page HTML to list public videos.
 final class YouTubePlaylistScraper {
 
     // MARK: - Static Helpers
 
-    /// Returns true if the URL points to a YouTube playlist.
     nonisolated static func isYouTubePlaylistURL(_ url: URL) -> Bool {
         guard let host = url.host?.lowercased() else { return false }
         let isYouTubeDomain = host == "youtube.com" || host == "www.youtube.com"
@@ -31,7 +27,6 @@ final class YouTubePlaylistScraper {
         return extractPlaylistID(from: url) != nil
     }
 
-    /// Extracts the playlist ID from a YouTube playlist URL.
     nonisolated static func extractPlaylistID(from url: URL) -> String? {
         guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
             return nil
@@ -39,22 +34,18 @@ final class YouTubePlaylistScraper {
         return components.queryItems?.first { $0.name == "list" }?.value
     }
 
-    /// The pseudo-feed URL stored in the database for a YouTube playlist.
     nonisolated static func feedURL(for playlistID: String) -> String {
         "youtube-playlist://\(playlistID)"
     }
 
-    /// Constructs the canonical YouTube playlist URL from a playlist ID.
     nonisolated static func playlistURL(for playlistID: String) -> URL? {
         URL(string: "https://www.youtube.com/playlist?list=\(playlistID)")
     }
 
-    /// Checks if a feed URL is a YouTube playlist pseudo-feed.
     nonisolated static func isYouTubePlaylistFeedURL(_ url: String) -> Bool {
         url.hasPrefix("youtube-playlist://")
     }
 
-    /// Extracts the playlist ID from a YouTube playlist pseudo-feed URL.
     nonisolated static func playlistIDFromFeedURL(_ url: String) -> String? {
         guard isYouTubePlaylistFeedURL(url) else { return nil }
         return String(url.dropFirst("youtube-playlist://".count))
@@ -62,7 +53,6 @@ final class YouTubePlaylistScraper {
 
     // MARK: - Public
 
-    /// Fetches videos from the given YouTube playlist.
     func scrapePlaylist(playlistID: String) async -> YouTubePlaylistScrapeResult {
         guard let url = Self.playlistURL(for: playlistID) else {
             return YouTubePlaylistScrapeResult(

--- a/Integrations/arXiv/ArXivHelper.swift
+++ b/Integrations/arXiv/ArXivHelper.swift
@@ -1,19 +1,10 @@
 import Foundation
 
-/// Helpers for detecting arXiv URLs and mapping them between list pages,
-/// RSS feeds, abstract pages, and PDF downloads.
-///
-/// arXiv publishes standard RSS feeds that already contain paper titles and
-/// abstracts, so a dedicated scraper isn't needed. Instead, when the user
-/// adds an arXiv list URL (e.g. `https://arxiv.org/list/cs.AI/recent`) we
-/// transparently rewrite it to the category's RSS feed
-/// (`https://rss.arxiv.org/rss/cs.AI`) so the standard RSSParser can handle
-/// refreshes.
+/// Helpers for detecting arXiv URLs and rewriting list pages to their RSS feeds.
 nonisolated enum ArXivHelper {
 
     // MARK: - Host Detection
 
-    /// Returns `true` if the URL's host is an arXiv-owned domain.
     static func isArXivHost(_ url: URL) -> Bool {
         guard let host = url.host?.lowercased() else { return false }
         return host == "arxiv.org"
@@ -24,32 +15,24 @@ nonisolated enum ArXivHelper {
 
     // MARK: - List URL → Feed URL
 
-    /// Returns `true` if the URL points to an arXiv subject listing page,
-    /// e.g. `https://arxiv.org/list/cs.AI/recent`.
     static func isArXivListURL(_ url: URL) -> Bool {
         guard isArXivHost(url) else { return false }
         return extractCategoryFromListURL(url) != nil
     }
 
-    /// Extracts the arXiv subject category (e.g. `cs.AI`, `math.CO`,
-    /// `physics.optics`) from a list URL. Returns `nil` if the URL isn't a
-    /// valid list URL.
     static func extractCategoryFromListURL(_ url: URL) -> String? {
         guard isArXivHost(url) else { return nil }
         let components = url.path.split(separator: "/").map(String.init)
-        // Expected shape: ["list", "<category>", ...]
         guard components.count >= 2, components[0] == "list" else { return nil }
         let category = components[1]
         guard isValidCategory(category) else { return nil }
         return category
     }
 
-    /// Returns the RSS feed URL for a given arXiv subject category.
     static func feedURL(forCategory category: String) -> String {
         "https://rss.arxiv.org/rss/\(category)"
     }
 
-    /// Returns `true` if the given URL string points to an arXiv RSS feed.
     static func isArXivFeedURL(_ urlString: String) -> Bool {
         guard let url = URL(string: urlString), let host = url.host?.lowercased() else {
             return false
@@ -65,16 +48,12 @@ nonisolated enum ArXivHelper {
 
     // MARK: - Abstract & PDF URLs
 
-    /// Returns `true` if the URL points to an arXiv abstract page
-    /// (`/abs/<id>`).
     static func isArXivAbstractURL(_ url: URL) -> Bool {
         guard isArXivHost(url) else { return false }
         return extractArXivID(from: url) != nil
     }
 
-    /// Extracts the arXiv paper ID from an abstract or PDF URL.
-    /// Handles both the new (`2411.12345`) and legacy (`hep-th/0601001`)
-    /// identifier formats, plus any trailing version suffix (`v1`, `v2`, …).
+    /// Extracts the arXiv paper ID (handles new and legacy formats plus version suffix).
     static func extractArXivID(from url: URL) -> String? {
         guard isArXivHost(url) else { return nil }
         let path = url.path
@@ -86,20 +65,16 @@ nonisolated enum ArXivHelper {
         if remainder.hasSuffix(".pdf") {
             remainder = String(remainder.dropLast(4))
         }
-        // Trim any trailing slash.
         if remainder.hasSuffix("/") {
             remainder = String(remainder.dropLast())
         }
         return remainder.isEmpty ? nil : remainder
     }
 
-    /// Returns the canonical PDF URL for a given arXiv paper ID.
     static func pdfURL(forID arXivID: String) -> URL? {
         URL(string: "https://arxiv.org/pdf/\(arXivID).pdf")
     }
 
-    /// Returns the canonical PDF URL for the article at the given URL string,
-    /// if it refers to an arXiv abstract or PDF page.
     static func pdfURL(forArticleURL urlString: String) -> URL? {
         guard let url = URL(string: urlString),
               let arXivID = extractArXivID(from: url) else {
@@ -110,9 +85,6 @@ nonisolated enum ArXivHelper {
 
     // MARK: - Validation
 
-    /// arXiv subject categories look like `cs`, `cs.AI`, `math.CO`,
-    /// `physics.optics`, `hep-th`, etc. We accept the conservative superset of
-    /// lowercase letters, digits, dots, and hyphens.
     private static func isValidCategory(_ category: String) -> Bool {
         guard !category.isEmpty, category.count <= 32 else { return false }
         let allowed = CharacterSet(charactersIn:

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+Articles.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+Articles.swift
@@ -4,13 +4,9 @@ extension FeedManager {
 
     // MARK: - Chunk Boundaries
 
-    /// Safety cap for chunk-walking loops - two years' worth of 24-hour
-    /// chunks. Hitting this means the walk has skipped past every populated
-    /// chunk in that window without finding visible content.
     static var chunkWalkLimit: Int { 365 * 2 }
 
-    /// Articles are paginated in 24-hour chunks. Returns the chunk boundary
-    /// (00:00 local) at or before `date`.
+    /// Returns the 00:00-local chunk boundary at or before `date`.
     static func chunkStart(for date: Date) -> Date {
         Calendar.current.startOfDay(for: date)
     }
@@ -123,9 +119,7 @@ extension FeedManager {
         let muted = mutedFeedIDs
         var cursor = date
         var iterations = 0
-        // Walk backwards past chunks where every article is muted. The cursor
-        // must strictly decrease each iteration; the cap is a belt-and-braces
-        // guard against calendar edge cases so a bad step cannot spin forever.
+        // Cursor must strictly decrease each iteration; cap guards against calendar edge cases.
         while iterations < FeedManager.chunkWalkLimit {
             iterations += 1
             guard let earlier = (try? database.earliestArticleDate(before: cursor)) ?? nil else {

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+Batching.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+Batching.swift
@@ -101,10 +101,7 @@ extension FeedManager {
 
     // MARK: - Date-based Batches (Arbitrary Window)
 
-    /// Walks backwards in `chunkDays`-sized windows until it finds a window
-    /// that contains at least one visible article, honoring muted feeds and
-    /// per-feed / per-list rules. Returns the start date of that window, or
-    /// `nil` if no older content exists.
+    /// Walks backwards in `chunkDays` windows until a visible-article window is found.
     func nextArticleChunk(before date: Date, chunkDays days: Int) -> Date? {
         _ = dataRevision
         let calendar = Calendar.current
@@ -127,7 +124,6 @@ extension FeedManager {
         return nil
     }
 
-    /// Section-scoped variant of `nextArticleChunk(before:chunkDays:)`.
     func nextArticleChunk(for section: FeedSection, before date: Date, chunkDays days: Int) -> Date? {
         _ = dataRevision
         let sectionFeedIDs = Set(feeds.filter { $0.feedSection == section }.map(\.id))
@@ -152,7 +148,6 @@ extension FeedManager {
         return nil
     }
 
-    /// Feed-scoped variant of `nextArticleChunk(before:chunkDays:)`.
     func nextArticleChunk(for feed: Feed, before date: Date, chunkDays days: Int) -> Date? {
         _ = dataRevision
         let calendar = Calendar.current

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+ImagePreload.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+ImagePreload.swift
@@ -1,8 +1,6 @@
 import Foundation
 
-/// Accumulates article image URLs discovered during a refresh pass so
-/// `refreshAllFeeds` can run a single bounded-concurrency preload step
-/// at the end instead of contending with the feed-body fetches.
+/// Accumulates image URLs during refresh for a single bounded preload step at the end.
 actor ImagePreloadCollector {
 
     private var urls: [String] = []
@@ -20,13 +18,7 @@ actor ImagePreloadCollector {
 
 extension FeedManager {
 
-    /// Downloads and SQLite-caches the raw bytes for the given article
-    /// image URLs.  Runs at `.utility` priority with a small concurrency
-    /// cap so foreground scroll-driven image requests and the main
-    /// refresh pipeline stay ahead of this work.  Only the encoded bytes
-    /// are persisted — the `CachedAsyncImage` loader still does the
-    /// ImageIO downsample on first display, so this step adds zero
-    /// decoded-pixel memory pressure.
+    /// Downloads and caches raw bytes for article images at utility priority.
     nonisolated static func preloadImages(urls: [String]) async {
         guard !urls.isEmpty else { return }
 

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+InstagramProfile.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+InstagramProfile.swift
@@ -5,12 +5,9 @@ extension FeedManager {
 
     // MARK: - Instagram Profile Feeds
 
-    /// Minimum interval between Instagram API calls per feed (30 minutes).
     static let instagramRefreshInterval: TimeInterval = 30 * 60
 
-    /// Jittered effective refresh interval - the 30-minute floor plus up
-    /// to ~10 minutes so consecutive refreshes don't fall on a fixed
-    /// schedule (a strong automation signal on its own).
+    /// Adds up to 10 minutes of jitter to avoid a fixed-schedule automation signature.
     private static func jitteredRefreshInterval() -> TimeInterval {
         instagramRefreshInterval + TimeInterval.random(in: 0...(10 * 60))
     }

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+Lists.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+Lists.swift
@@ -64,7 +64,6 @@ extension FeedManager {
     func todayArticles(for list: FeedList) -> [Article] {
         let listFeedIDs = feedIDs(for: list)
         guard !listFeedIDs.isEmpty else { return [] }
-        // Get today's articles filtered by list's feeds, applying per-feed rules
         let articles = todayArticles().filter { listFeedIDs.contains($0.feedID) }
         return applyListRules(articles, listID: list.id)
     }
@@ -133,7 +132,7 @@ extension FeedManager {
         return result
     }
 
-    // MARK: - List Rule Application (additive on top of per-feed rules)
+    // MARK: - List Rule Application
 
     func applyListRules(_ articles: [Article], listID: Int64) -> [Article] {
         let allowedKeywords = (try? database.listRules(forListID: listID, type: "allowed_keyword")) ?? []

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+PendingReads.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+PendingReads.swift
@@ -21,9 +21,7 @@ extension FeedManager {
         pendingReadIDs.removeAll()
         let idArray = Array(ids)
 
-        // Persist before publishing observable changes so the next render
-        // of the article list views — which re-read from SQLite via
-        // `dataRevision` — sees the updated read state.
+        // Persist before publishing observable changes so re-reads via `dataRevision` see the update.
         try? database.markArticlesRead(ids: idArray, read: true)
 
         var newArticles = articles

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+Petal.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+Petal.swift
@@ -5,15 +5,7 @@ extension FeedManager {
 
     // MARK: - Petal Feed Lifecycle
 
-    /// Creates a new feed backed by a Petal recipe.  The recipe is
-    /// saved to `PetalStore` and the feed's URL is set to
-    /// `petal://<siteURL>` so `refreshFeed` dispatches to
-    /// `PetalEngine` on every refresh.
-    ///
-    /// - Parameter recipe: the completed recipe from the builder.
-    /// - Parameter iconData: an optional PNG payload imported from a
-    ///   `.srss` package (user-supplied icons override the acronym
-    ///   placeholder).
+    /// Creates a feed backed by a Petal recipe; the feed URL is `petal://<siteURL>`.
     @discardableResult
     func addPetalFeed(
         recipe: PetalRecipe,
@@ -31,8 +23,6 @@ extension FeedManager {
         )
         let feed = feeds.first(where: { $0.url == recipe.feedURL })
 
-        // Install the imported icon as the feed's custom favicon so
-        // it flows through the existing FaviconCache pipeline.
         if let feed, let iconData, let image = UIImage(data: iconData) {
             Task {
                 await FaviconCache.shared.setCustomFavicon(
@@ -45,8 +35,6 @@ extension FeedManager {
     }
 
     /// Updates the backing recipe for an existing Petal feed.
-    /// Also refreshes the feed's title/siteURL in the database if the
-    /// recipe's name or source URL changed.
     func updatePetalRecipe(
         feed: Feed,
         recipe: PetalRecipe
@@ -69,9 +57,7 @@ extension FeedManager {
         }
     }
 
-    /// Replacement for the RSS code path used by the normal refresh
-    /// pipeline.  Mirrors `FeedManager+Refresh.swift`'s
-    /// `refreshFeed(_:)` control flow but drives `PetalEngine`.
+    /// Mirror of `refreshFeed(_:)` that drives `PetalEngine` instead of the RSS path.
     func refreshPetalFeed(_ feed: Feed, reloadData: Bool) async throws {
         guard UserDefaults.standard.bool(forKey: "Labs.PetalRecipes") else {
             return

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+Refresh.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+Refresh.swift
@@ -189,7 +189,7 @@ extension FeedManager {
         await loadFromDatabaseInBackground()
     }
 
-    /// Refreshes every feed, then optionally chains the NLP pass.
+    /// Refreshes every feed, optionally chaining the NLP pass.
     func refreshAllFeeds(
         skipAuthenticatedScrapers: Bool = false,
         respectCooldown: Bool = false,
@@ -292,7 +292,6 @@ extension FeedManager {
         }
     }
 
-    /// Drains `feeds` through a task group capped at `maxConcurrent`.
     fileprivate func runBoundedRefresh(
         _ feeds: [Feed],
         maxConcurrent: Int,
@@ -341,7 +340,6 @@ extension FeedManager {
         }
     }
 
-    /// Runs the NLP pass while mirroring progress onto `nlpTotal` / `nlpCompleted`.
     fileprivate func processNewArticlesWithProgress() async {
         await NLPProcessingCoordinator.processNewArticlesIfEnabled(
             onBegin: { [weak self] total in
@@ -353,8 +351,7 @@ extension FeedManager {
         )
     }
 
-    /// Refreshes feeds that have never been fetched (e.g. added by the
-    /// share extension while the main app was in the background).
+    /// Refreshes feeds that have never been fetched.
     func refreshUnfetchedFeeds() async {
         let unfetched = feeds.filter { $0.lastFetched == nil }
         guard !unfetched.isEmpty else { return }
@@ -434,11 +431,7 @@ extension FeedManager {
         notifyFaviconChange()
     }
 
-    /// Cancels the in-flight `refreshAllFeeds` / `refreshAllFeedsAndFavicons`
-    /// task, if any.  URLSession fetches that are already in-flight receive
-    /// a `CancellationError`, no further feeds are submitted to the task
-    /// group, and the UI state (`isLoading`, progress counters) is torn down
-    /// by the refresh method's `defer` block once the task unwinds.
+    /// Cancels the in-flight refresh task; `defer` in the refresh method tears down UI state.
     @MainActor
     func cancelRefresh() {
         refreshTask?.cancel()

--- a/SakuraRSS/Classes/Feed Manager/FeedManager.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager.swift
@@ -13,7 +13,6 @@ final class FeedManager {
     var nlpTotal: Int = 0
     var nlpCompleted: Int = 0
 
-    /// Donut progress: feed refresh 0–80%, NLP processing 80–100%.
     var refreshProgress: Double {
         let hasRefresh = refreshTotal > 0
         let hasNLP = nlpTotal > 0
@@ -32,21 +31,16 @@ final class FeedManager {
     }
     private(set) var dataRevision: Int = 0
     private(set) var faviconRevision: Int = 0
-    /// Bumped when any feed refresh completes so views can flush any
-    /// staged UI state (e.g. the mark-as-read staging buffer) on refresh.
     private(set) var refreshRevision: Int = 0
     private(set) var unreadCounts: [Int64: Int] = [:]
     private(set) var feedsByID: [Int64: Feed] = [:]
 
-    /// Article IDs whose read state has been applied to the in-memory
-    /// `articles` array but not yet persisted to SQLite. Flushed in a
-    /// single detached task once scrolling settles.
+    /// Pending read-state flushes to SQLite; committed once scrolling settles.
     @ObservationIgnored var pendingReadIDs: Set<Int64> = []
     @ObservationIgnored var debouncedReadFlushTask: Task<Void, Never>?
     @ObservationIgnored var refreshTask: Task<Void, Never>?
 
-    /// Scroll state used to defer mark-as-read commits while the user
-    /// is scrolling fast. Updated by `TrackScrollActivityModifier`.
+    /// Scroll state used to defer mark-as-read commits during fast scroll.
     @ObservationIgnored var currentScrollPhase: ScrollPhase = .idle
     @ObservationIgnored var currentScrollVelocity: CGFloat = 0
     @ObservationIgnored var lastScrollOffset: CGFloat = 0
@@ -101,7 +95,6 @@ final class FeedManager {
         }
     }
 
-    /// Notify the UI that favicons may have changed so views re-fetch them.
     func notifyFaviconChange() {
         faviconRevision += 1
     }
@@ -112,8 +105,7 @@ final class FeedManager {
         }
     }
 
-    /// Applies per-feed decrement deltas in a single mutation so observers
-    /// only receive one notification for the batch.
+    /// Applies per-feed decrement deltas in a single mutation.
     func applyUnreadDecrements(_ decrements: [Int64: Int]) {
         guard !decrements.isEmpty else { return }
         var newCounts = unreadCounts

--- a/SakuraRSS/Structs/BatchSummarizer.swift
+++ b/SakuraRSS/Structs/BatchSummarizer.swift
@@ -1,24 +1,15 @@
 import Foundation
 import FoundationModels
 
-/// Runs LLM batch summarization: splits content into batches, summarizes each concurrently,
-/// then combines into a single summary.
+/// Runs LLM batch summarization concurrently then combines into a single summary.
 enum BatchSummarizer {
 
-    /// Minimum body length (in characters, after stripping HTML tags) for an
-    /// article to be worth handing to the LLM.  Articles shorter than this
-    /// are title-only stubs, placeholder/teaser bodies, or empty posts - all
-    /// of which cost LLM energy without improving the summary.
     static let minArticleBodyCharacters = 200
 
-    /// Returns true when `summary` has enough real content (after stripping
-    /// HTML tags and whitespace) to contribute to an LLM summary, and is not
-    /// a trivial duplicate of the title.
+    /// Returns true when `summary` has enough real content beyond the title to feed the LLM.
     static func hasUsefulContent(title: String, summary: String?) -> Bool {
         guard let summary, !summary.isEmpty else { return false }
 
-        // Strip HTML tags with a simple regex - good enough for the check
-        // since we only need a character count, not a rendered result.
         let stripped = summary
             .replacingOccurrences(
                 of: "<[^>]+>",
@@ -29,14 +20,13 @@ enum BatchSummarizer {
 
         guard stripped.count >= minArticleBodyCharacters else { return false }
 
-        // Reject bodies that are just the title repeated.
         if stripped.caseInsensitiveCompare(title) == .orderedSame {
             return false
         }
         return true
     }
 
-    /// Summarizes batches concurrently (max 3 at a time), then combines results if needed.
+    /// Summarizes batches concurrently (max 3 at a time), then combines.
     static func summarize(
         batches: [String],
         instructions: String,
@@ -83,7 +73,7 @@ enum BatchSummarizer {
         return response.content
     }
 
-    /// Packs strings into batches that each fit within the given character limit.
+    /// Packs strings into batches fitting within `charLimit`.
     static func packBatches(_ descriptions: [String], charLimit: Int) -> [String] {
         var batches: [String] = []
         var current: [String] = []

--- a/SakuraRSS/Structs/ContentBlock+Translation.swift
+++ b/SakuraRSS/Structs/ContentBlock+Translation.swift
@@ -3,17 +3,12 @@ import Foundation
 
 extension ContentBlock {
 
-    /// A contiguous slice of marker-encoded article text for translation purposes.
     enum TranslationSegment {
-        /// Plain text between markers — safe to send to the translator.
         case translatable(String)
-        /// A `{{TAG}}...{{/TAG}}` block whose payload must be preserved verbatim.
         case preserved(String)
     }
 
     /// Splits marker-encoded text into translatable spans and preserved marker blocks.
-    /// Translatable spans contain everything outside of `{{IMG}}`, `{{CODE}}`, `{{VIDEO}}`,
-    /// `{{YOUTUBE}}`, `{{XPOST}}`, `{{EMBED}}`, `{{TABLE}}`, and `{{MATH}}` markers.
     static func translationSegments(from text: String) -> [TranslationSegment] {
         let pattern = #"\{\{(IMG|CODE|VIDEO|YOUTUBE|XPOST|EMBED|TABLE|MATH)\}\}.*?\{\{/\1\}\}"#
         guard let regex = try? NSRegularExpression(
@@ -54,9 +49,7 @@ extension ContentBlock {
         return segments
     }
 
-    /// Translates marker-encoded article text one text block at a time, batching all text blocks
-    /// (and the optional title) into a single `session.translations(from:)` call so non-text
-    /// blocks (images, code, tables, embeds, math) are preserved verbatim in the output.
+    /// Translates marker-encoded article text, preserving non-text blocks verbatim.
     static func translateArticleContent(
         title: String?, markerText: String, session: TranslationSession
     ) async throws -> (title: String?, text: String) {

--- a/SakuraRSS/Structs/ContentBlock.swift
+++ b/SakuraRSS/Structs/ContentBlock.swift
@@ -27,7 +27,7 @@ enum ContentBlock: Identifiable {
         }
     }
 
-    /// Strips image and code markers from text, returning plain text suitable for translation/summarization.
+    /// Strips block markers, returning plain text suitable for translation/summarization.
     static func plainText(from text: String) -> String {
         let stripped = text.replacingOccurrences(
             of: #"\{\{IMG\}\}.+?\{\{/IMG\}\}"#, with: "", options: .regularExpression
@@ -60,11 +60,9 @@ enum ContentBlock: Identifiable {
         return ArticleMarker.unescape(stripped)
     }
 
-    /// Strips Markdown formatting from text, returning plain text suitable for content previews.
-    /// Handles links (including escaped brackets), bold, italic, headings, and sup/sub markers.
+    /// Strips Markdown formatting, returning plain text for content previews.
     static func stripMarkdown(_ text: String) -> String {
         var result = text
-        // Strip image markers (including optional link markers)
         result = result.replacingOccurrences(
             of: #"\{\{IMG\}\}.+?\{\{/IMG\}\}"#, with: "", options: .regularExpression
         )
@@ -86,40 +84,31 @@ enum ContentBlock: Identifiable {
         result = result.replacingOccurrences(
             of: #"(?s)\{\{TABLE\}\}.+?\{\{/TABLE\}\}"#, with: "", options: .regularExpression
         )
-        // Strip math markers, keeping the LaTeX text
         result = result.replacingOccurrences(
             of: #"\{\{MATH\}\}(.+?)\{\{/MATH\}\}"#, with: "$1", options: .regularExpression
         )
-        // Strip code markers, keeping content
         result = result.replacingOccurrences(of: "{{CODE}}", with: "")
         result = result.replacingOccurrences(of: "{{/CODE}}", with: "")
-        // Strip sup/sub markers, keeping content
         result = result.replacingOccurrences(
             of: #"\{\{SUP\}\}(.+?)\{\{/SUP\}\}"#, with: "$1", options: .regularExpression
         )
         result = result.replacingOccurrences(
             of: #"\{\{SUB\}\}(.+?)\{\{/SUB\}\}"#, with: "$1", options: .regularExpression
         )
-        // Strip Markdown links [text](url) → text (handle escaped brackets)
         result = result.replacingOccurrences(
             of: #"\[((?:[^\]\\]|\\.)+)\]\([^)]+\)"#, with: "$1", options: .regularExpression
         )
-        // Unescape brackets
         result = result.replacingOccurrences(of: "\\[", with: "[")
         result = result.replacingOccurrences(of: "\\]", with: "]")
-        // Strip bold **text** → text
         result = result.replacingOccurrences(
             of: #"\*\*(.+?)\*\*"#, with: "$1", options: .regularExpression
         )
-        // Strip italic *text* → text
         result = result.replacingOccurrences(
             of: #"\*(.+?)\*"#, with: "$1", options: .regularExpression
         )
-        // Strip heading prefixes
         result = result.replacingOccurrences(
             of: #"(?m)^#{1,6}\s+"#, with: "", options: .regularExpression
         )
-        // Collapse whitespace
         result = result.replacingOccurrences(
             of: #"\n{3,}"#, with: "\n\n", options: .regularExpression
         )
@@ -147,7 +136,6 @@ enum ContentBlock: Identifiable {
         var lastEnd = 0
 
         for match in matches {
-            // Text before the marker
             if match.range.location > lastEnd {
                 let before = nsText.substring(
                     with: NSRange(location: lastEnd, length: match.range.location - lastEnd)
@@ -166,7 +154,6 @@ enum ContentBlock: Identifiable {
             lastEnd = match.range.location + match.range.length
         }
 
-        // Text after the last marker
         if lastEnd < nsText.length {
             let after = nsText.substring(from: lastEnd)
                 .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -207,7 +194,6 @@ enum ContentBlock: Identifiable {
             let trimmed = content.trimmingCharacters(in: .whitespacesAndNewlines)
             return trimmed.isEmpty ? nil : .math(ArticleMarker.unescape(trimmed))
         default:
-            // IMG - possibly with a link
             let nsContent = content as NSString
             if let linkRegex,
                let linkMatch = linkRegex.firstMatch(
@@ -221,8 +207,7 @@ enum ContentBlock: Identifiable {
         }
     }
 
-    /// Parses a `{{TABLE}}` marker payload into header + rows.
-    /// Payload format: `header1|header2\nrow1col1|row1col2\n…`.
+    /// Parses `{{TABLE}}` payload `header1|header2\nrow1col1|row1col2\n…` into header + rows.
     private static func parseTableMarker(_ content: String) -> ContentBlock? {
         let lines = content
             .split(separator: "\n", omittingEmptySubsequences: false)

--- a/SakuraRSS/Structs/NLPProcessingCoordinator.swift
+++ b/SakuraRSS/Structs/NLPProcessingCoordinator.swift
@@ -8,18 +8,10 @@ enum NLPProcessingCoordinator {
     nonisolated static let logger = Logger(subsystem: "com.tsubuzaki.SakuraRSS", category: "NLPCoordinator")
     #endif
 
-    /// Number of articles processed per chunk before yielding back to the
-    /// cooperative scheduler.  Keeps main-thread hitches short when this
-    /// coordinator runs concurrently with scrolling.
     nonisolated private static let chunkSize = 20
 
     /// Processes unprocessed articles if Content Insights is enabled.
-    /// `onBegin` fires once with the total; `onProgress` fires in batches
-    /// (aligned to each cooperative-yield boundary) with the number of
-    /// articles completed since the last call.  Coalescing the ticks keeps
-    /// the progress donut from hopping to the MainActor 200 times per
-    /// refresh, which is the source of the scroll hitches users see while
-    /// NLP runs.
+    /// `onProgress` is coalesced per chunk to avoid MainActor hitches.
     static func processNewArticlesIfEnabled(
         onBegin: @escaping @Sendable (Int) async -> Void = { _ in },
         onProgress: @escaping @Sendable (Int) async -> Void = { _ in }
@@ -57,10 +49,7 @@ enum NLPProcessingCoordinator {
 
             await onBegin(toProcess.count)
 
-            // Reuse a single sentiment tagger and a single name-type tagger
-            // across every article in this pass.  NLTagger construction is
-            // measurably expensive; setting `.string` on an existing tagger
-            // is cheap.
+            // Reuse taggers across articles; NLTagger construction is expensive.
             let sentimentTagger = NLTagger(tagSchemes: [.sentimentScore])
             let nameTagger = NLTagger(tagSchemes: [.nameType])
 
@@ -94,7 +83,7 @@ enum NLPProcessingCoordinator {
         }.value
     }
 
-    /// Processes a single article on-demand (e.g., from ArticleDetailView).
+    /// Processes a single article on-demand.
     static func processArticle(_ article: Article) async {
         let defaults = UserDefaults.standard
         guard defaults.bool(forKey: "Intelligence.ContentInsights.Enabled") else { return }
@@ -104,15 +93,7 @@ enum NLPProcessingCoordinator {
         }.value
     }
 
-    /// Extracts sentiment and entities for an article. Called only when
-    /// Content Insights is enabled - the hybrid similarity ranker relies on
-    /// entities being present, so both passes always run together.
-    ///
-    /// When `sentimentTagger` and `nameTagger` are supplied, they are reused
-    /// across articles by the batch caller.  The single-article path
-    /// constructs fresh taggers on each call.  `runSentiment` / `runEntities`
-    /// let the batch caller skip passes that have already been completed
-    /// for this article on a previous run.
+    /// Extracts sentiment and entities for an article; reuses taggers when supplied.
     private nonisolated static func processArticleSync(
         _ article: Article,
         sentimentTagger: NLTagger? = nil,

--- a/SakuraRSS/Views/App+BackgroundTasks.swift
+++ b/SakuraRSS/Views/App+BackgroundTasks.swift
@@ -12,8 +12,6 @@ extension SakuraRSSApp {
         scheduleiCloudBackup()
     }
 
-    /// Registers launch handlers from a nonisolated seam so the closures
-    /// don't inherit `SakuraRSSApp`'s `@MainActor` isolation.
     nonisolated private func registerLaunchHandlers(
         appRefreshTaskID: String,
         cloudBackupTaskID: String
@@ -48,23 +46,15 @@ extension SakuraRSSApp {
     }
 
     nonisolated func handleAppRefresh(task: BGAppRefreshTask) {
-        // Always reschedule the next window before deciding what to run.
         scheduleAppRefresh()
 
-        // Respect Low Power Mode: do no background work at all, just
-        // complete cleanly so the system doesn't count this as a failure.
         if ProcessInfo.processInfo.isLowPowerModeEnabled {
             task.setTaskCompleted(success: true)
             return
         }
 
         let refreshTask = Task {
-            // Skip per-article HTML metadata image backfill when we're on
-            // an expensive path (cellular / hotspot) and the user has the
-            // Wi-Fi-only preference on.  The feed bodies themselves still
-            // load; only the optional og:image lookup is deferred.  A nil
-            // probe result is treated as "assume expensive" so we default
-            // to the safer behavior when the network type is unknown.
+            // nil probe means "assume expensive" so we default to the safer behavior.
             let imageBackfillModeRaw = UserDefaults.standard.string(
                 forKey: "BackgroundRefresh.ImageBackfillMode"
             )
@@ -78,10 +68,7 @@ extension SakuraRSSApp {
                 case .off: return true
                 }
             }()
-            // Per-article image preload is an order of magnitude more
-            // bandwidth than the og:image lookup, and background fetches
-            // run off the user's battery.  Gate on plugged-in + Wi-Fi so
-            // it only ever runs during an overnight/desk charging window.
+            // Gate image preload on plugged-in + Wi-Fi so it only runs during overnight charging.
             let pluggedIn = await MainActor.run { () -> Bool in
                 UIDevice.current.isBatteryMonitoringEnabled = true
                 switch UIDevice.current.batteryState {
@@ -113,10 +100,8 @@ extension SakuraRSSApp {
         }
     }
 
-    /// Submits a `BGProcessingTaskRequest` for the iCloud backup, requiring
-    /// network connectivity and external power so the system runs it during
-    /// idle/charging windows (typically overnight on Wi-Fi). Cancelled if the
-    /// user has set the backup interval to Off.
+    /// Submits a `BGProcessingTaskRequest` for the iCloud backup; requires
+    /// network + external power so it runs overnight on Wi-Fi.
     nonisolated func scheduleiCloudBackup() {
         let intervalRaw = UserDefaults.standard.integer(forKey: "iCloudBackup.Interval")
         let interval = iCloudBackupManager.BackupInterval(rawValue: intervalRaw) ?? .everyNight
@@ -131,11 +116,8 @@ extension SakuraRSSApp {
         try? BGTaskScheduler.shared.submit(request)
     }
 
-    /// For `.everyNight`, target the next occurrence of 2 AM local time so
-    /// the task's earliest run overlaps with typical overnight charging.
-    /// Using `now + 24h` caused the window to drift forward each launch,
-    /// landing mid-day when the device is rarely plugged in.
     nonisolated private func earliestBackupDate(for interval: iCloudBackupManager.BackupInterval) -> Date {
+        // For `.everyNight`, target the next 2 AM local so the run overlaps with typical overnight charging.
         switch interval {
         case .everyNight:
             let calendar = Calendar.current
@@ -155,7 +137,6 @@ extension SakuraRSSApp {
     }
 
     nonisolated func handleiCloudBackup(task: BGProcessingTask) {
-        // Always reschedule the next window before doing any work.
         scheduleiCloudBackup()
 
         let backupTask = Task {

--- a/SakuraRSS/Views/App+Startup.swift
+++ b/SakuraRSS/Views/App+Startup.swift
@@ -26,12 +26,7 @@ extension SakuraRSSApp {
         }
     }
 
-    /// Runs a one-time full Spotlight reindex when the on-device index
-    /// schema doesn't match the current build's `SpotlightIndexer.schemaVersion`.
-    /// Does NOT gate on Low Power Mode: if the schema has changed, search
-    /// is broken until the reindex runs.  In the steady state - when the
-    /// stored version already matches - this method is a single
-    /// `UserDefaults` read and returns immediately.
+    /// Full Spotlight reindex when the on-device schema doesn't match the current build.
     func reindexSpotlightIfSchemaChanged() {
         let defaults = UserDefaults.standard
         let storedRaw = defaults.object(forKey: SpotlightIndexer.schemaVersionDefaultsKey) as? Int

--- a/SakuraRSS/Views/App+URLHandling.swift
+++ b/SakuraRSS/Views/App+URLHandling.swift
@@ -35,10 +35,7 @@ extension SakuraRSSApp {
             case "putonpipboy":
                 wipeAllCachesAndData()
                 Task {
-                    // X and Instagram cookies live in Keychain, which
-                    // survives the filesystem wipe above - no cookie
-                    // re-warming needed.  X still has to re-extract its
-                    // in-memory GraphQL query IDs from the JS bundle.
+                    // X/Instagram cookies in Keychain survive the wipe; X must re-extract GraphQL IDs.
                     if UserDefaults.standard.bool(forKey: "Labs.XProfileFeeds") {
                         await XProfileScraper.fetchQueryIDsIfNeeded()
                     }
@@ -73,13 +70,10 @@ extension SakuraRSSApp {
         }
     }
 
-    /// Wipes everything in the app's Caches, Application Support, Documents,
-    /// and tmp directories except the feeds database in the shared app group
-    /// container. Invoked via `sakura://putonpipboy`.
+    /// Wipes app sandbox directories and tmp, preserving the feeds database in the group container.
     func wipeAllCachesAndData() {
         let fm = FileManager.default
 
-        // Wipe the main app sandbox directories entirely.
         let directories: [FileManager.SearchPathDirectory] = [
             .cachesDirectory,
             .applicationSupportDirectory,
@@ -90,10 +84,8 @@ extension SakuraRSSApp {
             wipeContents(of: dir)
         }
 
-        // Wipe the temporary directory.
         wipeContents(of: fm.temporaryDirectory)
 
-        // Wipe the shared app group container, but preserve the feeds database.
         if let groupURL = fm.containerURL(
             forSecurityApplicationGroupIdentifier: "group.com.tsubuzaki.SakuraRSS"
         ) {
@@ -105,7 +97,6 @@ extension SakuraRSSApp {
         }
     }
 
-    /// Removes every top-level entry inside `directory`, except names in `except`.
     func wipeContents(of directory: URL, except: Set<String> = []) {
         let fileManager = FileManager.default
         guard let entries = try? fileManager.contentsOfDirectory(

--- a/SakuraRSS/Views/Feeds/FeedEditSheet+Icons.swift
+++ b/SakuraRSS/Views/Feeds/FeedEditSheet+Icons.swift
@@ -10,11 +10,9 @@ extension FeedEditSheet {
             if customURL == "photo" {
                 return await FaviconCache.shared.customFavicon(feedID: feed.id)
             }
-            // Check if already cached for this feed
             if let cached = await FaviconCache.shared.customFavicon(feedID: feed.id) {
                 return cached
             }
-            // Download, cache locally, then return
             if let url = URL(string: customURL),
                let (data, _) = try? await URLSession.shared.data(for: .sakura(url: url)),
                let image = UIImage(data: data) {
@@ -33,7 +31,6 @@ extension FeedEditSheet {
         isFetchingIcon = true
         defer { isFetchingIcon = false }
 
-        // For X feeds, fetch the profile avatar using XProfileScraper
         if feed.isXFeed,
            let handle = XProfileScraper.handleFromFeedURL(feed.url),
            let cookies = await XProfileScraper.getXCookies() {
@@ -52,7 +49,6 @@ extension FeedEditSheet {
             }
         }
 
-        // For Instagram feeds, fetch the profile avatar using InstagramProfileScraper
         if feed.isInstagramFeed,
            let handle = InstagramProfileScraper.handleFromFeedURL(feed.url),
            let profileURL = InstagramProfileScraper.profileURL(for: handle) {
@@ -98,9 +94,7 @@ extension FeedEditSheet {
                 useDefaultIcon = false
                 return true
             }
-        } catch {
-            // Icon fetch failed - show error below
-        }
+        } catch { }
         showIconFetchError = true
         return false
     }

--- a/SakuraRSS/Views/Feeds/FeedEditSheet+Icons.swift
+++ b/SakuraRSS/Views/Feeds/FeedEditSheet+Icons.swift
@@ -94,7 +94,8 @@ extension FeedEditSheet {
                 useDefaultIcon = false
                 return true
             }
-        } catch { }
+        } catch {
+        }
         showIconFetchError = true
         return false
     }

--- a/SakuraRSS/Views/Home/AddFeedView.swift
+++ b/SakuraRSS/Views/Home/AddFeedView.swift
@@ -22,9 +22,6 @@ struct AddFeedView: View {
     @AppStorage("Labs.PetalRecipes") private var petalRecipesEnabled: Bool = false
     @FocusState private var isURLFieldFocused: Bool
 
-    /// The URL to seed the Petal builder with when the user taps
-    /// "Generate with Petal" after a failed search.  Prefers the
-    /// normalized input URL; falls back to whatever is in the field.
     private var petalSeedURL: String {
         let trimmed = urlInput.trimmingCharacters(in: .whitespaces)
         return trimmed.isEmpty ? "" : normalizeURL(trimmed)
@@ -253,30 +250,25 @@ struct AddFeedView: View {
         Task {
             var results: [DiscoveredFeed] = []
 
-            // 1. Try as direct feed URL (highest priority)
             if let feed = await tryDirectFeedURL(urlInput) {
                 results.append(feed)
             }
 
-            // 2. Search for feeds on the full URL
             let normalizedURL = normalizeURL(urlInput)
             if let url = URL(string: normalizedURL) {
                 let urlFeeds = await FeedDiscovery.shared.discoverFeeds(fromPageURL: url)
                 results.append(contentsOf: urlFeeds)
             }
 
-            // 3. Fall back to root domain search if nothing found yet
             if results.isEmpty {
                 let domain = extractDomain(from: urlInput)
                 let domainFeeds = await FeedDiscovery.shared.discoverFeeds(forDomain: domain)
                 results.append(contentsOf: domainFeeds)
             }
 
-            // Deduplicate by URL, keeping the first (highest priority) occurrence
             var seen = Set<String>()
             results = results.filter { seen.insert($0.url).inserted }
 
-            // Sort alphabetically by title
             results.sort { $0.title.localizedCaseInsensitiveCompare($1.title) == .orderedAscending }
 
             await MainActor.run {
@@ -314,17 +306,14 @@ struct AddFeedView: View {
     }
 
     private func addFeed(_ discovered: DiscoveredFeed) {
-        // X feeds require the experiment to be enabled
         guard !XProfileScraper.isXFeedURL(discovered.url)
                 || UserDefaults.standard.bool(forKey: "Labs.XProfileFeeds") else {
             return
         }
-        // Instagram feeds require the experiment to be enabled
         guard !InstagramProfileScraper.isInstagramFeedURL(discovered.url)
                 || UserDefaults.standard.bool(forKey: "Labs.InstagramProfileFeeds") else {
             return
         }
-        // If this is an X feed and the user hasn't logged in yet, prompt login first
         if XProfileScraper.isXFeedURL(discovered.url) && !feedManager.hasXFeeds {
             pendingXFeed = discovered
             Task {
@@ -337,7 +326,6 @@ struct AddFeedView: View {
             }
             return
         }
-        // If this is an Instagram feed and the user hasn't logged in yet, prompt login first
         if InstagramProfileScraper.isInstagramFeedURL(discovered.url)
             && !feedManager.hasInstagramFeeds {
             pendingInstagramFeed = discovered

--- a/SakuraRSS/Views/Home/AllArticlesView.swift
+++ b/SakuraRSS/Views/Home/AllArticlesView.swift
@@ -70,7 +70,7 @@ enum HomeSelection: Hashable, RawRepresentable {
                 return
             }
         }
-        // Legacy migration: bare section names from before the HomeSelection wrapper
+        // Legacy: bare section names from before the HomeSelection wrapper.
         if let section = HomeSection(rawValue: rawValue) {
             self = .section(section)
             return

--- a/SakuraRSS/Views/Home/TodaysSummaryView+Generation.swift
+++ b/SakuraRSS/Views/Home/TodaysSummaryView+Generation.swift
@@ -6,10 +6,6 @@ extension TodaysSummaryView {
     static let snippetCharLimit = 150
 
     func generateSummary(for date: Date) async {
-        // Skip articles that are title-only, have empty/placeholder bodies,
-        // or whose body is just the title repeated.  Removing these up
-        // front means fewer LLM calls (lower energy) *and* a better
-        // summary - the LLM has more signal to work with.
         let articles = feedManager.todaySummaryArticles().filter { article in
             BatchSummarizer.hasUsefulContent(title: article.title, summary: article.summary)
         }

--- a/SakuraRSS/Views/Home/TodaysSummaryView.swift
+++ b/SakuraRSS/Views/Home/TodaysSummaryView.swift
@@ -17,8 +17,7 @@ struct TodaysSummaryView: View {
     @State private var isExpanded = false
     @State var generationFailed = false
     @State var generationError: String?
-    /// True when auto-generation was skipped because Low Power Mode is on.
-    /// In this state the user must tap the refresh button to start.
+    /// Auto-generation skipped under Low Power Mode; user must tap refresh.
     @State private var deferredForLowPowerMode = false
 
     private var isSupported: Bool {
@@ -218,18 +217,13 @@ struct TodaysSummaryView: View {
             return
         }
 
-        // Under Low Power Mode we do not auto-run the on-device LLM -
-        // the user must tap the refresh button to kick off generation.
-        // This is the single most expensive recurring operation in the
-        // app; making it opt-in under LPM is a large battery win and
-        // the inline hint below explains why nothing is happening.
+        // Under Low Power Mode, require user action to kick off the on-device LLM.
         if ProcessInfo.processInfo.isLowPowerModeEnabled {
             deferredForLowPowerMode = true
             hasGenerated = true
             return
         }
 
-        // Wait for initial feed refresh to complete before generating
         while feedManager.isLoading {
             try? await Task.sleep(for: .milliseconds(200))
         }

--- a/SakuraRSS/Views/Home/WhileYouSleptView+Generation.swift
+++ b/SakuraRSS/Views/Home/WhileYouSleptView+Generation.swift
@@ -6,10 +6,6 @@ extension WhileYouSleptView {
     static let snippetCharLimit = 150
 
     func generateSummary(for date: Date) async {
-        // Skip articles that are title-only, have empty/placeholder bodies,
-        // or whose body is just the title repeated.  Removing these up
-        // front means fewer LLM calls (lower energy) *and* a better
-        // summary - the LLM has more signal to work with.
         let articles = feedManager.overnightArticles().filter { article in
             BatchSummarizer.hasUsefulContent(title: article.title, summary: article.summary)
         }

--- a/SakuraRSS/Views/Home/WhileYouSleptView.swift
+++ b/SakuraRSS/Views/Home/WhileYouSleptView.swift
@@ -16,8 +16,7 @@ struct WhileYouSleptView: View {
     @State var hasGenerated = false
     @State private var isExpanded = false
     @State var generationFailed = false
-    /// True when auto-generation was skipped because Low Power Mode is on.
-    /// In this state the user must tap the refresh button to start.
+    /// Auto-generation skipped under Low Power Mode; user must tap refresh.
     @State private var deferredForLowPowerMode = false
 
     private var isSupported: Bool {
@@ -210,15 +209,12 @@ struct WhileYouSleptView: View {
             return
         }
 
-        // Under Low Power Mode we do not auto-run the on-device LLM -
-        // the user must tap the refresh button to kick off generation.
         if ProcessInfo.processInfo.isLowPowerModeEnabled {
             deferredForLowPowerMode = true
             hasGenerated = true
             return
         }
 
-        // Wait for initial feed refresh to complete before generating
         while feedManager.isLoading {
             try? await Task.sleep(for: .milliseconds(200))
         }

--- a/SakuraRSS/Views/KeepScreenOnDuringPodcastWork.swift
+++ b/SakuraRSS/Views/KeepScreenOnDuringPodcastWork.swift
@@ -1,8 +1,6 @@
 import SwiftUI
 
-/// Keeps the device screen awake while any podcast download or transcription
-/// is in progress, so long-running work isn't interrupted when the device
-/// would otherwise auto-lock.
+/// Keeps the screen awake while podcast downloads or transcriptions are active.
 struct KeepScreenOnDuringPodcastWork: ViewModifier {
     @State private var manager = PodcastDownloadManager.shared
 

--- a/SakuraRSS/Views/Lists/AddFeedToListSheet.swift
+++ b/SakuraRSS/Views/Lists/AddFeedToListSheet.swift
@@ -79,7 +79,6 @@ struct AddFeedToListSheet: View {
                 selectedListIDs = feedManager.listIDsForFeed(feed)
             }
             .sheet(isPresented: $isShowingNewList) {
-                // After creating a new list, auto-select it
                 if let newList = feedManager.lists.last {
                     selectedListIDs.insert(newList.id)
                 }
@@ -94,13 +93,11 @@ struct AddFeedToListSheet: View {
 
     private func save() {
         let currentIDs = feedManager.listIDsForFeed(feed)
-        // Add to newly selected lists
         for id in selectedListIDs where !currentIDs.contains(id) {
             if let list = feedManager.lists.first(where: { $0.id == id }) {
                 feedManager.addFeedToList(list, feed: feed)
             }
         }
-        // Remove from deselected lists
         for id in currentIDs where !selectedListIDs.contains(id) {
             if let list = feedManager.lists.first(where: { $0.id == id }) {
                 feedManager.removeFeedFromList(list, feed: feed)

--- a/SakuraRSS/Views/Lists/ListEditSheet.swift
+++ b/SakuraRSS/Views/Lists/ListEditSheet.swift
@@ -149,7 +149,6 @@ struct ListEditSheet: View {
         if let list {
             feedManager.updateList(list, name: trimmedName, icon: selectedIcon,
                                    displayStyle: selectedDisplayStyle)
-            // Update feed membership
             let currentIDs = feedManager.feedIDs(for: list)
             for id in selectedFeedIDs where !currentIDs.contains(id) {
                 if let feed = feedManager.feedsByID[id] {
@@ -163,7 +162,6 @@ struct ListEditSheet: View {
             }
         } else {
             if let _ = try? feedManager.createList(name: trimmedName, icon: selectedIcon) {
-                // Newly created list - assign feeds
                 if let newList = feedManager.lists.last {
                     for id in selectedFeedIDs {
                         if let feed = feedManager.feedsByID[id] {

--- a/SakuraRSS/Views/More/Integrations/PodcastSettingsView.swift
+++ b/SakuraRSS/Views/More/Integrations/PodcastSettingsView.swift
@@ -66,8 +66,7 @@ struct PodcastSettingsView: View {
                 }
                 .disabled(isDownloadingModel)
                 .onChange(of: toggleState) { _, newValue in
-                    // Ignore the synthetic change fired when `.task` syncs
-                    // local state to persisted state on view appear.
+                    // Ignore synthetic change fired when `.task` syncs on appear.
                     guard hasBootstrapped else { return }
                     handleToggleChange(newValue)
                 }
@@ -107,10 +106,7 @@ struct PodcastSettingsView: View {
         .task {
             downloadsSize = PodcastDownloadManager.totalDownloadedSize()
             refreshModelStatus()
-            // Reconcile the toggle with on-disk state: if the user flipped the
-            // toggle on previously but the model never downloaded (or was
-            // manually removed), reset the toggle to off so the UI matches
-            // reality. Otherwise adopt the persisted value.
+            // Reconcile toggle with on-disk state when the model is missing.
             if transcriptionEnabled && !modelReady {
                 transcriptionEnabled = false
             }
@@ -149,13 +145,9 @@ struct PodcastSettingsView: View {
 
     private func handleToggleChange(_ newValue: Bool) {
         if newValue {
-            // User flipped on. Any stale error goes away now.
             downloadError = nil
-            // Guard: require network before kicking off a download.
             guard NetworkMonitor.shared.isOnline else {
                 downloadError = .offline
-                // Revert the toggle. The re-fire of this handler will land
-                // in the else branch, which is idempotent.
                 transcriptionEnabled = false
                 toggleState = false
                 return
@@ -163,10 +155,7 @@ struct PodcastSettingsView: View {
             transcriptionEnabled = true
             startDownload()
         } else {
-            // Toggling off - cancel any in-flight download and wipe the model.
-            // Don't clear downloadError here: if we're landing here because
-            // the toggle was reverted after a failure, we want the error
-            // message to stay visible.
+            // Don't clear downloadError: preserve it when toggle reverted after a failure.
             if downloadTask != nil {
                 userCancelledDownload = true
                 downloadTask?.cancel()
@@ -194,9 +183,6 @@ struct PodcastSettingsView: View {
                 })
                 await MainActor.run {
                     downloadTask = nil
-                    // If the user toggled off after the download completed
-                    // but before this continuation ran, delete the freshly
-                    // downloaded model so the UI and disk stay in sync.
                     if userCancelledDownload {
                         userCancelledDownload = false
                         try? engine.deleteModel()
@@ -214,17 +200,13 @@ struct PodcastSettingsView: View {
                     downloadTask = nil
                     isDownloadingModel = false
                     downloadProgress = 0
-                    // User-initiated cancel: silently swallow, UI already reset.
                     if userCancelledDownload {
                         userCancelledDownload = false
                         try? engine.deleteModel()
                         refreshModelStatus()
                         return
                     }
-                    // Distinguish offline from other failures so we can show
-                    // the right message.
                     downloadError = NetworkMonitor.shared.isOnline ? .generic : .offline
-                    // Roll the toggle back off and clean up any partial files.
                     transcriptionEnabled = false
                     try? engine.deleteModel()
                     toggleState = false
@@ -246,7 +228,6 @@ struct PodcastSettingsView: View {
     }
 }
 
-/// Circular determinate progress indicator styled as a donut.
 private struct ProgressDonut: View {
     let progress: Double
 

--- a/SakuraRSS/Views/Petal/PetalBuilderPreviewSection.swift
+++ b/SakuraRSS/Views/Petal/PetalBuilderPreviewSection.swift
@@ -1,10 +1,6 @@
 import SwiftUI
 
-/// "Preview" section of the Web Feed builder: shows what the
-/// current recipe would produce if saved, or a prompt telling
-/// the user to fetch the page first.
-///
-/// All state flows in via the parent; this view is pure.
+/// "Preview" section of the Web Feed builder showing matched articles.
 struct PetalBuilderPreviewSection: View {
 
     let articles: [ParsedArticle]
@@ -19,8 +15,6 @@ struct PetalBuilderPreviewSection: View {
             header
         }
     }
-
-    // MARK: - Body branches
 
     @ViewBuilder
     private var contentBody: some View {
@@ -53,9 +47,6 @@ struct PetalBuilderPreviewSection: View {
     }
 }
 
-/// A single preview row showing a matched article's title, URL,
-/// and summary - extracted so the parent `PetalBuilderPreviewSection`
-/// stays focused on branching between its empty/error states.
 private struct PetalBuilderPreviewRow: View {
 
     let article: ParsedArticle

--- a/SakuraRSS/Views/Petal/PetalBuilderSelectorsSection.swift
+++ b/SakuraRSS/Views/Petal/PetalBuilderSelectorsSection.swift
@@ -1,14 +1,6 @@
 import SwiftUI
 
-/// "Selectors" section of the Web Feed builder: the Auto-Detect
-/// button plus the six CSS-selector input rows.
-///
-/// Takes a binding to the whole recipe (rather than individual
-/// selector bindings) because every selector field ends up
-/// needing the same pattern and passing seven bindings clutters
-/// the parent call site.  Preview-refresh scheduling is
-/// delegated back via `onSelectorChanged` so this view doesn't
-/// have to own a debounce task.
+/// "Selectors" section of the Web Feed builder with Auto-Detect and CSS-selector rows.
 struct PetalBuilderSelectorsSection: View {
 
     @Binding var recipe: PetalRecipe

--- a/SakuraRSS/Views/Petal/PetalBuilderSourceSection.swift
+++ b/SakuraRSS/Views/Petal/PetalBuilderSourceSection.swift
@@ -1,10 +1,6 @@
 import SwiftUI
 
-/// "Source" section of the Web Feed builder: feed name, page
-/// URL, and fetch mode picker.
-///
-/// Owns no state of its own - the parent `PetalBuilderView` holds
-/// the recipe and passes bindings down.
+/// "Source" section of the Web Feed builder: name, URL, and fetch mode.
 struct PetalBuilderSourceSection: View {
 
     @Binding var name: String

--- a/SakuraRSS/Views/Petal/PetalBuilderView.swift
+++ b/SakuraRSS/Views/Petal/PetalBuilderView.swift
@@ -1,26 +1,6 @@
 import SwiftUI
 
 /// Selector-based recipe editor for a single Web Feed.
-///
-/// The view keeps things approachable for users who've never
-/// heard of CSS selectors:
-///
-/// 1. They paste a URL and tap **Fetch**.
-/// 2. The builder loads the page and shows a live preview of
-///    every item that currently matches `itemSelector`.
-/// 3. **Auto-Detect** runs a heuristic pattern finder that tries
-///    to guess the right selectors for them.
-/// 4. Saving calls `FeedManager.addPetalFeed` (create) or
-///    `updatePetalRecipe` (edit), which re-routes the refresh to
-///    `PetalEngine`.
-///
-/// The preview re-runs on a debounced basis so heavy typing
-/// doesn't hammer the network; fetches are cached so tweaking
-/// selectors after an initial fetch is instantaneous.
-///
-/// This view owns the state and action methods; the three form
-/// sections (source, selectors, preview) live in their own
-/// sibling files so each is small enough to read in one screen.
 struct PetalBuilderView: View {
 
     enum Mode {
@@ -151,7 +131,6 @@ struct PetalBuilderView: View {
 
     private func schedulePreview() {
         previewTask?.cancel()
-        // Only run the in-memory re-parse if we already have HTML.
         guard fetchedHTML != nil else { return }
         previewTask = Task {
             try? await Task.sleep(for: .milliseconds(250))
@@ -167,11 +146,7 @@ struct PetalBuilderView: View {
             ? String(localized: "Error.NoMatches", table: "Petal") : nil
     }
 
-    /// Runs the heuristic selector finder against the currently
-    /// cached HTML and folds its suggestions into the editable
-    /// recipe.  Preserves any fields the user has already filled
-    /// in (notably `name`, which is usually already set by the
-    /// AddFeed flow that seeds the builder with a URL).
+    /// Runs the heuristic selector finder against cached HTML and folds suggestions into the recipe.
     private func runAutoDetect() {
         guard let html = fetchedHTML else { return }
         guard let suggestion = PetalAutoDetect.detect(

--- a/SakuraRSS/Views/Petal/PetalElementAssignMenu.swift
+++ b/SakuraRSS/Views/Petal/PetalElementAssignMenu.swift
@@ -1,10 +1,6 @@
 import SwiftUI
 
-/// Replacement for the old chip row - a single "Assign to…" button
-/// that expands into a menu listing every recipe field the picked
-/// element can be bound to.  Rows are checkmarked when the currently
-/// picked selector already populates that field, and rows that are
-/// filled with a different selector show it as secondary text.
+/// "Assign to…" menu binding the picked element's selector to a recipe field.
 struct PetalElementAssignMenu: View {
 
     @Binding var recipe: PetalRecipe

--- a/SakuraRSS/Views/Petal/PetalElementBreadcrumb.swift
+++ b/SakuraRSS/Views/Petal/PetalElementBreadcrumb.swift
@@ -1,20 +1,14 @@
 import SwiftUI
 
-/// Horizontal breadcrumb trail showing the ancestor chain from the
-/// document root down to the currently-selected element, with a
-/// trailing drill-in control that exposes the selected element's
-/// direct visible children as menu items.
-///
-/// Tapping an ancestor segment drills *out* (selects that ancestor);
-/// picking a child from the trailing menu drills *in*.
+/// Breadcrumb trail for the element picker with drill-in child menu.
 struct PetalElementBreadcrumb: View {
 
     typealias Info = PetalElementPickerWebView.ElementInfo
 
-    let ancestors: [Info]           // immediate parent first
+    let ancestors: [Info]
     let selected: Info
     let children: [Info]
-    let onSelectAncestor: (Int) -> Void   // levels up (1 = parent)
+    let onSelectAncestor: (Int) -> Void
     let onSelectChild: (Int) -> Void
 
     var body: some View {
@@ -84,7 +78,7 @@ struct PetalElementBreadcrumb: View {
     }
 
     private var orderedAncestors: [Info] {
-        Array(ancestors.reversed())   // outermost first
+        Array(ancestors.reversed())
     }
 
     @ViewBuilder

--- a/SakuraRSS/Views/Petal/PetalElementPickerBottomBar.swift
+++ b/SakuraRSS/Views/Petal/PetalElementPickerBottomBar.swift
@@ -1,9 +1,6 @@
 import SwiftUI
 
-/// Picker chrome pinned to the bottom of the sheet:
-/// breadcrumb trail on top, picked-element summary + "Assign to…"
-/// menu on the bottom.  Shows a placeholder until the user taps
-/// an element in the web view.
+/// Bottom bar with breadcrumb trail and picked-element assign menu.
 struct PetalElementPickerBottomBar: View {
 
     @Binding var recipe: PetalRecipe

--- a/SakuraRSS/Views/Petal/PetalElementPickerController.swift
+++ b/SakuraRSS/Views/Petal/PetalElementPickerController.swift
@@ -1,24 +1,17 @@
 import Observation
 import WebKit
 
-/// Bridges Swift → JS calls so the breadcrumb can drive the
-/// in-page selection (drilling up to an ancestor or into a
-/// direct child of the currently-selected element).
+/// Bridges Swift calls into JS so the breadcrumb can drive in-page selection.
 @MainActor
 @Observable
 final class PetalElementPickerController {
 
     weak var webView: WKWebView?
 
-    /// Selects the ancestor `levelsUp` steps above the current
-    /// selection.  `1` is the immediate parent, `2` the
-    /// grandparent, and so on.
     func selectAncestor(levelsUp: Int) {
         webView?.evaluateJavaScript("window.petalSelectAncestor(\(levelsUp))")
     }
 
-    /// Selects the direct child of the current selection at the
-    /// given index in the visible-child list sent to Swift.
     func selectChild(atIndex index: Int) {
         webView?.evaluateJavaScript("window.petalSelectChild(\(index))")
     }

--- a/SakuraRSS/Views/Petal/PetalElementPickerView.swift
+++ b/SakuraRSS/Views/Petal/PetalElementPickerView.swift
@@ -1,10 +1,6 @@
 import SwiftUI
 
-/// Full-screen sheet that renders fetched HTML in a web view and
-/// lets the user tap elements, navigate the DOM via a breadcrumb,
-/// and assign the current selection to a recipe field via the
-/// "Assign to…" menu.  Recipe mutations flow through the binding
-/// so the builder sees them as soon as the sheet is dismissed.
+/// Element-picker sheet for assigning DOM selections to recipe fields.
 struct PetalElementPickerView: View {
 
     @Binding var recipe: PetalRecipe

--- a/SakuraRSS/Views/Petal/PetalElementPickerWebView+JS.swift
+++ b/SakuraRSS/Views/Petal/PetalElementPickerWebView+JS.swift
@@ -1,10 +1,6 @@
 extension PetalElementPickerWebView {
 
-    /// JavaScript injected at document-end.  Adds a touch-highlight,
-    /// posts the current selection (plus ancestors and visible
-    /// children) back to Swift on every tap, and exposes
-    /// `window.petalSelectAncestor` / `window.petalSelectChild` so
-    /// the breadcrumb can drive the selection from Swift.
+    /// JS that highlights tapped elements and bridges selection to Swift.
     static let injectionJS = #"""
     (function () {
       var style = document.createElement('style');

--- a/SakuraRSS/Views/Petal/PetalElementPickerWebView.swift
+++ b/SakuraRSS/Views/Petal/PetalElementPickerWebView.swift
@@ -1,13 +1,7 @@
 import SwiftUI
 import WebKit
 
-/// `UIViewRepresentable` wrapping a `WKWebView` that injects a
-/// tap-to-identify overlay into fetched HTML.
-///
-/// Every element tap produces a `PickedElement` (the selected
-/// element plus its ancestor chain and visible direct children)
-/// sent back via `onElementPicked`.  Navigation is blocked so
-/// tapping links doesn't leave the picker.
+/// `WKWebView` with a tap-to-identify overlay; element taps emit `PickedElement`.
 struct PetalElementPickerWebView: UIViewRepresentable {
 
     let html: String
@@ -15,15 +9,12 @@ struct PetalElementPickerWebView: UIViewRepresentable {
     let controller: PetalElementPickerController
     let onElementPicked: (PickedElement) -> Void
 
-    /// A single element's summary (selector + preview text + tag).
     struct ElementInfo: Hashable, Sendable {
         let selector: String
         let text: String
         let tag: String
     }
 
-    /// The full payload the JS overlay sends back when a tap or
-    /// breadcrumb/child navigation changes the selection.
     struct PickedElement {
         let selected: ElementInfo
         /// Immediate parent first, root-most ancestor last.

--- a/SakuraRSS/Views/Petal/PetalRecipeField.swift
+++ b/SakuraRSS/Views/Petal/PetalRecipeField.swift
@@ -1,7 +1,6 @@
 import Foundation
 
-/// Every recipe slot the element picker knows how to assign a
-/// selector to.
+/// Recipe slots the element picker can assign a selector to.
 enum PetalRecipeField: CaseIterable {
     case item, title, link, date, author, summary, image
 

--- a/SakuraRSS/Views/Petal/PetalSelectorField.swift
+++ b/SakuraRSS/Views/Petal/PetalSelectorField.swift
@@ -1,12 +1,6 @@
 import SwiftUI
 
-/// A tiny labelled monospaced text field used by the selectors
-/// section of the Web Feed builder.
-///
-/// Extracted so each selector row is one call to this view rather
-/// than three lines of layout repeated six times.  Keeping it
-/// separate also makes it easy to tweak the field styling (font,
-/// autocap, autocorrect) in one place later.
+/// Labelled monospaced text field used by the Web Feed builder's selector rows.
 struct PetalSelectorField: View {
 
     let label: String
@@ -28,11 +22,7 @@ struct PetalSelectorField: View {
 
 extension PetalSelectorField {
 
-    /// Convenience initializer for recipe fields that are
-    /// `String?`.  The builder treats an empty string as "no
-    /// selector" so the engine falls back to its defaults; this
-    /// initializer folds that convention into a single
-    /// construction call.
+    /// Convenience initializer for optional fields; empty string is treated as nil.
     init(
         label: String,
         optional binding: Binding<String?>,

--- a/SakuraRSS/Views/Search/DiscoverView.swift
+++ b/SakuraRSS/Views/Search/DiscoverView.swift
@@ -208,7 +208,6 @@ struct DiscoverView: View {
                 topics = topTopics
                 people = topPeople
 
-                // Build entity sections from top 3 of each
                 var sectionItems: [DiscoverEntitySection] = []
                 for topic in topTopics.prefix(3) {
                     let articles = (try? db.articlesForEntity(
@@ -239,7 +238,6 @@ struct DiscoverView: View {
                     }
                 }
 
-                // Daily-deterministic shuffle
                 sectionItems = Self.dailyShuffled(sectionItems)
                 sections = sectionItems
             }
@@ -277,7 +275,6 @@ struct DiscoverEntitySection: Identifiable {
     var id: String { name }
 }
 
-/// A wrapping horizontal layout that flows items to the next line when they exceed the available width.
 private struct FlowLayout: Layout {
 
     var spacing: CGFloat
@@ -322,7 +319,7 @@ private struct FlowLayout: Layout {
     }
 }
 
-/// A simple seeded random number generator for deterministic daily shuffles.
+/// Seeded RNG for deterministic daily shuffles.
 private nonisolated struct DailyRNG: RandomNumberGenerator {
     private var state: UInt64
 
@@ -331,7 +328,6 @@ private nonisolated struct DailyRNG: RandomNumberGenerator {
     }
 
     mutating func next() -> UInt64 {
-        // xorshift64
         state ^= state << 13
         state ^= state >> 7
         state ^= state << 17

--- a/SakuraRSS/Views/Shared/ArXivPDFViewerView.swift
+++ b/SakuraRSS/Views/Shared/ArXivPDFViewerView.swift
@@ -1,17 +1,14 @@
 import PDFKit
 import SwiftUI
 
-/// Identifier passed to `.navigationDestination(item:)` for the arXiv PDF
-/// viewer. Using a dedicated type (rather than `URL`) avoids colliding with
-/// the article detail view's other URL-typed navigation destinations.
+/// Navigation identifier for the arXiv PDF viewer.
 struct ArXivPDFReference: Identifiable, Hashable {
     let url: URL
     let title: String
     var id: URL { url }
 }
 
-/// In-app PDF viewer used for arXiv papers. Downloads the PDF with the
-/// standard Sakura user agent and renders it with PDFKit.
+/// In-app PDF viewer for arXiv papers.
 struct ArXivPDFViewerView: View {
 
     let url: URL

--- a/SakuraRSS/Views/Shared/Article Detail/ArticleDetailView+Extraction.swift
+++ b/SakuraRSS/Views/Shared/Article Detail/ArticleDetailView+Extraction.swift
@@ -106,11 +106,7 @@ extension ArticleDetailView {
             break
         }
 
-        // Automatic: use domain lists to determine the best extraction method
-
-        // For arXiv abstract pages, the RSS feed already contains the paper's
-        // abstract, and the arxiv.org abstract page itself is mostly metadata
-        // we don't want to render. Prefer the feed summary directly.
+        // arxiv.org abstract pages are mostly metadata; prefer the feed summary directly.
         if let url = URL(string: article.url), ArXivHelper.isArXivAbstractURL(url) {
             if let summary = article.summary, !summary.isEmpty {
                 extractedText = summary
@@ -119,7 +115,6 @@ extension ArticleDetailView {
             return
         }
 
-        // For X post URLs (from non-X feeds), use the X API to fetch the tweet directly
         let isFromXFeed = feedManager.feed(forArticle: article)?.isXFeed == true
         if article.isXPostURL, !isFromXFeed,
            UserDefaults.standard.bool(forKey: "Labs.XProfileFeeds"),
@@ -138,13 +133,11 @@ extension ArticleDetailView {
                 }
                 return
             }
-            // If X API fetch failed, fall through to normal extraction
             #if DEBUG
             debugPrint("[Extract] X post fetch failed, falling through: \(article.url)")
             #endif
         }
 
-        // For ExtractText domains (e.g. apple.com), use WebView-based extraction
         if let url = URL(string: article.url), ExtractTextDomains.shouldExtractText(for: url) {
             let text = await extractViaWebView(from: url, excludeTitle: articleTitle)
             extractedText = text
@@ -167,9 +160,7 @@ extension ArticleDetailView {
                                                     excludeTitle: articleTitle)
             if let text, !text.isEmpty {
                 let paragraphCount = text.components(separatedBy: "\n\n").count
-                // If a long text has very few paragraphs, the feed content likely
-                // lacks proper HTML structure. Fall through to URL fetch for a
-                // better extraction with the original page's <p> tags.
+                // If long text has very few paragraphs, feed HTML is likely malformed; fall through.
                 let looksWellStructured = paragraphCount > 1 || text.count < 500
                 #if DEBUG
                 debugPrint("[Extract] Feed content: \(paragraphCount) paragraphs, \(text.count) chars, wellStructured=\(looksWellStructured): \(article.url)")
@@ -216,14 +207,10 @@ extension ArticleDetailView {
                 result = ExtractionResult()
             }
 
-            // Auto-escalate when the plain HTTP extraction is too thin AND
-            // the HTML looks JS-rendered — Substack, React/Next.js, etc.
             let weak = ArticleExtractor.isWeakExtraction(result.text)
             let jsRendered = rawHTML.map(ArticleExtractor.looksJSRendered) ?? true
 
-            // Retry against the AMP variant of the page when the canonical
-            // response was too short.  AMP markup extracts more reliably
-            // than generic JS-rendered pages.
+            // AMP markup extracts more reliably than generic JS-rendered pages.
             if weak && !result.paywalled, let rawHTML,
                let ampURL = ArticleExtractor.amphtmlURL(from: rawHTML, baseURL: url) {
                 let (ampHTML, ampResponse) = await fetchHTML(from: ampURL)
@@ -283,8 +270,7 @@ extension ArticleDetailView {
         }
     }
 
-    /// Applies extracted metadata to `@State` fields without clobbering
-    /// values already supplied by the feed.
+    /// Applies extracted metadata without clobbering values already supplied by the feed.
     func applyMetadata(_ metadata: ArticleMetadata) {
         if article.author == nil, let author = metadata.author {
             extractedAuthor = author
@@ -297,9 +283,7 @@ extension ArticleDetailView {
         }
     }
 
-    /// Raw HTTP fetch used by the automatic extraction path.  Returns the
-    /// decoded HTML string alongside the URL response for header-based
-    /// signals (paywall status codes, encoding detection, …).
+    /// Raw HTTP fetch returning decoded HTML and the response for header signals.
     func fetchHTML(from url: URL) async -> (String?, URLResponse?) {
         do {
             let request = URLRequest.sakura(url: url)
@@ -310,7 +294,6 @@ extension ArticleDetailView {
         }
     }
 
-    /// Simple GET + HTML parse (no JavaScript rendering).
     private func fetchText(from url: URL, excludeTitle: String?) async -> String? {
         do {
             let (data, response) = try await URLSession.shared.data(
@@ -323,19 +306,16 @@ extension ArticleDetailView {
         }
     }
 
-    /// WebView-based extraction (loads page with JavaScript like Apple Newsroom).
     private func extractViaWebView(from url: URL, excludeTitle: String?) async -> String? {
         let extractor = WebViewExtractor()
         return await extractor.extractText(from: url)
     }
 
     func refreshArticleContent() async {
-        // Show spinner immediately to avoid flashing article.summary
-        // while extraction is pending
+        // Show spinner immediately to avoid flashing article.summary while extraction is pending.
         isExtracting = true
         defer { isExtracting = false }
 
-        // Clear cached images for this article
         if let imageURL = article.imageURL {
             try? DatabaseManager.shared.clearCachedImageData(for: imageURL)
         }
@@ -363,18 +343,13 @@ extension ArticleDetailView {
         hasCachedSummary = false
         showingSummary = false
 
-        // Keep the previous text so we can fall back if re-extraction fails
         let previousText = extractedText
         extractedText = nil
         await extractArticleContent()
-        // Re-assert over `extractArticleContent`'s own `defer` so the
-        // spinner stays visible through the fallback restoration below.
+        // Re-assert over `extractArticleContent`'s `defer` so spinner stays visible through fallback.
         isExtracting = true
 
-        // If re-extraction produced nothing, restore the previous content
-        // and re-cache it so subsequent loads still work.
-        // Only restore if the previous content was well-structured;
-        // don't re-cache a wall of text with no paragraph breaks.
+        // Only restore previous content if it was well-structured.
         if extractedText == nil, let previousText {
             let prevParagraphs = previousText.components(separatedBy: "\n\n").count
             if prevParagraphs > 1 || previousText.count < 500 {

--- a/SakuraRSS/Views/Shared/Article Detail/ArticleDetailView+SimilarContent.swift
+++ b/SakuraRSS/Views/Shared/Article Detail/ArticleDetailView+SimilarContent.swift
@@ -123,11 +123,7 @@ extension ArticleDetailView {
         }
     }
 
-    /// Kicks off insight loading (similar articles, topics, people) in
-    /// the background so it never blocks the UI thread. The SQLite
-    /// reads and NLP passes live inside `nonisolated static` helpers
-    /// that run on the generic executor (off MainActor); only the
-    /// final @State writes land back on MainActor after the awaits.
+    /// Kicks off similar/topic/people loading off MainActor.
     func loadInsightsInBackground() {
         guard contentInsightsEnabled else { return }
         let currentArticle = article
@@ -153,8 +149,7 @@ extension ArticleDetailView {
         }
     }
 
-    /// Runs entity extraction entirely off the main actor. Callable from
-    /// a detached task because it takes only Sendable inputs.
+    /// Runs entity extraction off the main actor using Sendable inputs.
     fileprivate nonisolated static func computeArticleEntities(
         articleID: Int64,
         articleTitle: String,
@@ -162,7 +157,6 @@ extension ArticleDetailView {
     ) async -> (topics: [String], people: [String]) {
         let db = DatabaseManager.shared
         return await Task.detached(priority: .userInitiated) {
-            // Ensure entity extraction has been run for this article.
             if (try? db.isEntitiesProcessed(articleId: articleID)) != true {
                 let text = [articleTitle, articleSummary]
                     .filter { !$0.isEmpty }
@@ -199,9 +193,7 @@ extension ArticleDetailView {
         }.value
     }
 
-    /// Runs similar-article discovery entirely off the main actor. The
-    /// NLP embedding pass, SQLite reads, and cache writes all happen on
-    /// a detached utility task; favicons are fetched concurrently after.
+    /// Runs similar-article discovery off the main actor.
     fileprivate nonisolated static func computeSimilarArticles(
         currentArticle: Article,
         feedsLookup: [Int64: Feed]
@@ -212,8 +204,6 @@ extension ArticleDetailView {
             )
         }.value
 
-        // Favicons are fetched in parallel - FaviconCache.favicon(for:) is
-        // already async and safe to call concurrently.
         return await withTaskGroup(of: (Int, SimilarArticleItem).self) { group in
             for (index, match) in rawMatches.enumerated() {
                 group.addTask {
@@ -241,17 +231,13 @@ extension ArticleDetailView {
         }
     }
 
-    /// Returns match metadata ordered by hybrid similarity score. Uses the
-    /// SQLite cache when available; otherwise runs the retrieve-then-rerank
-    /// pipeline, persists the result, and marks the source article as
-    /// computed. Must be called from a detached task.
+    /// Returns match metadata ordered by hybrid similarity score.
     fileprivate nonisolated static func computeRawMatches(
         currentArticle: Article,
         feedsLookup: [Int64: Feed]
     ) async -> [SimilarMatchData] {
         let db = DatabaseManager.shared
 
-        // 1. Cache hit path - instant return, no NLP, no window scan.
         if (try? db.isSimilarComputed(articleId: currentArticle.id)) == true {
             if let cached = try? db.cachedSimilarArticleIDs(forSourceID: currentArticle.id),
                !cached.isEmpty {
@@ -270,15 +256,10 @@ extension ArticleDetailView {
                 }
                 return results
             }
-            // Empty cache → computed earlier, no matches, skip recompute.
+            // Empty cache means computed earlier with no matches; skip recompute.
             return []
         }
 
-        // 2. Cache miss - run the hybrid ranker.
-        //
-        // Retrieval: widen the candidate window to ±7 days / up to 82
-        // articles so the reranker gets real recall instead of a narrow
-        // 48h slice.
         guard let candidates = try? db.articlesInWindow(
             around: currentArticle, hours: 168, limit: 82
         ), !candidates.isEmpty else {
@@ -286,10 +267,6 @@ extension ArticleDetailView {
             return []
         }
 
-        // Ensure the source article has entities extracted. The background
-        // coordinator normally handles this during feed refresh, but a
-        // freshly opened brand-new article may not have been processed yet.
-        // Same pattern as `computeArticleEntities` above.
         if (try? db.isEntitiesProcessed(articleId: currentArticle.id)) != true {
             let sourceText = [currentArticle.title, currentArticle.summary ?? ""]
                 .filter { !$0.isEmpty }
@@ -304,7 +281,6 @@ extension ArticleDetailView {
             try? db.markEntitiesProcessed(articleId: currentArticle.id)
         }
 
-        // Batch-load source + candidate entities in a single query.
         let sourceEntities: Set<String> = (try? db.entities(forArticleID: currentArticle.id))
             .map { Set($0.map { $0.name.lowercased() }) } ?? []
         let candidateIDs = candidates.map { $0.id }
@@ -321,8 +297,7 @@ extension ArticleDetailView {
             minimumScore: 0.35
         )
 
-        // Persist `1 - score` as the distance column so lower-is-better and
-        // rank-ordering stay consistent with the existing cache reader.
+        // Persist `1 - score` as distance so lower-is-better matches the cache reader.
         try? db.cacheSimilarArticles(
             similar.map { (id: $0.articleID, distance: 1.0 - $0.score) },
             forSourceID: currentArticle.id
@@ -345,8 +320,6 @@ extension ArticleDetailView {
     }
 }
 
-// Intermediate type so the detached task can return a single value type
-// without tripping the large-tuple lint rule.
 private struct SimilarMatchData: Sendable {
     let article: Article
     let feedName: String
@@ -362,7 +335,7 @@ private struct SimilarArticleCard: View {
     let item: SimilarArticleItem
 
     private let cardWidth: CGFloat = 240
-    private let imageHeight: CGFloat = 135  // 16:9 widescreen
+    private let imageHeight: CGFloat = 135
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {

--- a/SakuraRSS/Views/Shared/Article Detail/ArticleDetailView+Toolbar.swift
+++ b/SakuraRSS/Views/Shared/Article Detail/ArticleDetailView+Toolbar.swift
@@ -49,8 +49,6 @@ extension ArticleDetailView {
            !cached.isEmpty {
             hasCachedSummary = true
         }
-        // Insights (similar content, topics, people) load in the background
-        // so they never block the article body from rendering.
         loadInsightsInBackground()
     }
 

--- a/SakuraRSS/Views/Shared/Article Detail/ArticleDetailView+Translation.swift
+++ b/SakuraRSS/Views/Shared/Article Detail/ArticleDetailView+Translation.swift
@@ -23,9 +23,7 @@ extension ArticleDetailView {
                 try? DatabaseManager.shared.cacheTranslatedSummary(
                     response.targetText, for: article.id
                 )
-            } catch {
-                // Translation failed; user can retry
-            }
+            } catch { }
         } else {
             let source = extractedText ?? article.summary ?? ""
             guard !ContentBlock.plainText(from: source).isEmpty else { return }
@@ -40,9 +38,7 @@ extension ArticleDetailView {
                 try? DatabaseManager.shared.cacheArticleTranslation(
                     title: result.title, text: result.text, for: article.id
                 )
-            } catch {
-                // Translation failed; user can retry
-            }
+            } catch { }
         }
     }
 }

--- a/SakuraRSS/Views/Shared/Article Detail/ArticleDetailView+Translation.swift
+++ b/SakuraRSS/Views/Shared/Article Detail/ArticleDetailView+Translation.swift
@@ -23,7 +23,8 @@ extension ArticleDetailView {
                 try? DatabaseManager.shared.cacheTranslatedSummary(
                     response.targetText, for: article.id
                 )
-            } catch { }
+            } catch {
+            }
         } else {
             let source = extractedText ?? article.summary ?? ""
             guard !ContentBlock.plainText(from: source).isEmpty else { return }
@@ -38,7 +39,8 @@ extension ArticleDetailView {
                 try? DatabaseManager.shared.cacheArticleTranslation(
                     title: result.title, text: result.text, for: article.id
                 )
-            } catch { }
+            } catch {
+            }
         }
     }
 }

--- a/SakuraRSS/Views/Shared/Article Detail/XEmbedBlockView.swift
+++ b/SakuraRSS/Views/Shared/Article Detail/XEmbedBlockView.swift
@@ -1,10 +1,6 @@
 import SwiftUI
 
-/// Inline X (Twitter) embed used when an article body contains a
-/// `{{XPOST}}<url>{{/XPOST}}` marker.  When the reader is signed in to X
-/// and the X profile feeds lab is enabled, the tweet text is fetched via
-/// the same scraper the profile-feed feature uses; otherwise the embed
-/// falls back to a tappable link card that opens the original post.
+/// Inline X embed for `{{XPOST}}` markers; fetches the tweet when signed in, else shows a link card.
 struct XEmbedBlockView: View {
 
     let url: URL

--- a/SakuraRSS/Views/Shared/Article Detail/YouTubeEmbedBlockView.swift
+++ b/SakuraRSS/Views/Shared/Article Detail/YouTubeEmbedBlockView.swift
@@ -1,9 +1,7 @@
 import SwiftUI
 import WebKit
 
-/// Inline YouTube embed used when an article body contains a
-/// `{{YOUTUBE}}<id>{{/YOUTUBE}}` marker.  Uses the same WebKit-based
-/// player as `YouTubePlayerView` but exposes only a compact control row.
+/// Inline YouTube embed for `{{YOUTUBE}}` markers with a compact control row.
 struct YouTubeEmbedBlockView: View {
 
     let videoID: String

--- a/SakuraRSS/Views/Shared/ArticleDestinationView.swift
+++ b/SakuraRSS/Views/Shared/ArticleDestinationView.swift
@@ -1,9 +1,6 @@
 import SwiftUI
 
-/// Resolves the correct detail view for a pushed `Article` navigation
-/// destination. Consolidates the podcast / YouTube / clearthis.page /
-/// default article branching so every `navigationDestination(for: Article.self)`
-/// handler behaves consistently.
+/// Resolves the correct detail view for an `Article` navigation destination.
 struct ArticleDestinationView: View {
 
     @Environment(FeedManager.self) private var feedManager

--- a/SakuraRSS/Views/Shared/ArticleLink.swift
+++ b/SakuraRSS/Views/Shared/ArticleLink.swift
@@ -1,9 +1,6 @@
 import SwiftUI
 
-/// A navigation component that routes article taps based on the per-feed open mode
-/// (in-app viewer, Safari, SVC, SVC reader mode, Clear This Page, archive.today, or YouTube app).
-/// On iPad with a split view, articles that would normally push onto a NavigationStack
-/// are instead shown in the detail column via the `iPadArticleSelection` environment binding.
+/// Routes article taps based on the per-feed open mode; iPad splits route to the detail column.
 struct ArticleLink<Label: View>: View {
 
     @Environment(FeedManager.self) var feedManager
@@ -35,8 +32,6 @@ struct ArticleLink<Label: View>: View {
         feedManager.feed(forArticle: article)?.isInstagramFeed == true
     }
 
-    /// Whether this article should navigate to the iPad detail column
-    /// instead of pushing onto the NavigationStack.
     private var usesIPadDetailColumn: Bool {
         iPadArticleSelection != nil
     }

--- a/SakuraRSS/Views/Shared/Articles/ArticlesView.swift
+++ b/SakuraRSS/Views/Shared/Articles/ArticlesView.swift
@@ -210,15 +210,13 @@ struct ArticlesView: View {
             }
         }
         .onChange(of: articles) { oldValue, newValue in
-            // Stage any articles whose read state flipped while the view was
-            // mounted so they don't vanish from under the user's finger.
+            // Stage flipped-read articles so they don't vanish under the user's finger.
             let previouslyRead = Set(oldValue.filter { $0.isRead }.map(\.id))
             let currentlyRead = Set(newValue.filter { $0.isRead }.map(\.id))
             let newlyRead = currentlyRead.subtracting(previouslyRead)
             if !newlyRead.isEmpty {
                 stagedReadIDs.formUnion(newlyRead)
             }
-            // Drop staged IDs that have been removed from the article list.
             let currentIDs = Set(newValue.map(\.id))
             stagedReadIDs.formIntersection(currentIDs)
         }
@@ -286,8 +284,7 @@ struct ArticlesView: View {
         }
     }
 
-    /// Falls back to inbox if the selected style requires images but none are available,
-    /// or if podcast style is selected for a non-podcast feed.
+    /// Falls back to inbox when the chosen style isn't valid for the current feed.
     private var effectiveDisplayStyle: FeedDisplayStyle {
         if !hasImages && displayStyle.requiresImages {
             return .inbox

--- a/SakuraRSS/Views/Shared/BookmarksSectionTip.swift
+++ b/SakuraRSS/Views/Shared/BookmarksSectionTip.swift
@@ -1,7 +1,6 @@
 import TipKit
 
-/// Tip shown once to point users at the new Bookmarks entry inside the
-/// Home section picker.  Only displays when at least one bookmark exists.
+/// One-time tip pointing to the Bookmarks entry when at least one bookmark exists.
 struct BookmarksSectionTip: Tip {
 
     @Parameter

--- a/SakuraRSS/Views/Shared/CachedAsyncImage.swift
+++ b/SakuraRSS/Views/Shared/CachedAsyncImage.swift
@@ -2,12 +2,7 @@ import SwiftUI
 
 // MARK: - In-Memory Image Cache
 
-/// Shared memory cache for decoded UIImages, avoiding repeated SQLite
-/// lookups and Data → UIImage decoding during scroll recycling.
-/// NSCache is already thread-safe, so synchronous access from any
-/// context is the fast path — no actor hop per read.  Marked
-/// `nonisolated` because the app target otherwise infers `@MainActor`
-/// on UIKit-using types.
+/// Shared memory cache for decoded UIImages.
 nonisolated final class ImageMemoryCache: @unchecked Sendable {
 
     static let shared = ImageMemoryCache()
@@ -29,10 +24,6 @@ nonisolated final class ImageMemoryCache: @unchecked Sendable {
     }
 }
 
-/// Holds static state for `CachedAsyncImage`.  Kept in a separate
-/// non-generic type because Swift forbids stored static properties
-/// inside generic types.  `nonisolated` so the nonisolated image
-/// loader can read it without hopping to the main actor.
 private enum CachedAsyncImageConfig {
     nonisolated static let maxDisplayPixelSize: CGFloat = 2000
 }
@@ -57,9 +48,6 @@ struct CachedAsyncImage<Placeholder: View>: View {
         self.alignment = alignment
         self.onImageLoaded = onImageLoaded
         self.placeholder = placeholder
-        // Synchronous memory-cache check so the first render paints the
-        // cached bitmap directly — no placeholder flash while the async
-        // loader spins up during fast scroll recycling.
         let initial: UIImage? = {
             guard let url, !url.absoluteString.hasPrefix("data:") else { return nil }
             return ImageMemoryCache.shared.image(forKey: url.absoluteString)
@@ -88,9 +76,6 @@ struct CachedAsyncImage<Placeholder: View>: View {
                 return
             }
             if let image {
-                // Memory-cache hit from the synchronous init path — still
-                // notify the caller once so aspect-ratio-dependent layout
-                // can settle on the first appearance.
                 if !reportedCachedHit {
                     reportedCachedHit = true
                     onImageLoaded?(image)
@@ -108,14 +93,7 @@ struct CachedAsyncImage<Placeholder: View>: View {
         }
     }
 
-    /// Largest dimension we ever display.  Article-detail hero images
-    /// span the whole screen on iPad — 2000 px covers 2× iPad screen
-    /// width, which looks identical to a full-res image at normal
-    /// viewing distance.  Thumbnails in feed lists are far smaller
-    /// and get downsampled further by SwiftUI on render.  The win is
-    /// that a 4000×3000 photo no longer costs 48 MB of RAM per view.
-    /// Computed property because generic types can't hold stored
-    /// static state; the underlying constant lives on the enum above.
+    /// Largest dimension ever displayed; originals are downsampled to this size.
     nonisolated static var maxDisplayPixelSize: CGFloat {
         CachedAsyncImageConfig.maxDisplayPixelSize
     }
@@ -123,13 +101,10 @@ struct CachedAsyncImage<Placeholder: View>: View {
     nonisolated static func loadImage(from url: URL) async -> UIImage? {
         let urlString = url.absoluteString
 
-        // Skip data: URIs - they are typically inline SVG placeholders
-        // (e.g. Next.js blur-up shims) that contain no useful image content.
         if urlString.hasPrefix("data:") {
             return nil
         }
 
-        // 1. In-memory cache (instant, no decoding, no actor hop)
         let memoryCache = ImageMemoryCache.shared
         if let cached = memoryCache.image(forKey: urlString) {
             return cached
@@ -137,9 +112,6 @@ struct CachedAsyncImage<Placeholder: View>: View {
 
         let database = DatabaseManager.shared
 
-        // 2. Database cache (requires Data → UIImage decode via ImageIO
-        // downsample so the memory cost of cached thumbnails stays
-        // bounded even for originally-huge photos).
         if let cachedData = try? database.cachedImageData(for: urlString),
            let cachedImage = ImageDownsampler.downsample(
                cachedData, maxPixelSize: maxDisplayPixelSize
@@ -155,9 +127,6 @@ struct CachedAsyncImage<Placeholder: View>: View {
         debugPrint("[Image] Cache miss, downloading \(urlString)")
         #endif
 
-        // 3. Network download — persist the original bytes to SQLite
-        //    (so a bigger display context can resample if ever needed)
-        //    but hold only a downsampled UIImage in memory.
         do {
             let (data, response) = try await URLSession.shared.data(for: .sakura(url: url))
             let statusCode = (response as? HTTPURLResponse)?.statusCode
@@ -173,12 +142,6 @@ struct CachedAsyncImage<Placeholder: View>: View {
                 #endif
                 return nil
             }
-            // Skip the SQLite write if a concurrent loader has already
-            // populated the memory cache for this URL.  That task either
-            // already wrote the DB row or is about to, so a second write
-            // is wasted I/O on the write path.  The memory-cache check
-            // is what matters - the DB copy fills itself in on any later
-            // miss if the memory cache gets evicted.
             if memoryCache.image(forKey: urlString) == nil {
                 try? database.cacheImageData(data, for: urlString)
             }

--- a/SakuraRSS/Views/Shared/ClearThisPageView.swift
+++ b/SakuraRSS/Views/Shared/ClearThisPageView.swift
@@ -1,9 +1,7 @@
 import SwiftUI
 import WebKit
 
-/// Presents an article URL through the clearthis.page reader service in an
-/// embedded WebView. The service strips ads and clutter and reformats the
-/// page for distraction-free reading.
+/// Presents an article URL through clearthis.page in an embedded WebView.
 struct ClearThisPageView: View {
 
     @Environment(\.colorScheme) private var colorScheme
@@ -44,9 +42,6 @@ struct ClearThisPageView: View {
     }
 }
 
-/// Builds a clearthis.page URL that wraps the supplied article URL.
-/// Uses `URLComponents` so the article URL is properly percent-encoded
-/// without manual string interpolation.
 private func clearThisPageURL(for articleURL: URL) -> URL? {
     var components = URLComponents()
     components.scheme = "https"
@@ -58,14 +53,7 @@ private func clearThisPageURL(for articleURL: URL) -> URL? {
     return components.url
 }
 
-/// User script injected at document start. clearthis.page uses
-/// `dark-mode-switch.min.js`, which reads `localStorage['darkSwitch']`
-/// to decide whether to add `data-theme="dark"` to the `<body>` and check
-/// the `#darkSwitch` checkbox. This script seeds that storage value from
-/// the system color scheme (`prefers-color-scheme`), reapplies the body
-/// attribute itself for safety, hides the manual `.topbar` toggle since
-/// theme selection is automatic, and stays in sync if the system
-/// appearance changes while the WebView is open.
+/// Seeds `localStorage['darkSwitch']` from the system color scheme and keeps it in sync.
 private let clearThisPageThemeScript = """
 (function() {
   function isDark() {
@@ -102,8 +90,6 @@ private let clearThisPageThemeScript = """
     applyBodyAttribute();
     hideToggle();
   }
-  // Seed storage immediately so the page's own dark-mode-switch script
-  // picks up the right value as soon as it runs.
   syncStorage();
   if (document.readyState !== 'loading') {
     applyAll();
@@ -111,7 +97,6 @@ private let clearThisPageThemeScript = """
     document.addEventListener('DOMContentLoaded', applyAll);
   }
   window.addEventListener('load', applyAll);
-  // React to system appearance changes while the WebView is open.
   if (window.matchMedia) {
     var mq = window.matchMedia('(prefers-color-scheme: dark)');
     var listener = function() { applyAll(); };
@@ -181,9 +166,7 @@ private struct ClearThisPageWebView: UIViewRepresentable {
             _isLoading = isLoading
         }
 
-        /// Only allow HTTPS navigations. Cancels cleartext HTTP, app-scheme
-        /// links, and other potentially unsafe URL schemes that could be
-        /// triggered from the rendered page.
+        /// Only allows HTTPS navigations.
         func webView(
             _: WKWebView,
             decidePolicyFor navigationAction: WKNavigationAction,

--- a/SakuraRSS/Views/Shared/CodeBlockView.swift
+++ b/SakuraRSS/Views/Shared/CodeBlockView.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 
-/// A styled view for displaying code blocks extracted from `<pre>` elements.
-/// Shows monospaced text with a tinted background and horizontal scrolling for long lines.
+/// Monospaced block for code extracted from `<pre>` elements.
 struct CodeBlockView: View {
 
     let code: String

--- a/SakuraRSS/Views/Shared/FaviconImage.swift
+++ b/SakuraRSS/Views/Shared/FaviconImage.swift
@@ -10,13 +10,10 @@ struct FaviconImage: View {
     let skipInset: Bool
 
     var isNonSquare: Bool { !image.isSquare }
-    /// Completely filled squares are treated as edge-to-edge icons and skip every automatic inset.
     var isFilledSquare: Bool { image.isFilledSquare }
     var showInset: Bool { !skipInset && isCircle && !image.isCircular && !isFilledSquare }
     var needsWhiteBackground: Bool { !skipInset && image.isDark && !isFilledSquare }
     var isNearBlack: Bool { image.isNearBlack && !isFilledSquare }
-
-    /// In round-rect mode, a transparent favicon should be inset with a tinted background.
     var showRoundRectInset: Bool { !skipInset && !isCircle && image.isSquare && image.hasTransparentPixels }
 
     var iconSize: CGFloat {
@@ -75,30 +72,13 @@ struct FaviconImage: View {
 }
 
 // MARK: - Derived Metrics (memoized)
-//
-// Every pixel-sampling routine below used to run on every SwiftUI body
-// evaluation - i.e. once per favicon, per list row, per scroll tick.  The
-// FaviconDerivedMetrics struct captures the raw results of each sampling
-// pass once and is attached to the UIImage via an associated object, so
-// the hot path becomes a dictionary read.  FaviconCache also persists
-// the struct as a small JSON sidecar next to the cached PNG, so newly
-// launched sessions can skip the sampling entirely when the favicon
-// has been seen before.
 
 nonisolated struct FaviconDerivedMetrics: Codable, Sendable {
-    /// Twelve corner alpha samples (3 per corner) from a 32×32 downscaled
-    /// version of the image.
     let cornerAlphas: [UInt8]
-    /// Centre-pixel alpha from the same downscaled sample.
     let centerAlpha: UInt8
-    /// True when the image was too small (<8px) to corner-sample reliably.
     let cornerSampleUnavailable: Bool
-    /// Average RGB of every opaque pixel (16×16 sample), or `nil` when the
-    /// image has no opaque pixels.
     let averageColor: [Double]?
-    /// Average relative luminance (ITU-R BT.709) across opaque pixels.
     let averageLuminance: Double
-    /// True when virtually every opaque pixel is near-black.
     let isNearBlack: Bool
 }
 
@@ -111,7 +91,6 @@ private nonisolated(unsafe) var faviconDerivedMetricsKey: UInt8 = 0
 
 extension UIImage {
 
-    /// In-memory memoized metrics attached to this UIImage instance.
     nonisolated var faviconDerivedMetrics: FaviconDerivedMetrics? {
         get {
             (objc_getAssociatedObject(self, &faviconDerivedMetricsKey) as? FaviconDerivedMetricsBox)?.metrics
@@ -127,7 +106,6 @@ extension UIImage {
         }
     }
 
-    /// Returns the cached metrics, computing and attaching them on first call.
     @discardableResult
     nonisolated func ensureFaviconDerivedMetrics() -> FaviconDerivedMetrics {
         if let existing = faviconDerivedMetrics { return existing }
@@ -152,13 +130,11 @@ extension UIImage {
 
 extension UIImage {
 
-    /// Returns `true` when the image has equal width and height.
     var isSquare: Bool {
         guard let cgImage = cgImage else { return true }
         return cgImage.width == cgImage.height
     }
 
-    /// Samples corner and center pixel alpha values from a downscaled version of the image.
     fileprivate nonisolated func _rawSampleCornerAlphas() -> (corners: [UInt8], centerAlpha: UInt8)? {
         guard let cgImage = cgImage else { return nil }
         let width = cgImage.width
@@ -199,16 +175,14 @@ extension UIImage {
         return (corners, centerAlpha)
     }
 
-    /// Returns `true` when the image corners are transparent and the centre is opaque,
-    /// indicating the favicon is already circular (or rounded) and needs no inset treatment.
+    /// True when corners are transparent and centre is opaque (already circular/rounded).
     var isCircular: Bool {
         let metrics = ensureFaviconDerivedMetrics()
         guard !metrics.cornerSampleUnavailable else { return false }
         return metrics.cornerAlphas.allSatisfy { $0 <= 25 } && metrics.centerAlpha >= 200
     }
 
-    /// Returns `true` when all corners are opaque, meaning the image completely fills
-    /// the square and can be clipped to a circle at full size without needing an inset.
+    /// True when all corners are opaque; the image fills the square edge-to-edge.
     var isFilledSquare: Bool {
         let metrics = ensureFaviconDerivedMetrics()
         guard !metrics.cornerSampleUnavailable else { return false }
@@ -223,12 +197,10 @@ extension UIImage {
         ensureFaviconDerivedMetrics().averageLuminance < 0.3
     }
 
-    /// Returns `true` when the image contains any transparent pixels.
     var hasTransparentPixels: Bool {
         !isFilledSquare
     }
 
-    /// Computes the average colour of all opaque pixels as a SwiftUI `Color`.
     var averageColor: Color {
         guard let rgb = ensureFaviconDerivedMetrics().averageColor, rgb.count >= 3 else {
             return .gray
@@ -236,7 +208,6 @@ extension UIImage {
         return Color(red: rgb[0], green: rgb[1], blue: rgb[2])
     }
 
-    /// Raw 16×16 averaged RGB sample of opaque pixels.
     fileprivate nonisolated func _rawAverageColorComponents() -> (red: CGFloat, green: CGFloat, blue: CGFloat)? {
         guard let cgImage = cgImage else { return nil }
 
@@ -275,7 +246,6 @@ extension UIImage {
         return (totalR / opaqueCount, totalG / opaqueCount, totalB / opaqueCount)
     }
 
-    /// Returns an RGB tuple of the average colour of all opaque pixels.
     var averageColorComponents: (red: CGFloat, green: CGFloat, blue: CGFloat)? {
         guard let rgb = ensureFaviconDerivedMetrics().averageColor, rgb.count >= 3 else {
             return nil
@@ -283,15 +253,13 @@ extension UIImage {
         return (CGFloat(rgb[0]), CGFloat(rgb[1]), CGFloat(rgb[2]))
     }
 
-    /// Returns a background colour derived from the favicon's average colour,
-    /// lightened in light mode or darkened in dark mode, suitable for card backgrounds.
+    /// Background colour derived from the favicon's average colour for card backgrounds.
     func cardBackgroundColor(isDarkMode: Bool) -> Color {
         guard let avg = averageColorComponents else {
             return isDarkMode ? Color(white: 0.15) : Color(white: 0.9)
         }
 
         if isDarkMode {
-            // Mix 65% black with 35% of the average colour for a dark tinted background
             let blend: CGFloat = 0.35
             return Color(
                 red: blend * avg.red,
@@ -299,7 +267,6 @@ extension UIImage {
                 blue: blend * avg.blue
             )
         } else {
-            // Mix 65% white with 35% of the average colour for a light tinted background
             let whiteBlend: CGFloat = 0.65
             return Color(
                 red: whiteBlend + (1 - whiteBlend) * avg.red,
@@ -309,8 +276,7 @@ extension UIImage {
         }
     }
 
-    /// A near-white tint derived from the average colour of the image,
-    /// suitable as a subtle background behind a transparent favicon.
+    /// Near-white tint derived from the average colour for backgrounds behind transparent favicons.
     var nearWhiteAverageColor: Color {
         guard let rgb = ensureFaviconDerivedMetrics().averageColor, rgb.count >= 3 else {
             return Color(.secondarySystemBackground)
@@ -319,7 +285,6 @@ extension UIImage {
         let avgG = rgb[1]
         let avgB = rgb[2]
 
-        // Mix 85% white with 15% of the average colour
         let whiteBlend: Double = 0.85
         return Color(
             red: whiteBlend + (1 - whiteBlend) * avgR,
@@ -328,8 +293,7 @@ extension UIImage {
         )
     }
 
-    /// Returns `true` when virtually all opaque pixels are near-black,
-    /// meaning the icon would be invisible on a dark background.
+    /// True when virtually all opaque pixels are near-black.
     var isNearBlack: Bool {
         ensureFaviconDerivedMetrics().isNearBlack
     }
@@ -404,7 +368,6 @@ extension UIImage {
             let green = CGFloat(pixelData[offset + 1]) / 255.0
             let blue = CGFloat(pixelData[offset + 2]) / 255.0
 
-            // Relative luminance (ITU-R BT.709)
             totalLuminance += 0.2126 * red + 0.7152 * green + 0.0722 * blue
             opaquePixelCount += 1
         }

--- a/SakuraRSS/Views/Shared/FaviconProgressBadge.swift
+++ b/SakuraRSS/Views/Shared/FaviconProgressBadge.swift
@@ -1,22 +1,9 @@
 import SwiftUI
 
-/// A small pie-shaped badge meant to be overlaid on the bottom-right
-/// corner of a feed's favicon.  Visualises the rate-limit cooldown for
-/// X and Instagram profile refreshes: the pie fills from empty to full
-/// as the 30-minute window elapses, and the badge disappears once the
-/// feed is eligible to refresh again.
-///
-/// A `TimelineView` drives the pie on a periodic schedule so it
-/// advances smoothly without relying on any external observation
-/// mechanism.
+/// Pie badge overlaid on a favicon to visualise rate-limit cooldown progress.
 struct FaviconProgressBadge: View {
 
-    /// Last successful refresh date, or `nil` for feeds that have not
-    /// yet been fetched.
     let lastFetched: Date?
-
-    /// Duration of the cooldown window.  For X and Instagram profile
-    /// feeds this is 30 minutes.
     let cooldown: TimeInterval
 
     var size: CGFloat = 12
@@ -41,8 +28,7 @@ struct FaviconProgressBadge: View {
         }
     }
 
-    /// Returns the completed fraction (0...1) of the cooldown window,
-    /// or `nil` if the feed is already eligible to refresh (pie hidden).
+    /// Returns 0...1 cooldown fraction, or `nil` if refresh is already eligible.
     private func cooldownProgress(now: Date) -> Double? {
         guard let lastFetched, cooldown > 0 else { return nil }
         let elapsed = now.timeIntervalSince(lastFetched)
@@ -51,7 +37,6 @@ struct FaviconProgressBadge: View {
     }
 }
 
-/// Filled pie slice starting at 12 o'clock and sweeping clockwise.
 struct PieSliceShape: Shape {
 
     var progress: Double

--- a/SakuraRSS/Views/Shared/Feed Display Styles/Cards/CardView.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/Cards/CardView.swift
@@ -59,10 +59,8 @@ struct CardView: View {
                         .frame(maxHeight: .infinity, alignment: .bottom)
                 }
 
-                // Swipe indicator overlays
                 swipeIndicators
 
-                // Title and subtitle
                 VStack(alignment: .leading, spacing: 8) {
                     Spacer()
 
@@ -131,11 +129,9 @@ struct CardView: View {
             ?? (isDark ? Color(white: 0.15) : Color(white: 0.9))
 
         ZStack {
-            // Solid tinted background
             Rectangle()
                 .fill(bgColor)
 
-            // Favicon displayed large and slightly rotated
             if let favicon {
                 let iconImage = Image(uiImage: favicon)
                     .resizable()
@@ -154,7 +150,6 @@ struct CardView: View {
                 .offset(y: -geometry.size.height * 0.1)
             }
 
-            // Bottom gradient for text readability
             LinearGradient(
                 colors: [bgColor.opacity(0), bgColor],
                 startPoint: .init(x: 0.5, y: 0.5),
@@ -166,7 +161,6 @@ struct CardView: View {
 
     private var swipeIndicators: some View {
         ZStack {
-            // Right swipe: mark read indicator
             swipeIndicatorOverlay(
                 label: String(localized: "Cards.MarkRead", table: "Articles"),
                 systemImage: "envelope.open.fill",
@@ -175,7 +169,6 @@ struct CardView: View {
                 opacity: offset.width > 0 ? swipeProgress : 0
             )
 
-            // Left swipe: read/watch/listen later indicator
             swipeIndicatorOverlay(
                 label: skipLocalizationLabel,
                 systemImage: "eye.slash.fill",

--- a/SakuraRSS/Views/Shared/Feed Display Styles/Cards/CardsStyleView.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/Cards/CardsStyleView.swift
@@ -7,10 +7,7 @@ struct CardsStyleView: View {
     let articles: [Article]
     var onRefresh: (() async -> Void)?
 
-    /// Snapshot of article IDs that were unread when the deck was built.
-    /// Using a snapshot prevents cards from disappearing when markRead is
-    /// called during navigation, which would remove the matched transition
-    /// source and break the zoom animation.
+    /// Snapshot of unread article IDs; prevents cards vanishing during markRead navigation.
     @State private var deckArticleIDs: Set<Int64>?
     @State private var selectedArticle: Article?
     @State private var youTubeArticle: Article?
@@ -20,8 +17,7 @@ struct CardsStyleView: View {
         return articles.filter { ids.contains($0.id) }
     }
 
-    /// Tracks article IDs that have been swiped away during this view's lifetime.
-    /// This keeps the deck session-scoped: navigating away and back resets the deck.
+    /// Session-scoped swipe dismissals; resets on navigate-away-and-back.
     @State private var dismissedIDs: Set<Int64> = []
 
     private var visibleCards: [Article] {
@@ -64,7 +60,6 @@ struct CardsStyleView: View {
                     }
                 }
             } else {
-                // Show front card and one behind; new back cards fade in after swipe
                 ForEach(Array(visibleCards.prefix(2).enumerated().reversed()),
                         id: \.element.id) { index, article in
                     ArticleLink(article: article, onShowYouTubePlayer: {

--- a/SakuraRSS/Views/Shared/Feed Display Styles/Cards/ProgressiveBlurView.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/Cards/ProgressiveBlurView.swift
@@ -1,13 +1,6 @@
 import SwiftUI
 
-/// Builds a progressive blur by stacking multiple blur layers, each masked
-/// to reveal only its vertical slice. The result fades from sharp at the top
-/// to heavily blurred at the bottom, with a tint that adapts to the current
-/// color scheme for text contrast.
-///
-/// Uses a custom UIView subclass so that gradient masks are re-applied in
-/// `layoutSubviews`, ensuring the blur is visible on the very first display
-/// (not just after the view reappears).
+/// Progressive blur fading from sharp top to heavily blurred bottom.
 struct ProgressiveBlurView: UIViewRepresentable {
 
     @Environment(\.colorScheme) private var colorScheme
@@ -81,7 +74,6 @@ final class ProgressiveBlurUIView: UIView {
             blur.alpha = CGFloat(index + 1) / CGFloat(Self.steps)
         }
 
-        // Tint overlay
         tintOverlay.frame = bounds
         tintOverlay.backgroundColor = blurStyle == .dark
             ? UIColor.black.withAlphaComponent(0.3)

--- a/SakuraRSS/Views/Shared/Feed Display Styles/Feed/CarouselImageView.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/Feed/CarouselImageView.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 
-/// Loads and displays an image fitted to a fixed height, letting
-/// its natural aspect ratio determine the width.
+/// Image fitted to a fixed height; width follows the natural aspect ratio.
 struct CarouselImageView: View {
 
     let url: URL
@@ -11,8 +10,7 @@ struct CarouselImageView: View {
     init(url: URL, height: CGFloat) {
         self.url = url
         self.height = height
-        // Paint memory-cache hits on first render to avoid the placeholder
-        // flash during horizontal carousel scroll.
+        // Paint memory-cache hits on first render to avoid placeholder flash during scroll.
         _image = State(initialValue: ImageMemoryCache.shared.image(forKey: url.absoluteString))
     }
 

--- a/SakuraRSS/Views/Shared/Feed Display Styles/Feed/FeedArticleRow.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/Feed/FeedArticleRow.swift
@@ -104,7 +104,6 @@ struct FeedArticleRow: View {
                 .truncationMode(.tail)
 
                 if article.carouselImageURLs.count > 1 {
-                    // Multiple images - horizontal scroll at fixed height
                     let urls = article.carouselImageURLs.compactMap { URL(string: $0) }
                     if !urls.isEmpty {
                         ScrollView(.horizontal, showsIndicators: false) {

--- a/SakuraRSS/Views/Shared/Feed Display Styles/FeedDisplayStyleEnvironment.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/FeedDisplayStyleEnvironment.swift
@@ -29,15 +29,10 @@ extension EnvironmentValues {
 // MARK: - Zoom Transition Modifiers
 
 extension View {
-    /// Applies the zoom navigation transition on the destination side.
-    /// When no matching `matchedTransitionSource` exists, the system
-    /// falls back to the default push transition automatically.
     func zoomTransition(sourceID: Int64, in namespace: Namespace.ID) -> some View {
         self.navigationTransition(.zoom(sourceID: sourceID, in: namespace))
     }
 
-    /// Applies the zoom navigation transition on the destination side,
-    /// accepting an optional namespace.
     @ViewBuilder
     func zoomTransition(sourceID: Int64, in namespace: Namespace.ID?) -> some View {
         if let namespace {
@@ -47,7 +42,6 @@ extension View {
         }
     }
 
-    /// Marks this view as the source for a zoom navigation transition.
     @ViewBuilder
     func zoomSource(id: Int64, namespace: Namespace.ID?) -> some View {
         if let namespace {

--- a/SakuraRSS/Views/Shared/Feed Display Styles/Photos/PhotosArticleCard.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/Photos/PhotosArticleCard.swift
@@ -31,7 +31,6 @@ struct PhotosArticleCard: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            // Profile photo and feed name header
             HStack(spacing: 10) {
                 if let feed {
                     NavigationLink(value: feed) {
@@ -92,7 +91,6 @@ struct PhotosArticleCard: View {
             .padding(.horizontal, 12)
             .padding(.vertical, 10)
 
-            // Edge-to-edge photo or carousel
             if article.carouselImageURLs.count > 1 {
                 let urls = article.carouselImageURLs.compactMap { URL(string: $0) }
                 if !urls.isEmpty {
@@ -157,7 +155,6 @@ struct PhotosArticleCard: View {
                     .transition(.opacity)
             }
 
-            // Article caption / title (tapping opens the article)
             ArticleLink(article: article, onShowYouTubePlayer: {
                 youTubeArticle = $0
             }, label: {
@@ -181,7 +178,6 @@ struct PhotosArticleCard: View {
                     .padding(.bottom, 10)
             }
 
-            // Action buttons below photo
             HStack(spacing: 16) {
                 Button {
                     #if DEBUG

--- a/SakuraRSS/Views/Shared/Feed Display Styles/Podcast/PodcastEpisodeRow.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/Podcast/PodcastEpisodeRow.swift
@@ -26,7 +26,6 @@ struct PodcastEpisodeRow: View {
 
     var body: some View {
         HStack(spacing: 12) {
-            // Episode artwork
             if let imageURL = article.imageURL, let url = URL(string: imageURL) {
                 CachedAsyncImage(url: url) {
                     RoundedRectangle(cornerRadius: 8)

--- a/SakuraRSS/Views/Shared/Feed Display Styles/Scroll/ScrollExpandedArticleView.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/Scroll/ScrollExpandedArticleView.swift
@@ -274,7 +274,6 @@ struct ScrollExpandedArticleView: View { // swiftlint:disable:this type_body_len
     // MARK: - Extraction
 
     private func loadArticleText() async {
-        // Check cache first
         if let cached = try? DatabaseManager.shared.cachedArticleContent(for: article.id),
            !cached.isEmpty {
             extractedText = cached
@@ -346,9 +345,7 @@ struct ScrollExpandedArticleView: View { // swiftlint:disable:this type_body_len
                 try? DatabaseManager.shared.cacheTranslatedSummary(
                     response.targetText, for: article.id
                 )
-            } catch {
-                // Translation failed; user can retry
-            }
+            } catch { }
         } else {
             let source = extractedText ?? article.summary ?? ""
             guard !ContentBlock.plainText(from: source).isEmpty else { return }
@@ -363,9 +360,7 @@ struct ScrollExpandedArticleView: View { // swiftlint:disable:this type_body_len
                 try? DatabaseManager.shared.cacheArticleTranslation(
                     title: result.title, text: result.text, for: article.id
                 )
-            } catch {
-                // Translation failed; user can retry
-            }
+            } catch { }
         }
     }
 

--- a/SakuraRSS/Views/Shared/Feed Display Styles/Scroll/ScrollExpandedArticleView.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/Scroll/ScrollExpandedArticleView.swift
@@ -345,7 +345,8 @@ struct ScrollExpandedArticleView: View { // swiftlint:disable:this type_body_len
                 try? DatabaseManager.shared.cacheTranslatedSummary(
                     response.targetText, for: article.id
                 )
-            } catch { }
+            } catch {
+            }
         } else {
             let source = extractedText ?? article.summary ?? ""
             guard !ContentBlock.plainText(from: source).isEmpty else { return }
@@ -360,7 +361,8 @@ struct ScrollExpandedArticleView: View { // swiftlint:disable:this type_body_len
                 try? DatabaseManager.shared.cacheArticleTranslation(
                     title: result.title, text: result.text, for: article.id
                 )
-            } catch { }
+            } catch {
+            }
         }
     }
 

--- a/SakuraRSS/Views/Shared/Feed Display Styles/Scroll/ScrollStyleView.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/Scroll/ScrollStyleView.swift
@@ -1,10 +1,6 @@
 import SwiftUI
 
-/// A TikTok/Reels-inspired full-screen vertical pager where each article
-/// takes up the entire screen. Tapping the image or content preview expands
-/// the article to reveal the full extracted text; tapping again collapses it.
-/// When expanded, overscrolling past the top collapses back to the compact
-/// overlay and overscrolling past the bottom advances to the next article.
+/// Full-screen vertical pager; tap to expand an article, overscroll to navigate.
 struct ScrollStyleView: View {
 
     @Environment(FeedManager.self) var feedManager
@@ -92,13 +88,11 @@ struct ScrollStyleView: View {
     }
 
     private func handleTap(on article: Article) {
-        // YouTube videos always open in player (never expand inline)
         if article.isYouTubeURL && youTubeOpenMode == .inAppPlayer {
             feedManager.markRead(article)
             youTubeArticle = article
             return
         }
-        // Podcast episodes always open in podcast player (never expand inline)
         if article.isPodcastEpisode {
             feedManager.markRead(article)
             podcastArticle = article

--- a/SakuraRSS/Views/Shared/Feed Display Styles/Video/VideoArticleCard.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/Video/VideoArticleCard.swift
@@ -27,7 +27,6 @@ struct VideoArticleCard: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            // Thumbnail
             if let imageURL = article.imageURL, let url = URL(string: imageURL) {
                 Color.clear
                     .aspectRatio(16 / 9, contentMode: .fit)
@@ -44,7 +43,6 @@ struct VideoArticleCard: View {
                     .aspectRatio(16 / 9, contentMode: .fit)
             }
 
-            // Channel avatar + title + metadata
             HStack(alignment: .top, spacing: 12) {
                 if let feed, let navigateToFeed {
                     Button { navigateToFeed(feed) } label: { feedAvatarView }

--- a/SakuraRSS/Views/Shared/FeedIconPlaceholder.swift
+++ b/SakuraRSS/Views/Shared/FeedIconPlaceholder.swift
@@ -1,10 +1,6 @@
 import SwiftUI
 
-/// Placeholder tile drawn wherever an article has no cover image.
-/// Fills the tile with the favicon's average color and centers the
-/// feed icon (favicon, acronym icon, or first-letter fallback).
-/// Social-feed favicons, which are usually profile photos, are
-/// clipped into a circle so they read as avatars rather than squares.
+/// Placeholder tile used when an article has no cover image; centers the feed icon.
 struct FeedIconPlaceholder: View {
 
     enum Fallback {

--- a/SakuraRSS/Views/Shared/FeedRefreshProgressDonut.swift
+++ b/SakuraRSS/Views/Shared/FeedRefreshProgressDonut.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 
-/// A small donut-shaped progress indicator displayed in the Home tab
-/// toolbar while feeds are refreshing. 
+/// Donut progress indicator shown in the Home toolbar during feed refresh.
 struct FeedRefreshProgressDonut: View {
 
     let progress: Double

--- a/SakuraRSS/Views/Shared/ImageViewerView.swift
+++ b/SakuraRSS/Views/Shared/ImageViewerView.swift
@@ -41,7 +41,6 @@ private class LayoutAwareScrollView: UIScrollView {
             imageView.frame = CGRect(origin: .zero, size: fitSize)
             contentSize = fitSize
         }
-        // Center the image within the scroll view bounds
         let offsetX = max((bounds.width - contentSize.width) / 2, 0)
         let offsetY = max((bounds.height - contentSize.height) / 2, 0)
         imageView.frame.origin = CGPoint(x: offsetX, y: offsetY)

--- a/SakuraRSS/Views/Shared/InitialsAvatarView.swift
+++ b/SakuraRSS/Views/Shared/InitialsAvatarView.swift
@@ -79,14 +79,12 @@ struct InitialsAvatarView: View {
         return renderer.image { _ in
             let rect = CGRect(origin: .zero, size: CGSize(width: size, height: size))
 
-            // Draw rounded rectangle background
             let cornerRadius = size / 8
             let path = UIBezierPath(roundedRect: rect, cornerRadius: cornerRadius)
             bgColor.setFill()
             path.fill()
 
             if isGlyphBased(name) {
-                // Draw newspaper SF Symbol for glyph-based languages
                 let fontSize = size * 0.4
                 let config = UIImage.SymbolConfiguration(pointSize: fontSize, weight: .semibold)
                 if let symbol = UIImage(systemName: "newspaper", withConfiguration: config)?
@@ -101,7 +99,6 @@ struct InitialsAvatarView: View {
                     symbol.draw(in: symbolRect)
                 }
             } else {
-                // Draw initials text for Latin-based languages
                 let initials = initials(for: name)
                 let fontSize = size * 0.4
                 let font = UIFont.systemFont(ofSize: fontSize, weight: .semibold)

--- a/SakuraRSS/Views/Shared/InstagramLoginView.swift
+++ b/SakuraRSS/Views/Shared/InstagramLoginView.swift
@@ -1,9 +1,7 @@
 import SwiftUI
 import WebKit
 
-/// A web view that presents the Instagram login page.
-/// Session cookies persist in the default WKWebsiteDataStore so that
-/// InstagramProfileScraper can use them for authenticated profile scraping.
+/// Web view presenting the Instagram login page; cookies persist for InstagramProfileScraper.
 struct InstagramLoginView: View {
 
     @Environment(\.dismiss) var dismiss
@@ -31,7 +29,6 @@ struct InstagramLoginView: View {
     }
 }
 
-/// UIViewRepresentable wrapper for a WKWebView that loads the Instagram login page.
 private struct InstagramLoginWebView: UIViewRepresentable {
 
     @Binding var isLoggedIn: Bool
@@ -70,9 +67,6 @@ private struct InstagramLoginWebView: UIViewRepresentable {
                 try? await Task.sleep(for: .seconds(1))
                 guard !Task.isCancelled else { return }
 
-                // Copy any cookies Instagram just set in the WKWebView
-                // over to Keychain so `hasInstagramSession()`, which
-                // reads from Keychain, can detect the successful login.
                 await InstagramProfileScraper.syncCookiesFromWebKit()
 
                 let loggedIn = await InstagramProfileScraper.hasInstagramSession()

--- a/SakuraRSS/Views/Shared/Podcast Episode/PodcastEpisodeView+Summaries.swift
+++ b/SakuraRSS/Views/Shared/Podcast Episode/PodcastEpisodeView+Summaries.swift
@@ -9,8 +9,7 @@ extension PodcastEpisodeView {
             return
         }
 
-        // Prefer the full transcript when available - summarizing actual episode content
-        // produces far better results than the RSS feed's short description.
+        // Prefer the transcript when available for better summaries than the RSS description.
         let transcriptText = transcript?
             .map(\.text)
             .joined(separator: " ") ?? ""
@@ -27,8 +26,7 @@ extension PodcastEpisodeView {
         do {
             let summary: String
             if useTranscript {
-                // Full transcripts can easily exceed the language model's context window.
-                // Use the existing BatchSummarizer to chunk, summarize concurrently, then combine.
+                // Full transcripts exceed the context window; batch-summarize then combine.
                 let charLimit = 6000
                 let sentences = source
                     .split(whereSeparator: { ".!?".contains($0) })

--- a/SakuraRSS/Views/Shared/Podcast Episode/PodcastEpisodeView+Transcription.swift
+++ b/SakuraRSS/Views/Shared/Podcast Episode/PodcastEpisodeView+Transcription.swift
@@ -2,7 +2,6 @@ import SwiftUI
 
 extension PodcastEpisodeView {
 
-    /// Reloads the cached transcript from the database.
     func reloadCachedTranscript() {
         if let cached = try? DatabaseManager.shared.cachedTranscript(for: article.id),
            !cached.isEmpty {
@@ -12,9 +11,7 @@ extension PodcastEpisodeView {
         }
     }
 
-    /// A "follow along" button shown at the bottom of the scroll view when
-    /// the user has scrolled away from the active transcript segment.
-    /// Tapping it re-enables auto-scroll and jumps back to the active segment.
+    /// Overlay button that re-enables transcript auto-scroll and jumps to the active segment.
     @ViewBuilder
     func followAlongOverlay(scrollProxy: ScrollViewProxy) -> some View {
         if showingTranscript, let transcript, !transcript.isEmpty, !isTranscriptAutoScrolling {
@@ -38,8 +35,7 @@ extension PodcastEpisodeView {
         }
     }
 
-    /// The id of the transcript segment that covers the current playback time.
-    /// Uses binary search since segments are sorted by start time.
+    /// Returns the id of the segment covering the current playback time.
     func activeTranscriptID(in segments: [TranscriptSegment]) -> Int? {
         guard !segments.isEmpty else { return nil }
         let currentTime = AudioPlayer.shared.currentTime

--- a/SakuraRSS/Views/Shared/Podcast Episode/PodcastEpisodeView+Translation.swift
+++ b/SakuraRSS/Views/Shared/Podcast Episode/PodcastEpisodeView+Translation.swift
@@ -23,7 +23,8 @@ extension PodcastEpisodeView {
                 try? DatabaseManager.shared.cacheTranslatedSummary(
                     response.targetText, for: article.id
                 )
-            } catch { }
+            } catch {
+            }
         } else {
             let source = article.summary ?? ""
             guard !source.isEmpty else { return }
@@ -36,7 +37,8 @@ extension PodcastEpisodeView {
                     text: response.targetText,
                     for: article.id
                 )
-            } catch { }
+            } catch {
+            }
         }
     }
 }

--- a/SakuraRSS/Views/Shared/Podcast Episode/PodcastEpisodeView+Translation.swift
+++ b/SakuraRSS/Views/Shared/Podcast Episode/PodcastEpisodeView+Translation.swift
@@ -23,9 +23,7 @@ extension PodcastEpisodeView {
                 try? DatabaseManager.shared.cacheTranslatedSummary(
                     response.targetText, for: article.id
                 )
-            } catch {
-                // Translation failed; user can retry
-            }
+            } catch { }
         } else {
             let source = article.summary ?? ""
             guard !source.isEmpty else { return }
@@ -38,9 +36,7 @@ extension PodcastEpisodeView {
                     text: response.targetText,
                     for: article.id
                 )
-            } catch {
-                // Translation failed; user can retry
-            }
+            } catch { }
         }
     }
 }

--- a/SakuraRSS/Views/Shared/Podcast Episode/PodcastEpisodeView.swift
+++ b/SakuraRSS/Views/Shared/Podcast Episode/PodcastEpisodeView.swift
@@ -16,11 +16,9 @@ struct PodcastEpisodeView: View {
 
     let playbackSpeedPresets: [Double] = [0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0, 2.5, 3.0]
 
-    // Downloads
     let downloadManager = PodcastDownloadManager.shared
     let networkMonitor = NetworkMonitor.shared
     @State var isDownloaded: Bool = false
-    // Transcript
     @State var transcript: [TranscriptSegment]?
     @State var showingTranscript: Bool = false
     @State var isTranscriptAutoScrolling: Bool = true
@@ -41,14 +39,12 @@ struct PodcastEpisodeView: View {
         !isDownloaded && !isOffline && downloadProgress == nil
     }
 
-    // Translation state
     @State var translatedText: String?
     @State var translatedSummary: String?
     @State var isTranslating = false
     @State var translationConfig: TranslationSession.Configuration?
     @State var showingTranslation = false
 
-    // Summarization state
     @State var summarizedText: String?
     @State var isSummarizing = false
     @State var hasCachedSummary = false
@@ -88,7 +84,6 @@ struct PodcastEpisodeView: View {
         ScrollViewReader { scrollProxy in
             ScrollView {
                 VStack(spacing: 24) {
-                    // Artwork
                     if let imageURL = article.imageURL, let url = URL(string: imageURL) {
                         CachedAsyncImage(url: url) {
                             RoundedRectangle(cornerRadius: 16)
@@ -118,7 +113,6 @@ struct PodcastEpisodeView: View {
                             .padding(.horizontal, 40)
                     }
 
-                    // Title and metadata
                     VStack(spacing: 8) {
                         Text(article.title)
                             .font(.title3)
@@ -151,10 +145,8 @@ struct PodcastEpisodeView: View {
                     }
                     .padding(.horizontal)
 
-                    // Playback controls
                     if isThisEpisode {
                         VStack(spacing: 12) {
-                            // Seek bar
                             SeekBarView(
                                 currentTime: Binding(
                                     get: { audioPlayer.currentTime },
@@ -164,7 +156,6 @@ struct PodcastEpisodeView: View {
                                 onSeek: { audioPlayer.seek(to: $0) }
                             )
 
-                            // Transport controls with transcript toggle and speed
                             HStack {
                                 transcriptToggle
                                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -195,7 +186,6 @@ struct PodcastEpisodeView: View {
                         }
                         .padding(.horizontal)
                     } else {
-                        // Not currently playing - show play button with download
                         HStack(spacing: 12) {
                             Button {
                                 startPlayback()
@@ -225,10 +215,8 @@ struct PodcastEpisodeView: View {
                         }
                     }
 
-                    // Action buttons
                     actionButtons
 
-                    // Transcript / Episode description
                     Group {
                         if showingTranscript, let transcript, !transcript.isEmpty {
                             TranscriptView(
@@ -307,7 +295,6 @@ struct PodcastEpisodeView: View {
                 }
                 favicon = await FaviconCache.shared.favicon(for: feed)
             }
-            // Load cached summary/translation
             if let cached = try? DatabaseManager.shared.cachedArticleSummary(for: article.id),
                !cached.isEmpty {
                 hasCachedSummary = true
@@ -316,7 +303,6 @@ struct PodcastEpisodeView: View {
                let text = cached.text, !text.isEmpty {
                 translatedText = text
             }
-            // Load download/transcript state
             isDownloaded = downloadManager.isDownloaded(articleID: article.id)
             if let cached = try? DatabaseManager.shared.cachedTranscript(for: article.id),
                !cached.isEmpty {

--- a/SakuraRSS/Views/Shared/Podcast Episode/TranscriptView.swift
+++ b/SakuraRSS/Views/Shared/Podcast Episode/TranscriptView.swift
@@ -6,8 +6,7 @@ struct TranscriptView: View {
     let currentTime: TimeInterval
     let isPlaying: Bool
     let onSeek: (TimeInterval) -> Void
-    /// Proxy for the enclosing scroll view. Required so the transcript can
-    /// auto-follow without nesting its own ScrollView inside the parent's.
+    /// Proxy from the enclosing scroll view; required so auto-follow doesn't nest scroll views.
     let scrollProxy: ScrollViewProxy
     @Binding var isAutoScrolling: Bool
 
@@ -15,7 +14,6 @@ struct TranscriptView: View {
 
     private var activeSegmentID: Int? {
         guard !segments.isEmpty else { return nil }
-        // Binary search for the latest segment whose start is <= currentTime.
         var low = 0
         var high = segments.count - 1
         var result: Int?
@@ -32,9 +30,6 @@ struct TranscriptView: View {
     }
 
     var body: some View {
-        // Render segments as a readable list of tappable lines. Each segment
-        // is tappable to seek, and the active segment is emphasized with
-        // weight + color.
         LazyVStack(alignment: .leading, spacing: 10) {
             ForEach(segments) { segment in
                 segmentText(segment)

--- a/SakuraRSS/Views/Shared/PodcastDownloadButton.swift
+++ b/SakuraRSS/Views/Shared/PodcastDownloadButton.swift
@@ -86,12 +86,10 @@ struct PodcastDownloadButton: View {
 
     private func donutProgress(progress: Double) -> some View {
         ZStack {
-            // Background track
             Circle()
                 .stroke(.secondary.opacity(0.2), lineWidth: lineWidth)
                 .frame(width: size - lineWidth, height: size - lineWidth)
 
-            // Progress arc
             Circle()
                 .trim(from: 0, to: CGFloat(progress))
                 .stroke(.accent, style: StrokeStyle(lineWidth: lineWidth, lineCap: .round))
@@ -99,7 +97,6 @@ struct PodcastDownloadButton: View {
                 .rotationEffect(.degrees(-90))
                 .animation(.smooth, value: progress)
 
-            // Stop icon in center
             Image(systemName: "stop.fill")
                 .font(.system(size: size * 0.3))
                 .foregroundStyle(.accent)

--- a/SakuraRSS/Views/Shared/RelativeTimeText.swift
+++ b/SakuraRSS/Views/Shared/RelativeTimeText.swift
@@ -1,8 +1,6 @@
 import SwiftUI
 
-/// Displays a date as localized relative time
-/// (e.g. "5 minutes ago", "2 weeks ago", "3 months ago", "2週間前").
-/// Articles less than a minute old show "Just now".
+/// Localized relative time text; sub-minute intervals render as "Just now".
 struct RelativeTimeText: View {
 
     let date: Date

--- a/SakuraRSS/Views/Shared/SeekBarView.swift
+++ b/SakuraRSS/Views/Shared/SeekBarView.swift
@@ -26,18 +26,15 @@ struct SeekBarView: View {
 
     var body: some View {
         VStack(spacing: 8) {
-            // Track
             GeometryReader { geometry in
                 let trackWidth = geometry.size.width
                 let thumbX = progress * trackWidth
 
                 ZStack(alignment: .leading) {
-                    // Background track
                     Capsule()
                         .fill(.tertiary)
                         .frame(height: isDragging ? 8 : 6)
 
-                    // Sponsor segment markers
                     if duration > 0 {
                         ForEach(Array(segments.enumerated()), id: \.offset) { _, segment in
                             let startFraction = CGFloat(segment.start / duration)
@@ -53,7 +50,6 @@ struct SeekBarView: View {
                         }
                     }
 
-                    // Filled track
                     Capsule()
                         .fill(.tint)
                         .frame(width: max(thumbX, 0), height: isDragging ? 8 : 6)
@@ -83,7 +79,6 @@ struct SeekBarView: View {
             .frame(height: 16)
             .animation(.easeInOut(duration: 0.15), value: isDragging)
 
-            // Time labels
             HStack {
                 Text(formatTime(displayTime))
                     .font(.caption)

--- a/SakuraRSS/Views/Shared/SelectableText.swift
+++ b/SakuraRSS/Views/Shared/SelectableText.swift
@@ -1,9 +1,6 @@
 import SwiftUI
 
-/// A read-only text view that supports proper range selection with drag handles.
-/// Uses Apple's `AttributedString(markdown:)` parser for inline formatting (bold, italic,
-/// links, strikethrough, code), with additional support for heading prefixes
-/// (`# `, `## `, `### `) and custom `{{SUP}}`/`{{SUB}}` markers.
+/// Read-only text view with range selection, Markdown formatting, and `{{SUP}}`/`{{SUB}}` markers.
 struct SelectableText: UIViewRepresentable {
 
     let text: String
@@ -57,7 +54,6 @@ struct SelectableText: UIViewRepresentable {
             var contentLine = line
             var lineFont = font
 
-            // Detect heading prefixes
             if contentLine.hasPrefix("### ") {
                 contentLine = String(contentLine.dropFirst(4))
                 lineFont = UIFont.preferredFont(forTextStyle: .headline)
@@ -75,8 +71,7 @@ struct SelectableText: UIViewRepresentable {
         return attributed
     }
 
-    /// Splits a line around `{{SUP}}…{{/SUP}}` and `{{SUB}}…{{/SUB}}` markers,
-    /// parsing the remaining segments as standard Markdown.
+    /// Splits around `{{SUP/SUB}}` markers and parses remaining segments as Markdown.
     private func parseLine(_ text: String, baseFont: UIFont) -> NSAttributedString {
         let supSubPattern = #"\{\{(SUP|SUB)\}\}(.+?)\{\{/(SUP|SUB)\}\}"#
         guard let supSubRegex = try? NSRegularExpression(pattern: supSubPattern) else {
@@ -124,8 +119,7 @@ struct SelectableText: UIViewRepresentable {
         return result
     }
 
-    /// Parses standard Markdown using `AttributedString(markdown:)` and converts
-    /// Foundation attributes into UIKit attributes for the text view.
+    /// Parses Markdown via `AttributedString` and converts to UIKit attributes.
     private func parseMarkdown(_ text: String, baseFont: UIFont) -> NSAttributedString {
         guard !text.isEmpty else {
             return NSAttributedString()

--- a/SakuraRSS/Views/Shared/TrackScrollActivityModifier.swift
+++ b/SakuraRSS/Views/Shared/TrackScrollActivityModifier.swift
@@ -1,8 +1,6 @@
 import SwiftUI
 
-/// Forwards scroll phase and offset updates from an enclosing scroll view
-/// to `FeedManager` so mark-as-read commits can wait until scrolling
-/// has slowed down.
+/// Forwards scroll phase/offset to `FeedManager` so mark-as-read can defer during fast scroll.
 struct TrackScrollActivityModifier: ViewModifier {
 
     @Environment(FeedManager.self) private var feedManager

--- a/SakuraRSS/Views/Shared/WordWrappingText.swift
+++ b/SakuraRSS/Views/Shared/WordWrappingText.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 
-/// A text view that uses strict word wrapping via UILabel,
-/// preventing the system from breaking lines mid-word at punctuation like apostrophes.
+/// UILabel-backed text view with strict word wrapping.
 struct WordWrappingText: UIViewRepresentable {
 
     let text: String
@@ -29,8 +28,7 @@ struct WordWrappingText: UIViewRepresentable {
     }
 }
 
-/// A UILabel subclass that sets preferredMaxLayoutWidth on layout,
-/// ensuring multiline text wraps correctly inside SwiftUI.
+/// UILabel that sets preferredMaxLayoutWidth so multiline wraps correctly inside SwiftUI.
 class WrappingLabel: UILabel {
     override func layoutSubviews() {
         super.layoutSubviews()

--- a/SakuraRSS/Views/Shared/XLoginView.swift
+++ b/SakuraRSS/Views/Shared/XLoginView.swift
@@ -1,9 +1,7 @@
 import SwiftUI
 import WebKit
 
-/// A web view that presents the X (Twitter) login page.
-/// Session cookies persist in the default WKWebsiteDataStore so that
-/// XProfileScraper can use them for authenticated profile scraping.
+/// Web view presenting the X login page; session cookies persist for XProfileScraper.
 struct XLoginView: View {
 
     @Environment(\.dismiss) var dismiss
@@ -32,7 +30,6 @@ struct XLoginView: View {
     }
 }
 
-/// UIViewRepresentable wrapper for a WKWebView that loads the X login page.
 private struct XLoginWebView: UIViewRepresentable {
 
     @Binding var isLoggedIn: Bool
@@ -71,9 +68,6 @@ private struct XLoginWebView: UIViewRepresentable {
                 try? await Task.sleep(for: .seconds(1))
                 guard !Task.isCancelled else { return }
 
-                // Copy any cookies X just set in the WKWebView over to
-                // Keychain so `hasXSession()`, which reads from Keychain,
-                // can detect the successful login.
                 await XProfileScraper.syncCookiesFromWebKit()
 
                 let loggedIn = await XProfileScraper.hasXSession()

--- a/SakuraRSS/Views/Shared/YouTube Player/YouTubePlayerScripts.swift
+++ b/SakuraRSS/Views/Shared/YouTube Player/YouTubePlayerScripts.swift
@@ -4,8 +4,7 @@ nonisolated enum YouTubePlayerScripts {
 
     static let pipMessageHandlerName = "ytPiP"
 
-    /// Injected at document start to suppress YouTube's Page Visibility-based
-    /// auto-pause so audio keeps playing when the app is backgrounded.
+    /// Suppresses YouTube's visibility-based auto-pause so audio continues when backgrounded.
     static let backgroundPlaybackOverride = """
     (function() {
         try {
@@ -47,8 +46,7 @@ nonisolated enum YouTubePlayerScripts {
     })();
     """
 
-    /// Attaches listeners to the video so PiP enter/leave events are forwarded
-    /// to native code immediately, without waiting for the polling observer.
+    /// Forwards PiP enter/leave events to native code immediately.
     static let pipEventBridge = """
     (function() {
         function send(state) {
@@ -75,8 +73,7 @@ nonisolated enum YouTubePlayerScripts {
     })();
     """
 
-    /// Blocks autoplay by pausing the video whenever it tries to play until
-    /// `window.__ytAutoplayBlocked` is cleared (by a native play action).
+    /// Blocks autoplay until `window.__ytAutoplayBlocked` is cleared by a native play action.
     static let autoplayBlocker = """
     (function() {
         window.__ytAutoplayBlocked = true;
@@ -103,10 +100,7 @@ nonisolated enum YouTubePlayerScripts {
     })();
     """
 
-/// Reads chapter markers and returns an array of `{title, startSeconds}`
-    /// entries, or an empty array if the video has no chapters. Tries the
-    /// desktop player overlay shape first, then falls back to the mobile
-    /// engagement panels shape (m.youtube.com).
+    /// Returns `[{title, startSeconds}]` for chapters, empty when none exist.
     static let extractChapters = """
     (function() {
         function textFrom(v) {

--- a/SakuraRSS/Views/Shared/YouTube Player/YouTubePlayerStyles.swift
+++ b/SakuraRSS/Views/Shared/YouTube Player/YouTubePlayerStyles.swift
@@ -2,15 +2,7 @@ import Foundation
 
 nonisolated enum YouTubePlayerStyles {
 
-    /// CSS injected into the YouTube watch page to hide the surrounding
-    /// mobile-site chrome (top bar, metadata section, comments, related
-    /// videos, subscribe buttons, etc.) and YouTube's own player controls,
-    /// so that only the bare video player remains visible while our SwiftUI
-    /// controls sit underneath.
-    ///
-    /// Crucially, nothing here touches the `<video>` element, `#movie_player`,
-    /// `.html5-video-player`, `.html5-video-container`, or their ancestor
-    /// containers - those must stay visible for the video to actually render.
+    /// CSS injected into YouTube watch pages to hide chrome while keeping the video visible.
     static let css = """
     html, body {
         margin: 0 !important;
@@ -230,9 +222,7 @@ nonisolated enum YouTubePlayerStyles {
     """
 
     static func injectionScript(css: String) -> String {
-        // Escape characters that would otherwise break out of the JS
-        // template literal we wrap the CSS in. Backticks terminate the
-        // string and `${` starts an interpolation; both must be escaped.
+        // Escape characters that would break out of the JS template literal.
         let safeCSS = css
             .replacingOccurrences(of: "\\", with: "\\\\")
             .replacingOccurrences(of: "`", with: "\\`")

--- a/SakuraRSS/Views/Shared/YouTube Player/YouTubePlayerView+Session.swift
+++ b/SakuraRSS/Views/Shared/YouTube Player/YouTubePlayerView+Session.swift
@@ -39,7 +39,7 @@ extension YouTubePlayerView {
             return true
         }
 
-        // Retry once after a delay to let WebKit finish loading cookies from disk.
+        // Retry once so WebKit can finish loading cookies from disk.
         if UserDefaults.standard.bool(forKey: youtubeSessionCacheKey) {
             try? await Task.sleep(for: .milliseconds(500))
             let retryResult = await retryHasYouTubeSession()
@@ -62,9 +62,7 @@ extension YouTubePlayerView {
         }
     }
 
-    /// Creates a hidden WKWebView that loads YouTube, initialising the default
-    /// WKWebsiteDataStore (and its cookie store) so that a subsequent call to
-    /// `hasYouTubeSession()` sees the persisted session cookies.
+    /// Hidden WKWebView load to warm the default cookie store before `hasYouTubeSession`.
     @MainActor
     static func warmUpWebView() async {
         let config = WKWebViewConfiguration()

--- a/SakuraRSS/Views/Shared/YouTube Player/YouTubePlayerView+Translation.swift
+++ b/SakuraRSS/Views/Shared/YouTube Player/YouTubePlayerView+Translation.swift
@@ -24,9 +24,7 @@ extension YouTubePlayerView {
                 try? DatabaseManager.shared.cacheTranslatedSummary(
                     response.targetText, for: article.id
                 )
-            } catch {
-                // Translation failed; user can retry
-            }
+            } catch { }
         } else {
             let source = descriptionSource ?? ""
             guard !ContentBlock.plainText(from: source).isEmpty else { return }
@@ -40,9 +38,7 @@ extension YouTubePlayerView {
                 try? DatabaseManager.shared.cacheArticleTranslation(
                     title: nil, text: result.text, for: article.id
                 )
-            } catch {
-                // Translation failed; user can retry
-            }
+            } catch { }
         }
     }
 }

--- a/SakuraRSS/Views/Shared/YouTube Player/YouTubePlayerView+Translation.swift
+++ b/SakuraRSS/Views/Shared/YouTube Player/YouTubePlayerView+Translation.swift
@@ -24,7 +24,8 @@ extension YouTubePlayerView {
                 try? DatabaseManager.shared.cacheTranslatedSummary(
                     response.targetText, for: article.id
                 )
-            } catch { }
+            } catch {
+            }
         } else {
             let source = descriptionSource ?? ""
             guard !ContentBlock.plainText(from: source).isEmpty else { return }
@@ -38,7 +39,8 @@ extension YouTubePlayerView {
                 try? DatabaseManager.shared.cacheArticleTranslation(
                     title: nil, text: result.text, for: article.id
                 )
-            } catch { }
+            } catch {
+            }
         }
     }
 }

--- a/SakuraRSS/Views/Shared/YouTube Player/YouTubePlayerView.swift
+++ b/SakuraRSS/Views/Shared/YouTube Player/YouTubePlayerView.swift
@@ -28,14 +28,12 @@ struct YouTubePlayerView: View {
     @State var wantsPlaybackInBackground = false
     @State var playerID = UUID()
 
-    // SponsorBlock
     @AppStorage("YouTube.SponsorBlock.Enabled") var sponsorBlockEnabled = false
     @AppStorage("YouTube.SponsorBlock.Categories") private var sponsorBlockCategories = "sponsor,selfpromo,interaction"
     @State var sponsorSegments: [SponsorSegment] = []
     @State var skippedSegmentIDs: Set<String> = []
     @State var skippedSegmentMessage: String?
 
-    // Translation & summarization
     @State var translatedText: String?
     @State var translatedSummary: String?
     @State var isTranslating = false
@@ -99,13 +97,11 @@ struct YouTubePlayerView: View {
 
             ScrollView(.vertical) {
                 VStack(spacing: 8) {
-                    // Title
                     WordWrappingText(article.title, font: .preferredFont(forTextStyle: .title2, weight: .bold))
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding(.horizontal)
                         .padding(.top, 12)
 
-                    // Seek bar
                     SeekBarView(
                         currentTime: Binding(
                             get: { currentTime },
@@ -119,7 +115,6 @@ struct YouTubePlayerView: View {
                     .padding(.horizontal)
                     .padding(.top, 16)
 
-                    // Playback controls
                     HStack(spacing: 32) {
                         Button {
                             togglePiP()
@@ -161,7 +156,6 @@ struct YouTubePlayerView: View {
                     .foregroundStyle(.primary)
                     .padding(.top, 16)
 
-                    // Visit Advertiser button
                     if isAd, let advertiserURL {
                         Button {
                             openURL(advertiserURL)
@@ -174,7 +168,6 @@ struct YouTubePlayerView: View {
                         .padding(.top, 12)
                     }
 
-                    // Channel info
                     if let feed {
                         HStack(alignment: .top, spacing: 12) {
                             feedAvatarView
@@ -195,10 +188,8 @@ struct YouTubePlayerView: View {
                         .padding(.top, 20)
                     }
 
-                    // Action buttons
                     descriptionActionButtons
 
-                    // Description
                     if let text = displayDescription, !text.isEmpty {
                         VStack(alignment: .leading, spacing: 12) {
                             if showingSummary && summarizedText != nil {

--- a/SakuraRSS/Views/Shared/YouTube Player/YouTubePlayerWebView.swift
+++ b/SakuraRSS/Views/Shared/YouTube Player/YouTubePlayerWebView.swift
@@ -30,12 +30,7 @@ struct YouTubePlayerWebView: UIViewRepresentable {
     }
 
     func makeUIView(context: Context) -> WKWebView {
-        // Configure the audio session for background-capable playback before
-        // the web view has a chance to start loading - so the video decoder
-        // picks up the `.playback`/`.moviePlayback` category from the very
-        // first frame. Without this, the video starts under whatever
-        // category is active, and briefly pauses on background until the
-        // scene-phase handler re-activates the session.
+        // Configure audio session before load so the decoder picks up `.playback` from the first frame.
         let session = AVAudioSession.sharedInstance()
         try? session.setCategory(.playback, mode: .moviePlayback)
         try? session.setActive(true)
@@ -97,10 +92,7 @@ struct YouTubePlayerWebView: UIViewRepresentable {
 
     func updateUIView(_ uiView: WKWebView, context: Context) {}
 
-    /// Rewrites Shorts URLs to the regular watch URL so the WebView loads
-    /// the standard player layout instead of the mobile Shorts UI, which
-    /// renders a separate canvas and a stack of overlays we can't reliably
-    /// hide.
+    /// Rewrites Shorts URLs to the regular watch URL so the WebView uses the standard player.
     static func normalizedURL(_ url: URL) -> URL {
         let path = url.path
         guard path.hasPrefix("/shorts/") else { return url }

--- a/SakuraRSS/Views/Shared/YouTubeLoginView.swift
+++ b/SakuraRSS/Views/Shared/YouTubeLoginView.swift
@@ -1,9 +1,7 @@
 import SwiftUI
 import WebKit
 
-/// A web view that presents the YouTube/Google login page.
-/// Session cookies persist in the default WKWebsiteDataStore so that
-/// the YouTube player can use them for authenticated playback (e.g. PiP).
+/// Web view presenting the YouTube/Google login page; cookies persist for authenticated playback.
 struct YouTubeLoginView: View {
 
     @Environment(\.dismiss) var dismiss

--- a/SakuraRSS/Views/iPadSidebarView.swift
+++ b/SakuraRSS/Views/iPadSidebarView.swift
@@ -39,12 +39,10 @@ struct IPadSidebarView: View {
         return (try? DatabaseManager.shared.searchArticles(query: searchText)) ?? []
     }
 
-    // Feed management state (mirrored from FeedsListPage)
     @State private var feedToEdit: Feed?
     @State private var feedToDelete: Feed?
     @State private var feedForRules: Feed?
 
-    // List management state
     @State private var listToEdit: FeedList?
     @State private var listForRules: FeedList?
     @State private var listToDelete: FeedList?

--- a/Shared/Data Portability/iCloudBackupManager.swift
+++ b/Shared/Data Portability/iCloudBackupManager.swift
@@ -53,13 +53,11 @@ final class iCloudBackupManager: @unchecked Sendable {
 
         let destinationURL = documentsURL.appendingPathComponent("Sakura.feeds")
 
-        // Replace atomically
         if FileManager.default.fileExists(atPath: destinationURL.path) {
             try FileManager.default.removeItem(at: destinationURL)
         }
         try FileManager.default.copyItem(at: cleanedURL, to: destinationURL)
 
-        // Write metadata
         let metadata = try buildMetadata()
         let metadataURL = documentsURL.appendingPathComponent("backup-metadata.json")
         let encoder = JSONEncoder()
@@ -67,14 +65,11 @@ final class iCloudBackupManager: @unchecked Sendable {
         let data = try encoder.encode(metadata)
         try data.write(to: metadataURL, options: .atomic)
 
-        // Record last backup date
         UserDefaults.standard.set(Date().timeIntervalSince1970,
                                   forKey: "iCloudBackup.LastBackupDate")
     }
 
-    /// Runs a backup if the user's chosen interval has elapsed since the last backup.
-    /// The system already throttled us via `earliestBeginDate`, so we allow a
-    /// 10% slack to avoid skipping a granted run over minor timing drift.
+    /// Runs a backup if the user's chosen interval has elapsed (allows 10% slack for timing drift).
     func backupIfScheduled() async {
         let intervalRaw = UserDefaults.standard.integer(forKey: "iCloudBackup.Interval")
         let interval = BackupInterval(rawValue: intervalRaw) ?? .everyNight
@@ -101,10 +96,8 @@ final class iCloudBackupManager: @unchecked Sendable {
             .appendingPathComponent("Documents")
             .appendingPathComponent("backup-metadata.json")
 
-        // Trigger download if needed
         if !FileManager.default.fileExists(atPath: metadataURL.path) {
             try? FileManager.default.startDownloadingUbiquitousItem(at: metadataURL)
-            // Wait briefly for download
             for _ in 0..<20 {
                 try? await Task.sleep(nanoseconds: 250_000_000)
                 if FileManager.default.fileExists(atPath: metadataURL.path) { break }
@@ -126,7 +119,6 @@ final class iCloudBackupManager: @unchecked Sendable {
             .appendingPathComponent("Documents")
             .appendingPathComponent("Sakura.feeds")
 
-        // Trigger download if needed
         if !FileManager.default.fileExists(atPath: backupURL.path) {
             try FileManager.default.startDownloadingUbiquitousItem(at: backupURL)
             for _ in 0..<60 {
@@ -142,7 +134,6 @@ final class iCloudBackupManager: @unchecked Sendable {
         let dbPath = DatabaseManager.databasePath
         let dbURL = URL(fileURLWithPath: dbPath)
 
-        // Remove existing database files (main + WAL + SHM if present)
         for suffix in ["", "-wal", "-shm"] {
             let fileURL = URL(fileURLWithPath: dbPath + suffix)
             if FileManager.default.fileExists(atPath: fileURL.path) {
@@ -150,10 +141,7 @@ final class iCloudBackupManager: @unchecked Sendable {
             }
         }
 
-        // Copy backup to database location
         try FileManager.default.copyItem(at: backupURL, to: dbURL)
-
-        // Reconnect DatabaseManager
         try DatabaseManager.shared.reconnect()
     }
 
@@ -179,11 +167,10 @@ final class iCloudBackupManager: @unchecked Sendable {
             try FileManager.default.removeItem(at: tempDB)
         }
 
-        // Copy the live database file
         let sourceURL = URL(fileURLWithPath: DatabaseManager.databasePath)
         try FileManager.default.copyItem(at: sourceURL, to: tempDB)
 
-        // Also copy WAL/SHM if they exist so the temp copy is complete
+        // Copy WAL/SHM so the temp copy is complete.
         for suffix in ["-wal", "-shm"] {
             let src = URL(fileURLWithPath: DatabaseManager.databasePath + suffix)
             let dst = tempDir.appendingPathComponent("Sakura-backup.feeds" + suffix)
@@ -195,13 +182,11 @@ final class iCloudBackupManager: @unchecked Sendable {
             }
         }
 
-        // Open the temp copy and strip caches, then vacuum
         let connection = try Connection(tempDB.path)
         try connection.run("DELETE FROM image_cache")
         try connection.run("DELETE FROM summary_cache")
         try connection.run("VACUUM")
 
-        // Clean up WAL/SHM from temp (VACUUM consolidates everything)
         for suffix in ["-wal", "-shm"] {
             let dst = tempDir.appendingPathComponent("Sakura-backup.feeds" + suffix)
             try? FileManager.default.removeItem(at: dst)

--- a/Shared/Database Manager/DatabaseManager+Articles.swift
+++ b/Shared/Database Manager/DatabaseManager+Articles.swift
@@ -1,7 +1,6 @@
 import Foundation
 @preconcurrency import SQLite
 
-/// Groups optional article fields to keep the insert call under the parameter limit.
 struct ArticleInsertData: Sendable {
     var author: String?
     var summary: String?
@@ -13,7 +12,6 @@ struct ArticleInsertData: Sendable {
     var duration: Int?
 }
 
-/// A single article to be batch-inserted, pairing its required and optional fields.
 struct ArticleInsertItem {
     var title: String
     var url: String
@@ -80,10 +78,7 @@ nonisolated extension DatabaseManager {
                     articleAudioURL <- item.data.audioURL,
                     articleDuration <- item.data.duration
                 ))
-                // `INSERT OR IGNORE` on a URL-uniqueness conflict does not
-                // change sqlite3_changes(), so we gate on the per-statement
-                // change count rather than the returned rowid (which can
-                // carry over from a prior statement).
+                // INSERT OR IGNORE leaves sqlite3_changes() unchanged on conflict, so gate on per-statement change count rather than rowid.
                 if database.changes > 0 {
                     insertedIDs.append(rowid)
                 }
@@ -92,9 +87,7 @@ nonisolated extension DatabaseManager {
         return insertedIDs
     }
 
-    /// Returns the articles with the given IDs, ordered by published date
-    /// descending.  Used to look up just-inserted rows for Spotlight
-    /// indexing so unchanged rows aren't re-indexed on every refresh.
+    /// Returns the articles with the given IDs, ordered by published date descending.
     func articles(withIDs ids: [Int64]) throws -> [Article] {
         guard !ids.isEmpty else { return [] }
         let query = articles
@@ -103,10 +96,7 @@ nonisolated extension DatabaseManager {
         return try database.prepare(query).map(rowToArticle)
     }
 
-    /// Returns articles for a set of feed IDs ordered by published date
-    /// descending.  Used by the list widgets so a single SQLite statement
-    /// (with indexes on `feed_id` and `published_date`) replaces N
-    /// per-feed queries merged and re-sorted in Swift.
+    /// Returns articles for a set of feed IDs ordered by published date descending.
     func articles(forFeedIDs feedIDs: [Int64], limit: Int) throws -> [Article] {
         guard !feedIDs.isEmpty else { return [] }
         let query = articles
@@ -135,8 +125,7 @@ nonisolated extension DatabaseManager {
         try database.scalar(articles.filter(articleFeedID == fid).count)
     }
 
-    /// Returns the URLs already ingested for `fid` so refresh can skip
-    /// per-article work (e.g. HTML metadata lookups) on known items.
+    /// Returns the URLs already ingested for `fid`.
     func existingArticleURLs(forFeedID fid: Int64) throws -> Set<String> {
         let query = articles
             .filter(articleFeedID == fid)
@@ -255,9 +244,7 @@ nonisolated extension DatabaseManager {
         try database.run(target.update(articleIsRead <- read))
     }
 
-    /// Batched counterpart of `markArticleRead(id:read:)` — applies a single
-    /// `UPDATE ... WHERE id IN (...)` so N scroll-mark-as-read events collapse
-    /// into one SQLite write instead of N.
+    /// Batched counterpart of `markArticleRead(id:read:)`.
     func markArticlesRead(ids: [Int64], read: Bool) throws {
         guard !ids.isEmpty else { return }
         let target = articles.filter(ids.contains(articleID))
@@ -316,8 +303,7 @@ nonisolated extension DatabaseManager {
         try database.run(target.update(articleLastAccessed <- Date().timeIntervalSince1970))
     }
 
-    /// Batched counterpart of `updateLastAccessed(articleID:)` — stamps the
-    /// same timestamp across all ids in one `UPDATE`.
+    /// Batched counterpart of `updateLastAccessed(articleID:)`.
     func updateLastAccessed(articleIDs ids: [Int64]) throws {
         guard !ids.isEmpty else { return }
         let target = articles.filter(ids.contains(articleID))
@@ -354,7 +340,6 @@ nonisolated extension DatabaseManager {
         var results: [Article] = []
         let stmt = try database.prepare(sql, bindings)
         for row in stmt {
-            // Map raw SQL row to Article manually
             guard let id = row[0] as? Int64,
                   let feedID = row[1] as? Int64,
                   let title = row[2] as? String,

--- a/Shared/Database Manager/DatabaseManager+ImageCache.swift
+++ b/Shared/Database Manager/DatabaseManager+ImageCache.swift
@@ -10,8 +10,7 @@ nonisolated extension DatabaseManager {
         return row[imageCacheData]
     }
 
-    /// Cheap existence check for the image cache — avoids loading the full
-    /// `BLOB` just to decide whether a preload step should skip a URL.
+    /// Cheap existence check that avoids loading the full BLOB.
     func isImageCached(for url: String) -> Bool {
         guard let row = try? database.pluck(
             imageCache.select(imageCacheURL).filter(imageCacheURL == url)

--- a/Shared/Database Manager/DatabaseManager+NLP.swift
+++ b/Shared/Database Manager/DatabaseManager+NLP.swift
@@ -22,10 +22,7 @@ nonisolated extension DatabaseManager {
         try database.run(target.update(articleEntitiesProcessed <- true))
     }
 
-    /// Returns articles that still need either sentiment or entity
-    /// extraction, flagging which passes are outstanding for each one.
-    /// Callers fetch each article at most once and run only the tagger(s)
-    /// that are still outstanding, instead of doing two separate scans.
+    /// An article pending sentiment or entity extraction, with per-pass flags.
     struct UnprocessedNLPArticle: Sendable {
         let id: Int64
         let needsSentiment: Bool
@@ -74,9 +71,7 @@ nonisolated extension DatabaseManager {
         }
     }
 
-    /// Batch-fetches entities for many article IDs in a single query, returning
-    /// a map of article ID → lowercased entity-name set. Used by the hybrid
-    /// similarity ranker so we don't fire N single-row queries.
+    /// Batch-fetches entities for many article IDs as a map of id to lowercased name set.
     func entities(forArticleIDs ids: [Int64]) throws -> [Int64: Set<String>] {
         guard !ids.isEmpty else { return [:] }
         let placeholders = ids.map { _ in "?" }.joined(separator: ", ")
@@ -242,11 +237,9 @@ nonisolated extension DatabaseManager {
         forSourceID sourceID: Int64
     ) throws {
         try database.transaction {
-            // Clear any existing cache for this source
             try database.run(
                 similarArticles.filter(similarSourceID == sourceID).delete()
             )
-            // Insert new entries
             for (index, match) in matches.enumerated() {
                 try database.run(similarArticles.insert(
                     similarSourceID <- sourceID,
@@ -255,7 +248,7 @@ nonisolated extension DatabaseManager {
                     similarRank <- index
                 ))
             }
-            // Mark source as computed (even if matches is empty)
+            // Mark source as computed even when matches is empty.
             try database.run(
                 articles.filter(articleID == sourceID)
                     .update(articleSimilarComputed <- true)
@@ -263,9 +256,7 @@ nonisolated extension DatabaseManager {
         }
     }
 
-    /// Wipes every cached similar-article match and resets the per-article
-    /// `similar_computed` flag. Used on algorithm-version bumps so the next
-    /// article open recomputes under the new scoring.
+    /// Wipes every cached similar-article match and resets `similar_computed`.
     func invalidateSimilarContentCache() throws {
         try database.transaction {
             try database.run(similarArticles.delete())

--- a/Shared/Database Manager/DatabaseManager.swift
+++ b/Shared/Database Manager/DatabaseManager.swift
@@ -122,18 +122,13 @@ nonisolated final class DatabaseManager: @unchecked Sendable {
     }
 
     /// Replaces the current database connection and re-creates tables.
-    /// Used after restoring a backup file to the database path.
     func reconnect() throws {
         database = try Connection(Self.databasePath)
         try Self.applyConnectionPragmas(database)
         try createTables()
     }
 
-    /// Switches the connection to WAL mode and raises the busy timeout so
-    /// main-thread reads from view bodies don't stall while background
-    /// NLP or refresh tasks hold a write transaction. Rollback-journal
-    /// mode locks the whole file; WAL lets readers progress concurrently
-    /// with a single writer, which is the access pattern this app has.
+    /// Enables WAL mode and raises busy timeout so reads don't stall behind writes.
     private static func applyConnectionPragmas(_ connection: Connection) throws {
         try connection.run("PRAGMA journal_mode = WAL")
         try connection.run("PRAGMA synchronous = NORMAL")
@@ -149,10 +144,7 @@ nonisolated final class DatabaseManager: @unchecked Sendable {
         }
     }
 
-    /// Collapses the legacy `Intelligence.SimilarContent.Enabled` /
-    /// `Intelligence.TopicsPeople.Enabled` toggles into a single
-    /// `Intelligence.ContentInsights.Enabled` key. Runs exactly once per
-    /// install, tracked by `Intelligence.ContentInsights.Migrated`.
+    /// Collapses legacy intelligence toggles into `Intelligence.ContentInsights.Enabled`.
     private func migrateContentInsightsToggle() {
         let defaults = UserDefaults.standard
         let migratedKey = "Intelligence.ContentInsights.Migrated"
@@ -167,14 +159,7 @@ nonisolated final class DatabaseManager: @unchecked Sendable {
         defaults.set(true, forKey: migratedKey)
     }
 
-    /// Bumps the similar-content algorithm version and wipes the cache the
-    /// first time the app launches under a newer ranker. Deferred to a
-    /// background task so the rewrite (which scans every article row)
-    /// doesn't block the DB connection during cold launch — the old
-    /// v1 rankings stay visible to the user for a few seconds longer,
-    /// which is better than a frozen first-launch screen.  The version
-    /// stamp is written eagerly so a crash between the bump and the
-    /// wipe still lets the next launch finish the job.
+    /// Bumps the similar-content algorithm version and wipes the cache on upgrade.
     private func invalidateStaleSimilarContentCache() {
         let key = "Intelligence.SimilarContent.AlgorithmVersion"
         let current = 2   // v1: embedding-only; v2: hybrid embedding + entity Jaccard

--- a/Shared/Domain Options/BodyPriorityDomains.swift
+++ b/Shared/Domain Options/BodyPriorityDomains.swift
@@ -1,11 +1,6 @@
 import Foundation
 
-/// Domains whose feeds carry the meaningful article text in the
-/// body/summary while the `<title>` element holds a generic category
-/// label (e.g. the JMA extra feed at
-/// https://www.data.jma.go.jp/developer/xml/feed/extra.xml). For these
-/// feeds, the title and body are swapped so lists surface the useful
-/// information first.
+/// Domains where the meaningful text lives in the body while the title is generic; swap them.
 nonisolated enum BodyPriorityDomains {
 
     static let allowlistedDomains: Set<String> = [
@@ -17,9 +12,7 @@ nonisolated enum BodyPriorityDomains {
         return allowlistedDomains.contains(where: { host == $0 || host.hasSuffix(".\($0)") })
     }
 
-    /// Returns a copy of `article` with title and body swapped when the
-    /// feed's domain is in the allowlist. The body is sourced from
-    /// `summary` when present, otherwise from `content`.
+    /// Returns a copy of `article` with title and body swapped when the domain is allowlisted.
     static func applying(to article: ParsedArticle, feedDomain: String) -> ParsedArticle {
         guard shouldSwapTitleAndBody(feedDomain: feedDomain) else { return article }
 

--- a/Shared/Domain Options/Display Styles/DisplayStyleFeedDomains.swift
+++ b/Shared/Domain Options/Display Styles/DisplayStyleFeedDomains.swift
@@ -4,12 +4,9 @@ import Foundation
 nonisolated enum DisplayStyleFeedDomains {
 
     static let allowlistedDomains: Set<String> = [
-        // X (Twitter)
         "x.com",
         "twitter.com",
-        // Bluesky
         "bsky.app",
-        // Mastodon
         "mastodon.social",
         "mastodon.online",
         "mastodon.world",

--- a/Shared/Domain Options/Display Styles/DisplayStylePhotosDomains.swift
+++ b/Shared/Domain Options/Display Styles/DisplayStylePhotosDomains.swift
@@ -4,9 +4,7 @@ import Foundation
 nonisolated enum DisplayStylePhotosDomains {
 
     static let allowlistedDomains: Set<String> = [
-        // Instagram
         "instagram.com",
-        // Pixelfed
         "pixelfed.social",
         "pixelfed.tokyo"
     ]

--- a/Shared/Domain Options/ExtractTextDomains.swift
+++ b/Shared/Domain Options/ExtractTextDomains.swift
@@ -1,7 +1,6 @@
 import Foundation
 
-/// Domains that require WebView-based text extraction (JavaScript rendering)
-/// instead of simple HTTP fetch, because their content is dynamically loaded.
+/// Domains that require WebView-based text extraction because content is dynamically loaded.
 nonisolated enum ExtractTextDomains {
 
     static let allowlistedDomains: Set<String> = [

--- a/Shared/Domain Options/Favicons/FaviconAlternateDomains.swift
+++ b/Shared/Domain Options/Favicons/FaviconAlternateDomains.swift
@@ -1,8 +1,6 @@
 import Foundation
 
 /// Maps feed domains to alternative domains for favicon fetching.
-/// For example, feeds served from a CDN subdomain can be mapped
-/// to the main site so that the correct favicon is retrieved.
 nonisolated enum FaviconAlternateDomains {
 
     static let mappings: [String: String] = [

--- a/Shared/Domain Options/Favicons/FaviconCircularDomains.swift
+++ b/Shared/Domain Options/Favicons/FaviconCircularDomains.swift
@@ -1,22 +1,16 @@
 import Foundation
 
-/// Domains whose feed icons should be displayed as circles (e.g. profile photos).
-/// Icons for these domains also skip blank-padding trimming automatically.
+/// Domains whose feed icons should be displayed as circles (also skips trimming).
 nonisolated enum FaviconCircularDomains {
 
     static let allowlistedDomains: Set<String> = [
-        // X (Twitter)
         "x.com",
         "twitter.com",
-        // Instagram
         "instagram.com",
-        // Pixelfed
         "pixelfed.social",
         "pixelfed.tokyo",
-        // YouTube
         "youtube.com",
         "youtu.be",
-        // note
         "note.com"
     ]
 

--- a/Shared/Domain Options/Favicons/FaviconForceAppleTouchIconDomains.swift
+++ b/Shared/Domain Options/Favicons/FaviconForceAppleTouchIconDomains.swift
@@ -1,10 +1,6 @@
 import Foundation
 
-/// Domains whose favicon should be fetched directly from
-/// `/apple-touch-icon.png` rather than going through the normal PWA /
-/// FaviconFinder pipeline.  Some sites (e.g. Microsoft) serve a pale
-/// favicon.ico and a masked manifest icon, while the apple-touch-icon
-/// is the only richly-colored logo.
+/// Domains whose favicon should be fetched directly from `/apple-touch-icon.png`.
 nonisolated enum FaviconForceAppleTouchIconDomains {
 
     static let allowlistedDomains: Set<String> = [

--- a/Shared/Domain Options/Favicons/FaviconSkipTrimDomains.swift
+++ b/Shared/Domain Options/Favicons/FaviconSkipTrimDomains.swift
@@ -1,8 +1,6 @@
 import Foundation
 
-/// Domains whose favicons should not have blank/white padding trimmed,
-/// because the original image should be used as-is (e.g. profile photos).
-/// Note: Circle icon domains (FaviconCircularDomains) automatically skip trimming.
+/// Domains whose favicons should not have blank padding trimmed.
 nonisolated enum FaviconSkipTrimDomains {
 
     static let allowlistedDomains: Set<String> = []

--- a/Shared/Domain Options/FollowLimitSetDomains.swift
+++ b/Shared/Domain Options/FollowLimitSetDomains.swift
@@ -1,34 +1,20 @@
 import Foundation
 
-/// Caps how many feeds a user can follow on specific hosts.
-///
-/// Hosts with an entry here are scraped via authenticated flows (X,
-/// Instagram) where hitting the upstream API at an unbounded cadence
-/// is a strong bot-like signal and invites rate-limit or account-lock
-/// penalties.  The limit is enforced in `FeedManager.addFeed` before
-/// any insert happens, so the cap applies to every path that adds a
-/// feed (Add Feed sheet, share extension, OPML import, etc.).
+/// Caps how many feeds a user can follow on specific hosts to avoid bot-detection.
 nonisolated enum FollowLimitSetDomains {
 
-    /// Maximum followed feeds per host.  Keys match `URL.host` output
-    /// (lowercased, no scheme or trailing slash).  Subdomains of a
-    /// listed host share the same cap.
     static let limits: [String: Int] = [
         "x.com": 30,
         "instagram.com": 10
     ]
 
-    /// Returns the follow limit that applies to the given feed domain,
-    /// or `nil` if no limit is configured for the host.
+    /// Returns the follow limit for the given feed domain, or `nil` if unlimited.
     static func followLimit(for feedDomain: String) -> Int? {
         guard let key = limitKey(for: feedDomain) else { return nil }
         return limits[key]
     }
 
-    /// Returns the canonical host key a feed domain maps to - e.g.
-    /// both `www.x.com` and `x.com` resolve to `"x.com"`.  Used to
-    /// group existing feeds by their limit bucket when enforcing the
-    /// cap.  Returns `nil` when no bucket applies.
+    /// Returns the canonical host key a feed domain maps to.
     static func limitKey(for feedDomain: String) -> String? {
         let host = feedDomain.lowercased()
         if limits[host] != nil {

--- a/Shared/NLP/NLPProcessor.swift
+++ b/Shared/NLP/NLPProcessor.swift
@@ -10,14 +10,9 @@ nonisolated enum NLPProcessor {
 
     // MARK: - Hybrid Scoring Tunables
 
-    /// Weight applied to the normalized embedding similarity term in the
-    /// hybrid ranker. The two weights should sum to 1.0.
+    // Weights should sum to 1.0.
     static let hybridEmbeddingWeight: Double = 0.65
-    /// Weight applied to the entity Jaccard overlap term in the hybrid
-    /// ranker. Ignored when the source article has no entities.
     static let hybridEntityWeight: Double = 0.35
-    /// Cosine-distance ceiling returned by `NLEmbedding.distance`. Used to
-    /// normalize distances to a [0, 1] similarity in the hybrid formula.
     static let maxEmbeddingDistance: Double = 2.0
 
     struct EntityResult {
@@ -33,9 +28,7 @@ nonisolated enum NLPProcessor {
         return extractEntities(from: text, using: tagger)
     }
 
-    /// Batch-friendly variant: reuses a caller-owned `NLTagger` across many
-    /// articles so tagger construction cost is amortized.  The caller is
-    /// responsible for passing a tagger initialized with `.nameType`.
+    /// Batch-friendly variant reusing a caller-owned `.nameType` tagger.
     static func extractEntities(from text: String, using tagger: NLTagger) -> [EntityResult] {
         guard !text.isEmpty else { return [] }
         tagger.string = text
@@ -82,9 +75,7 @@ nonisolated enum NLPProcessor {
         return sentimentScore(for: text, using: tagger)
     }
 
-    /// Batch-friendly variant: reuses a caller-owned `NLTagger` across many
-    /// articles.  The caller is responsible for passing a tagger initialized
-    /// with `.sentimentScore`.
+    /// Batch-friendly variant reusing a caller-owned `.sentimentScore` tagger.
     static func sentimentScore(for text: String, using tagger: NLTagger) -> Double? {
         guard !text.isEmpty else { return nil }
         tagger.string = text
@@ -116,19 +107,7 @@ nonisolated enum NLPProcessor {
 
     // MARK: - Similarity via NLEmbedding + Entity Overlap
 
-    /// Ranks `candidates` by a hybrid score that blends normalized
-    /// `NLEmbedding` sentence-embedding similarity with entity Jaccard
-    /// overlap. See `hybridEmbeddingWeight` / `hybridEntityWeight`.
-    ///
-    /// - Parameters:
-    ///   - article: Source article being viewed.
-    ///   - sourceEntities: Lowercased entity names for the source article.
-    ///     Pass an empty set to fall back to embedding-only scoring.
-    ///   - candidates: Candidate articles paired with their lowercased
-    ///     entity sets. Caller is expected to batch-load entities so this
-    ///     function stays allocation-light.
-    ///   - maxResults: Maximum number of ranked matches to return.
-    ///   - minimumScore: Matches below this blended score are dropped.
+    /// Ranks candidates by blended embedding similarity and entity Jaccard overlap.
     static func findSimilarArticlesHybrid(
         to article: Article,
         sourceEntities: Set<String>,
@@ -193,9 +172,7 @@ nonisolated enum NLPProcessor {
         return results
     }
 
-    /// Combined text fed into the sentence embedding. Title is repeated so
-    /// it dominates summary content in the resulting vector - short, cheap,
-    /// and noticeably helpful for headline-driven feeds.
+    // Title is repeated so it dominates summary content in the embedding vector.
     private static func articleText(_ article: Article) -> String {
         let title = article.title
         let summary = article.summary ?? ""

--- a/Shared/Network/ImageDownsampler.swift
+++ b/Shared/Network/ImageDownsampler.swift
@@ -2,30 +2,16 @@ import Foundation
 import ImageIO
 import UIKit
 
-/// ImageIO-backed thumbnail helpers.  Preferred over
-/// `UIImage(data:) → byPreparingThumbnail(ofSize:)` because
-/// `CGImageSource` decodes only enough of the source to produce the
-/// thumbnail — a full-resolution photo never has to land in memory
-/// as a UIImage, which matters in the widget extension's tight
-/// memory budget and for main-app scroll smoothness.
-///
-/// Marked `nonisolated` because the app target infers `@MainActor`
-/// isolation for UIKit-using types by default; every method here is
-/// pure and safe to call from any actor / thread.
+/// ImageIO-backed thumbnail helpers that avoid full-resolution decoding.
 nonisolated enum ImageDownsampler {
 
-    /// Downsamples the encoded bytes in `data` to a thumbnail whose
-    /// largest dimension is `maxPixelSize`, returning a decoded
-    /// `UIImage`.  Returns `nil` if the source cannot be decoded.
+    /// Downsamples encoded bytes to a thumbnail whose largest dimension is `maxPixelSize`.
     nonisolated static func downsample(_ data: Data, maxPixelSize: CGFloat) -> UIImage? {
         guard let source = createSource(from: data) else { return nil }
         return downsample(source: source, maxPixelSize: maxPixelSize)
     }
 
-    /// Downsamples the encoded bytes in `data` to a thumbnail whose
-    /// largest dimension is `maxPixelSize` and returns JPEG-encoded
-    /// bytes suitable for storing/transporting (e.g. widget entry
-    /// payloads).  Returns `nil` on any failure.
+    /// Downsamples encoded bytes and returns JPEG-encoded thumbnail bytes.
     nonisolated static func downsampleToJPEG(
         _ data: Data,
         maxPixelSize: CGFloat,

--- a/Shared/Network/KeychainCookieStore.swift
+++ b/Shared/Network/KeychainCookieStore.swift
@@ -1,26 +1,12 @@
 import Foundation
 
-/// A minimal Keychain-backed persistence layer for `HTTPCookie` arrays.
-///
-/// Cookies are archived with secure coding and stored as a single
-/// `kSecClassGenericPassword` item per `service`.  Items are accessible
-/// `kSecAttrAccessibleAfterFirstUnlock`, which means they survive
-/// process relaunches and are readable from `BGAppRefreshTask`s on a
-/// device that has been unlocked at least once since boot.
-///
-/// This exists because relying on `WKWebsiteDataStore.default()` as a
-/// cookie persistence layer requires a MainActor WKWebView round-trip
-/// to restore cookies from disk - unreliable from background tasks and
-/// adds multi-second warming latency to cold-launch scrapes.
+/// Keychain-backed persistence for `HTTPCookie` arrays, readable from background tasks.
 struct KeychainCookieStore {
 
-    /// Keychain service identifier - unique per cookie jar.
     let service: String
-
-    /// Single-account constant; each service stores exactly one item.
     private let account = "cookies"
 
-    /// Persists the given cookies, replacing any previously stored value.
+    /// Persists cookies, replacing any previously stored value.
     func save(_ cookies: [HTTPCookie]) {
         let data: Data
         do {
@@ -46,7 +32,6 @@ struct KeychainCookieStore {
             kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock
         ]
 
-        // Try update first, fall back to add on first save.
         let updateStatus = SecItemUpdate(
             matchQuery as CFDictionary,
             updateAttributes as CFDictionary
@@ -67,8 +52,7 @@ struct KeychainCookieStore {
         }
     }
 
-    /// Loads the persisted cookies, or returns `nil` if no item is stored
-    /// or if the archived data cannot be decoded.
+    /// Loads persisted cookies, or `nil` if none stored or decode fails.
     func load() -> [HTTPCookie]? {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
@@ -98,7 +82,6 @@ struct KeychainCookieStore {
         }
     }
 
-    /// Deletes the stored cookies, if any.
     func clear() {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,

--- a/Shared/Network/NetworkMonitor.swift
+++ b/Shared/Network/NetworkMonitor.swift
@@ -9,9 +9,7 @@ final class NetworkMonitor {
     static let shared = NetworkMonitor()
 
     private(set) var isOnline: Bool = true
-    /// True when the active path is cellular, Personal Hotspot, or otherwise
-    /// flagged as expensive by the system.  Callers use this to skip
-    /// optional/cosmetic downloads during background refresh.
+    /// True when the active path is flagged as expensive by the system.
     private(set) var isExpensive: Bool = false
 
     private let monitor = NWPathMonitor()
@@ -29,11 +27,7 @@ final class NetworkMonitor {
         monitor.start(queue: queue)
     }
 
-    /// One-shot path probe safe to call from non-MainActor contexts (e.g.
-    /// the `BGAppRefreshTask` handler).  Spins up a short-lived monitor,
-    /// awaits one path update, and returns.  Returns `nil` if no path is
-    /// reported within the timeout — treat that as "assume expensive" at
-    /// the call site.
+    /// One-shot path probe safe from non-MainActor contexts; returns `nil` on timeout.
     nonisolated static func currentPathIsExpensive(timeout: TimeInterval = 1.0) async -> Bool? {
         final class ProbeState: @unchecked Sendable {
             var resumed = false

--- a/Shared/SpotlightIndexer.swift
+++ b/Shared/SpotlightIndexer.swift
@@ -5,16 +5,9 @@ nonisolated enum SpotlightIndexer {
 
     static let domainIdentifier = "com.tsubuzaki.SakuraRSS.article"
 
-    /// Schema version for the Spotlight searchable-item attributes produced
-    /// by `indexArticles`.  Bump this whenever the attribute shape changes
-    /// (fields added/removed/renamed) so the next launch triggers a
-    /// one-time full reindex.  The full reindex is otherwise never run
-    /// automatically - the per-feed-refresh incremental path keeps the
-    /// index up to date in the steady state.
+    /// Bump to trigger a one-time full reindex on next launch when attribute shape changes.
     static let schemaVersion: Int = 1
 
-    /// `UserDefaults` key holding the `schemaVersion` value that was in
-    /// effect the last time a full reindex completed.
     static let schemaVersionDefaultsKey = "App.SpotlightIndexVersion"
 
     // MARK: - Indexing
@@ -108,44 +101,37 @@ nonisolated enum SpotlightIndexer {
 
     private static func stripMarkup(_ text: String) -> String? {
         var result = text
-        // Remove image placeholders like {{IMG}}https://...{{/IMG}}
         result = result.replacingOccurrences(
             of: "\\{\\{IMG\\}\\}.*?\\{\\{/IMG\\}\\}",
             with: "",
             options: .regularExpression
         )
-        // Remove markdown images ![alt](url)
         result = result.replacingOccurrences(
             of: "!\\[[^\\]]*\\]\\([^)]*\\)",
             with: "",
             options: .regularExpression
         )
-        // Convert markdown links [text](url) to just text
         result = result.replacingOccurrences(
             of: "\\[([^\\]]+)\\]\\([^)]*\\)",
             with: "$1",
             options: .regularExpression
         )
-        // Remove bare URLs
         result = result.replacingOccurrences(
             of: "https?://\\S+",
             with: "",
             options: .regularExpression
         )
-        // Strip any remaining HTML tags
         result = result.replacingOccurrences(
             of: "<[^>]+>",
             with: " ",
             options: .regularExpression
         )
-        // Decode HTML entities
         result = result.replacingOccurrences(of: "&amp;", with: "&")
         result = result.replacingOccurrences(of: "&lt;", with: "<")
         result = result.replacingOccurrences(of: "&gt;", with: ">")
         result = result.replacingOccurrences(of: "&quot;", with: "\"")
         result = result.replacingOccurrences(of: "&#39;", with: "'")
         result = result.replacingOccurrences(of: "&nbsp;", with: " ")
-        // Collapse whitespace
         result = result.replacingOccurrences(
             of: "\\s+",
             with: " ",

--- a/Shared/SuggestedFeeds.swift
+++ b/Shared/SuggestedFeeds.swift
@@ -33,8 +33,7 @@ enum SuggestedFeedsLoader {
         return try? JSONDecoder().decode(SuggestedFeedsData.self, from: data)
     }
 
-    /// Returns merged topics for the universal region and the user's current region (if available).
-    /// Topics with the same title are merged, with sites sorted alphabetically.
+    /// Returns merged topics for universal and current-region feeds, with sites sorted.
     static func topicsForCurrentRegion() -> [SuggestedTopic] {
         guard let feedsData = load() else { return [] }
 
@@ -46,7 +45,6 @@ enum SuggestedFeedsLoader {
         var topicMap: [String: [SuggestedSite]] = [:]
         var topicOrder: [String] = []
 
-        // Add universal topics first
         if let universal = universalRegion {
             for topic in universal.topics {
                 topicMap[topic.title] = topic.sites
@@ -54,7 +52,6 @@ enum SuggestedFeedsLoader {
             }
         }
 
-        // Merge local region topics
         if let local = localRegion {
             for topic in local.topics {
                 if var existing = topicMap[topic.title] {
@@ -67,7 +64,6 @@ enum SuggestedFeedsLoader {
             }
         }
 
-        // Build final topics with alphabetically sorted sites
         return topicOrder.compactMap { title in
             guard let sites = topicMap[title] else { return nil }
             let sorted = sites.sorted { $0.title.localizedCaseInsensitiveCompare($1.title) == .orderedAscending }

--- a/Widgets/AllArticlesWidget/ArticleProvider.swift
+++ b/Widgets/AllArticlesWidget/ArticleProvider.swift
@@ -28,9 +28,7 @@ struct ArticleProvider: TimelineProvider {
 
     func getTimeline(in _: Context, completion: @escaping (Timeline<ArticleEntry>) -> Void) {
         let entry = loadEntry()
-        // Timeline refreshes every 90 minutes instead of every 30.  Widgets
-        // running outside the app process wake it on every reload; tripling
-        // the interval triples the battery savings for this path.
+        // 90-minute interval; widget reloads wake the app process.
         let timeline = Timeline(entries: [entry], policy: .after(Date().addingTimeInterval(90 * 60)))
         completion(timeline)
     }

--- a/Widgets/ListWidget/ListWidgetProvider.swift
+++ b/Widgets/ListWidget/ListWidgetProvider.swift
@@ -30,9 +30,7 @@ struct ListWidgetProvider: AppIntentTimelineProvider {
 
     func timeline(for configuration: ListWidgetIntent, in _: Context) async -> Timeline<ListWidgetEntry> {
         let entry = await loadEntry(for: configuration)
-        // Timeline refreshes every 90 minutes instead of every 30.  Widgets
-        // running outside the app process wake it on every reload; tripling
-        // the interval triples the battery savings for this path.
+        // 90-minute interval; widget reloads wake the app process.
         return Timeline(entries: [entry], policy: .after(Date().addingTimeInterval(90 * 60)))
     }
 
@@ -78,9 +76,6 @@ struct ListWidgetProvider: AppIntentTimelineProvider {
             let maxPages = 3
             let totalLimit = perPage * maxPages
 
-            // One SQLite statement across every feed in the list, sorted
-            // and limited by the DB — saves the N per-feed queries +
-            // Swift-side merge/sort that the old path did on every wake.
             let dbArticles = try database.articles(forFeedIDs: feedIDs, limit: totalLimit)
 
             let totalPages = max(1, Int(ceil(Double(dbArticles.count) / Double(perPage))))
@@ -88,10 +83,7 @@ struct ListWidgetProvider: AppIntentTimelineProvider {
             let pageStart = currentPage * perPage
             let pageArticles = Array(dbArticles.dropFirst(pageStart).prefix(perPage))
 
-            // Skip image network fetches when the top article IDs haven't
-            // changed since the last timeline build.  DB-cached images still
-            // resolve normally; this prevents retrying failing downloads on
-            // every 90-minute timeline wake.
+            // Skip network fetches when article set is unchanged, to avoid retrying failed downloads each wake.
             let articleIDsMarker = pageArticles.map(\.id).map(String.init).joined(separator: ",")
             let markerKey = "listWidgetMarker_\(listID)_\(layout.rawValue)_\(columns)_\(currentPage)"
             let previousMarker = defaults?.string(forKey: markerKey)

--- a/Widgets/SingleFeedWidget/SingleFeedProvider.swift
+++ b/Widgets/SingleFeedWidget/SingleFeedProvider.swift
@@ -30,9 +30,7 @@ struct SingleFeedProvider: AppIntentTimelineProvider {
 
     func timeline(for configuration: SingleFeedIntent, in _: Context) async -> Timeline<SingleFeedEntry> {
         let entry = await loadEntry(for: configuration)
-        // Timeline refreshes every 90 minutes instead of every 30.  Widgets
-        // running outside the app process wake it on every reload; tripling
-        // the interval triples the battery savings for this path.
+        // 90-minute interval; widget reloads wake the app process.
         return Timeline(entries: [entry], policy: .after(Date().addingTimeInterval(90 * 60)))
     }
 
@@ -70,10 +68,7 @@ struct SingleFeedProvider: AppIntentTimelineProvider {
             let pageStart = currentPage * perPage
             let pageArticles = Array(dbArticles.dropFirst(pageStart).prefix(perPage))
 
-            // Skip image network fetches when the top article IDs haven't
-            // changed since the last timeline build.  DB-cached images still
-            // resolve normally; this prevents retrying failing downloads on
-            // every 90-minute timeline wake.
+            // Skip network fetches when article set is unchanged, to avoid retrying failed downloads each wake.
             let articleIDsMarker = pageArticles.map(\.id).map(String.init).joined(separator: ",")
             let markerKey = "singleFeedMarker_\(feedID)_\(layout.rawValue)_\(columns)_\(currentPage)"
             let previousMarker = defaults?.string(forKey: markerKey)

--- a/Widgets/WidgetThumbnailCache.swift
+++ b/Widgets/WidgetThumbnailCache.swift
@@ -1,11 +1,6 @@
 import Foundation
 
-/// Small on-disk cache of already-downsampled widget thumbnail bytes.
-/// When a widget timeline build detects an unchanged article set, the
-/// provider pulls from this cache instead of re-running the SQLite
-/// fetch + ImageIO thumbnail pass — a straight file read, bytes out.
-/// One cache per `scope` (e.g. list + layout + column combination)
-/// keeps state isolated between widget configurations.
+/// On-disk cache of downsampled widget thumbnail bytes, scoped per widget configuration.
 struct WidgetThumbnailCache {
 
     let scope: String
@@ -35,8 +30,7 @@ struct WidgetThumbnailCache {
         try? data.write(to: url, options: .atomic)
     }
 
-    /// Deletes entries outside `keeping`, so stale thumbnails from
-    /// since-rotated articles don't accumulate on disk.
+    /// Deletes thumbnails whose article IDs aren't in `ids`.
     func prune(keeping ids: [Int64]) {
         guard let directory else { return }
         let keepSet = Set(ids.map { "\($0).jpg" })


### PR DESCRIPTION
## Summary

- Removes narrative multi-paragraph comments throughout the codebase
- Trims docstrings to at most two lines describing how the API is used
- Drops docstrings from self-explanatory types and members
- Preserves `// MARK:`, `#if DEBUG`, swiftlint directives, copyright headers, and short non-obvious WHY comments

Touches 189 files (403 insertions, 2254 deletions). No code behavior was changed.

## Test plan

- [ ] Project builds in Xcode (no Swift compiler available in this environment)
- [ ] Smoke-test article extraction, feed discovery, Petal builder, and the Instagram/X/Reddit/YouTube integrations to confirm no accidental code changes

https://claude.ai/code/session_01RKyu2pYpjS9EWehmjg1kit

---
_Generated by [Claude Code](https://claude.ai/code/session_01RKyu2pYpjS9EWehmjg1kit)_