### PR TITLE
Fix YouTube audio fade-out on background and PiP transitions

### DIFF
--- a/SakuraRSS/Views/Shared/Article Detail/YouTubeEmbedBlockView.swift
+++ b/SakuraRSS/Views/Shared/Article Detail/YouTubeEmbedBlockView.swift
@@ -12,6 +12,7 @@ struct YouTubeEmbedBlockView: View {
     @State private var duration: TimeInterval = 0
     @State private var webView: WKWebView?
     @State private var isAd = false
+    @State private var isAdSkippable = false
     @State private var advertiserURL: URL?
     @State private var videoAspectRatio: CGFloat = 16 / 9
     @State private var isPiP = false
@@ -36,6 +37,7 @@ struct YouTubeEmbedBlockView: View {
                 duration: $duration,
                 webView: $webView,
                 isAd: $isAd,
+                isAdSkippable: $isAdSkippable,
                 advertiserURL: $advertiserURL,
                 videoAspectRatio: $videoAspectRatio,
                 isPiP: $isPiP

--- a/SakuraRSS/Views/Shared/YouTube Player/YouTubePlayerScripts.swift
+++ b/SakuraRSS/Views/Shared/YouTube Player/YouTubePlayerScripts.swift
@@ -46,6 +46,35 @@ nonisolated enum YouTubePlayerScripts {
     })();
     """
 
+    /// Resumes playback when the system (not the user) pauses the video, so background
+    /// and PiP transitions don't produce an audible fade-out/fade-in.
+    static let pauseGuard = """
+    (function() {
+        function attach(video) {
+            if (!video || video.__ytPauseGuardAttached) return;
+            video.__ytPauseGuardAttached = true;
+            video.addEventListener('pause', function() {
+                if (window.__ytUserPaused === true) return;
+                if (video.ended) return;
+                if (video.currentTime > 0 && video.duration > 0
+                    && video.currentTime >= video.duration - 0.25) return;
+                var promise = video.play();
+                if (promise && typeof promise.catch === 'function') {
+                    promise.catch(function(){});
+                }
+            }, true);
+        }
+        function scan() {
+            document.querySelectorAll('video').forEach(attach);
+        }
+        scan();
+        var observer = new MutationObserver(scan);
+        if (document.documentElement) {
+            observer.observe(document.documentElement, { childList: true, subtree: true });
+        }
+    })();
+    """
+
     /// Forwards PiP enter/leave events to native code immediately.
     static let pipEventBridge = """
     (function() {

--- a/SakuraRSS/Views/Shared/YouTube Player/YouTubePlayerScripts.swift
+++ b/SakuraRSS/Views/Shared/YouTube Player/YouTubePlayerScripts.swift
@@ -46,8 +46,25 @@ nonisolated enum YouTubePlayerScripts {
     })();
     """
 
-    /// Resumes playback when the system (not the user) pauses the video, so background
-    /// and PiP transitions don't produce an audible fade-out/fade-in.
+    /// Blocks YouTube's internal `video.pause()` calls (e.g. on visibility change or
+    /// PiP transitions) so there is no pause to fade out of. Pauses are only honored
+    /// when Swift first sets `window.__ytUserPaused = true` or when the video has ended.
+    static let pauseOverride = """
+    (function() {
+        var proto = HTMLMediaElement.prototype;
+        if (proto.__ytPauseOverridden) return;
+        proto.__ytPauseOverridden = true;
+        var originalPause = proto.pause;
+        proto.pause = function() {
+            if (window.__ytUserPaused === true || this.ended) {
+                return originalPause.apply(this, arguments);
+            }
+        };
+    })();
+    """
+
+    /// Safety net for native pauses that bypass the JS pause override (e.g. WebKit
+    /// suspending media directly). Resumes immediately in the same event loop.
     static let pauseGuard = """
     (function() {
         function attach(video) {

--- a/SakuraRSS/Views/Shared/YouTube Player/YouTubePlayerScripts.swift
+++ b/SakuraRSS/Views/Shared/YouTube Player/YouTubePlayerScripts.swift
@@ -146,6 +146,35 @@ nonisolated enum YouTubePlayerScripts {
     })();
     """
 
+    /// Inline JS expression that returns the visible ad-skip button element or null.
+    static let findSkipButtonExpression = """
+    (function() {
+        var selector = '.ytp-skip-ad-button, .ytp-ad-skip-button,'
+            + ' .ytp-ad-skip-button-modern, .ytp-skip-ad-button-text';
+        var buttons = document.querySelectorAll(selector);
+        for (var i = 0; i < buttons.length; i++) {
+            var btn = buttons[i];
+            if (btn.disabled) continue;
+            var rect = btn.getBoundingClientRect();
+            if (rect.width === 0 && rect.height === 0) continue;
+            if (getComputedStyle(btn).visibility === 'hidden') continue;
+            return btn;
+        }
+        return null;
+    })()
+    """
+
+    /// Clicks the ad-skip button if one is currently skippable. Returns a bool.
+    static let skipAd = """
+    (function() {
+        var btn = \(findSkipButtonExpression);
+        if (!btn) return false;
+        var target = btn.closest('button') || btn;
+        target.click();
+        return true;
+    })();
+    """
+
     /// Returns `[{title, startSeconds}]` for chapters, empty when none exist.
     static let extractChapters = """
     (function() {

--- a/SakuraRSS/Views/Shared/YouTube Player/YouTubePlayerStyles.swift
+++ b/SakuraRSS/Views/Shared/YouTube Player/YouTubePlayerStyles.swift
@@ -188,36 +188,21 @@ nonisolated enum YouTubePlayerStyles {
         opacity: 0 !important;
         pointer-events: none !important;
     }
-    /* Keep the skip-ad button visible and tappable, styled as a full-width
-       strip at the bottom of the web view. */
+    /* Park the skip-ad button offscreen but keep it in the DOM and clickable so
+       our native Skip Ad button can trigger `.click()` on it. */
     .ytp-skip-ad-button, .ytp-ad-skip-button,
     .ytp-ad-skip-button-modern, .ytp-ad-skip-button-container,
     button[class*="skip"] {
-        display: flex !important;
+        display: block !important;
         visibility: visible !important;
-        align-items: center !important;
-        justify-content: center !important;
         position: fixed !important;
-        bottom: 0 !important;
-        left: 0 !important;
-        width: 100vw !important;
-        height: 48px !important;
-        opacity: 1 !important;
+        top: -9999px !important;
+        left: -9999px !important;
+        width: 1px !important;
+        height: 1px !important;
+        opacity: 0 !important;
         pointer-events: auto !important;
-        z-index: 9999999 !important;
-        background: rgba(0, 0, 0, 0.8) !important;
-        color: #fff !important;
-        font-size: 16px !important;
-        border: none !important;
-        border-radius: 0 !important;
-        margin: 0 !important;
-        padding: 0 !important;
-        box-sizing: border-box !important;
-    }
-    .ytp-skip-ad-button *, .ytp-ad-skip-button *,
-    .ytp-ad-skip-button-modern *, .ytp-ad-skip-button-container *,
-    button[class*="skip"] * {
-        border-radius: 0 !important;
+        z-index: -1 !important;
     }
     """
 

--- a/SakuraRSS/Views/Shared/YouTube Player/YouTubePlayerView+Background.swift
+++ b/SakuraRSS/Views/Shared/YouTube Player/YouTubePlayerView+Background.swift
@@ -2,24 +2,32 @@ import AVFoundation
 import SwiftUI
 import WebKit
 
-extension YouTubePlayerView {
+/// Applies the playback audio session exactly once per app launch. Re-running
+/// `setCategory`/`setActive` during scene transitions causes a brief audio drop.
+enum YouTubeAudioSession {
 
-    func activateBackgroundAudioSession() {
+    private static var isConfigured = false
+
+    static func configureForPlaybackIfNeeded() {
+        guard !isConfigured else { return }
         let session = AVAudioSession.sharedInstance()
         try? session.setCategory(.playback, mode: .moviePlayback)
         try? session.setActive(true)
+        isConfigured = true
+    }
+}
+
+extension YouTubePlayerView {
+
+    func activateBackgroundAudioSession() {
+        YouTubeAudioSession.configureForPlaybackIfNeeded()
     }
 
     func handleScenePhaseChange(_ newPhase: ScenePhase) {
         switch newPhase {
         case .background, .inactive:
             wantsPlaybackInBackground = isPlaying
-            activateBackgroundAudioSession()
-            if isPlaying {
-                resumePlaybackIfNeeded()
-            }
         case .active:
-            activateBackgroundAudioSession()
             if wantsPlaybackInBackground {
                 resumePlaybackIfNeeded()
                 wantsPlaybackInBackground = false
@@ -33,7 +41,10 @@ extension YouTubePlayerView {
         let script = """
         (function() {
             var v = document.querySelector('video');
-            if (v && v.paused) { v.play().catch(function(){}); }
+            if (v && v.paused && !v.ended && window.__ytUserPaused !== true) {
+                var p = v.play();
+                if (p && typeof p.catch === 'function') { p.catch(function(){}); }
+            }
         })();
         """
         webView?.evaluateJavaScript(script, completionHandler: nil)

--- a/SakuraRSS/Views/Shared/YouTube Player/YouTubePlayerView+Background.swift
+++ b/SakuraRSS/Views/Shared/YouTube Player/YouTubePlayerView+Background.swift
@@ -2,25 +2,33 @@ import AVFoundation
 import SwiftUI
 import WebKit
 
-/// Applies the playback audio session exactly once per app launch. Re-running
-/// `setCategory`/`setActive` during scene transitions causes a brief audio drop.
+/// Lifecycle helper for the YouTube player's audio session. Setting the category
+/// is separated from claiming the audio route so we don't interrupt other apps
+/// until the player actually starts playing, and we release the route on dismiss
+/// so other apps can resume.
 enum YouTubeAudioSession {
 
-    private static var isConfigured = false
-
-    static func configureForPlaybackIfNeeded() {
-        guard !isConfigured else { return }
+    static func prepare() {
         let session = AVAudioSession.sharedInstance()
         try? session.setCategory(.playback, mode: .moviePlayback)
-        try? session.setActive(true)
-        isConfigured = true
+    }
+
+    static func activate() {
+        try? AVAudioSession.sharedInstance().setActive(true)
+    }
+
+    static func deactivate() {
+        try? AVAudioSession.sharedInstance().setActive(
+            false, options: .notifyOthersOnDeactivation
+        )
     }
 }
 
 extension YouTubePlayerView {
 
     func activateBackgroundAudioSession() {
-        YouTubeAudioSession.configureForPlaybackIfNeeded()
+        YouTubeAudioSession.prepare()
+        YouTubeAudioSession.activate()
     }
 
     func handleScenePhaseChange(_ newPhase: ScenePhase) {

--- a/SakuraRSS/Views/Shared/YouTube Player/YouTubePlayerView+Helpers.swift
+++ b/SakuraRSS/Views/Shared/YouTube Player/YouTubePlayerView+Helpers.swift
@@ -46,6 +46,28 @@ extension YouTubePlayerView {
     }
 
     @ViewBuilder
+    var skipAdButton: some View {
+        Button {
+            skipAd()
+        } label: {
+            Label {
+                Text(String(localized: "YouTube.Ad.Skip", table: "Integrations"))
+            } icon: {
+                Image(systemName: "forward.end.fill")
+            }
+            .font(.subheadline.bold())
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+            .background(.ultraThinMaterial, in: Capsule())
+            .overlay {
+                Capsule()
+                    .strokeBorder(.white.opacity(0.25), lineWidth: 1)
+            }
+        }
+        .foregroundStyle(.white)
+    }
+
+    @ViewBuilder
     var feedAvatarView: some View {
         if let favicon {
             FaviconImage(favicon, size: 36, circle: true, skipInset: true)

--- a/SakuraRSS/Views/Shared/YouTube Player/YouTubePlayerView+Playback.swift
+++ b/SakuraRSS/Views/Shared/YouTube Player/YouTubePlayerView+Playback.swift
@@ -102,6 +102,10 @@ extension YouTubePlayerView {
         webView?.evaluateJavaScript(script, completionHandler: nil)
     }
 
+    func skipAd() {
+        webView?.evaluateJavaScript(YouTubePlayerScripts.skipAd) { _, _ in }
+    }
+
     func togglePiP() {
         let script = """
         (function() {

--- a/SakuraRSS/Views/Shared/YouTube Player/YouTubePlayerView.swift
+++ b/SakuraRSS/Views/Shared/YouTube Player/YouTubePlayerView.swift
@@ -307,7 +307,10 @@ struct YouTubePlayerView: View {
             wantsPlaybackInBackground = false
         }
         .onDisappear {
-            pauseForOtherPlayer()
+            if !isPiP {
+                pauseForOtherPlayer()
+                YouTubeAudioSession.deactivate()
+            }
         }
         .task {
             activateBackgroundAudioSession()

--- a/SakuraRSS/Views/Shared/YouTube Player/YouTubePlayerView.swift
+++ b/SakuraRSS/Views/Shared/YouTube Player/YouTubePlayerView.swift
@@ -17,6 +17,7 @@ struct YouTubePlayerView: View {
     @State private var duration: TimeInterval = 0
     @State var webView: WKWebView?
     @State var isAd = false
+    @State var isAdSkippable = false
     @State private var advertiserURL: URL?
     @State private var hasStartedPlaying = false
     @State private var isPiP = false
@@ -55,6 +56,7 @@ struct YouTubePlayerView: View {
                 duration: $duration,
                 webView: $webView,
                 isAd: $isAd,
+                isAdSkippable: $isAdSkippable,
                 advertiserURL: $advertiserURL,
                 videoAspectRatio: $videoAspectRatio,
                 isPiP: $isPiP,
@@ -74,6 +76,14 @@ struct YouTubePlayerView: View {
                 }
             }
             .animation(.smooth.speed(2.0), value: skippedSegmentMessage)
+            .overlay(alignment: .bottomTrailing) {
+                if isAd && isAdSkippable && !isPiP {
+                    skipAdButton
+                        .padding(12)
+                        .transition(.opacity.combined(with: .scale(scale: 0.9)))
+                }
+            }
+            .animation(.smooth.speed(2.0), value: isAd && isAdSkippable && !isPiP)
             .overlay {
                 if isPiP {
                     Color.black
@@ -139,12 +149,19 @@ struct YouTubePlayerView: View {
                         }
 
                         Button {
-                            fastForward()
+                            if isAd && isAdSkippable {
+                                skipAd()
+                            } else {
+                                fastForward()
+                            }
                         } label: {
-                            Image(systemName: "goforward.10")
+                            Image(systemName: (isAd && isAdSkippable)
+                                ? "forward.end.fill"
+                                : "goforward.10")
                                 .font(.title2)
+                                .contentTransition(.symbolEffect(.replace))
                         }
-                        .disabled(isAd)
+                        .disabled(isAd && !isAdSkippable)
 
                         Button {
                             enterFullscreen()

--- a/SakuraRSS/Views/Shared/YouTube Player/YouTubePlayerWebView.swift
+++ b/SakuraRSS/Views/Shared/YouTube Player/YouTubePlayerWebView.swift
@@ -30,7 +30,7 @@ struct YouTubePlayerWebView: UIViewRepresentable {
     }
 
     func makeUIView(context: Context) -> WKWebView {
-        YouTubeAudioSession.configureForPlaybackIfNeeded()
+        YouTubeAudioSession.prepare()
 
         let config = WKWebViewConfiguration()
         config.websiteDataStore = .default()
@@ -39,6 +39,11 @@ struct YouTubePlayerWebView: UIViewRepresentable {
         config.allowsPictureInPictureMediaPlayback = true
 
         let controller = WKUserContentController()
+        controller.addUserScript(WKUserScript(
+            source: YouTubePlayerScripts.pauseOverride,
+            injectionTime: .atDocumentStart,
+            forMainFrameOnly: false
+        ))
         controller.addUserScript(WKUserScript(
             source: YouTubePlayerScripts.backgroundPlaybackOverride,
             injectionTime: .atDocumentStart,

--- a/SakuraRSS/Views/Shared/YouTube Player/YouTubePlayerWebView.swift
+++ b/SakuraRSS/Views/Shared/YouTube Player/YouTubePlayerWebView.swift
@@ -30,10 +30,7 @@ struct YouTubePlayerWebView: UIViewRepresentable {
     }
 
     func makeUIView(context: Context) -> WKWebView {
-        // Configure audio session before load so the decoder picks up `.playback` from the first frame.
-        let session = AVAudioSession.sharedInstance()
-        try? session.setCategory(.playback, mode: .moviePlayback)
-        try? session.setActive(true)
+        YouTubeAudioSession.configureForPlaybackIfNeeded()
 
         let config = WKWebViewConfiguration()
         config.websiteDataStore = .default()
@@ -51,6 +48,11 @@ struct YouTubePlayerWebView: UIViewRepresentable {
             source: YouTubePlayerStyles.injectionScript(css: YouTubePlayerStyles.css),
             injectionTime: .atDocumentStart,
             forMainFrameOnly: true
+        ))
+        controller.addUserScript(WKUserScript(
+            source: YouTubePlayerScripts.pauseGuard,
+            injectionTime: .atDocumentEnd,
+            forMainFrameOnly: false
         ))
         controller.addUserScript(WKUserScript(
             source: YouTubePlayerScripts.pipEventBridge,

--- a/SakuraRSS/Views/Shared/YouTube Player/YouTubePlayerWebView.swift
+++ b/SakuraRSS/Views/Shared/YouTube Player/YouTubePlayerWebView.swift
@@ -11,6 +11,7 @@ struct YouTubePlayerWebView: UIViewRepresentable {
     @Binding var duration: TimeInterval
     @Binding var webView: WKWebView?
     @Binding var isAd: Bool
+    @Binding var isAdSkippable: Bool
     @Binding var advertiserURL: URL?
     @Binding var videoAspectRatio: CGFloat
     @Binding var isPiP: Bool
@@ -22,6 +23,7 @@ struct YouTubePlayerWebView: UIViewRepresentable {
             currentTime: $currentTime,
             duration: $duration,
             isAd: $isAd,
+            isAdSkippable: $isAdSkippable,
             advertiserURL: $advertiserURL,
             videoAspectRatio: $videoAspectRatio,
             isPiP: $isPiP,
@@ -133,6 +135,7 @@ struct YouTubePlayerWebView: UIViewRepresentable {
         @Binding var currentTime: TimeInterval
         @Binding var duration: TimeInterval
         @Binding var isAd: Bool
+        @Binding var isAdSkippable: Bool
         @Binding var advertiserURL: URL?
         @Binding var videoAspectRatio: CGFloat
         @Binding var isPiP: Bool
@@ -145,6 +148,7 @@ struct YouTubePlayerWebView: UIViewRepresentable {
             currentTime: Binding<TimeInterval>,
             duration: Binding<TimeInterval>,
             isAd: Binding<Bool>,
+            isAdSkippable: Binding<Bool>,
             advertiserURL: Binding<URL?>,
             videoAspectRatio: Binding<CGFloat>,
             isPiP: Binding<Bool>,
@@ -154,6 +158,7 @@ struct YouTubePlayerWebView: UIViewRepresentable {
             _currentTime = currentTime
             _duration = duration
             _isAd = isAd
+            _isAdSkippable = isAdSkippable
             _advertiserURL = advertiserURL
             _videoAspectRatio = videoAspectRatio
             _isPiP = isPiP
@@ -284,11 +289,13 @@ struct YouTubePlayerWebView: UIViewRepresentable {
                     var vw = video.videoWidth || 0;
                     var vh = video.videoHeight || 0;
                     var inPiP = document.pictureInPictureElement === video;
+                    var skipBtn = \(YouTubePlayerScripts.findSkipButtonExpression);
                     return {
                         playing: !video.paused,
                         currentTime: video.currentTime,
                         duration: video.duration || 0,
                         isAd: isAd,
+                        adSkippable: isAd && !!skipBtn,
                         advertiserURL: advURL,
                         videoWidth: vw,
                         videoHeight: vh,
@@ -313,6 +320,9 @@ struct YouTubePlayerWebView: UIViewRepresentable {
                                 self?.isAd = ad
                             }
                             // swiftlint:enable identifier_name
+                            if let skippable = dict["adSkippable"] as? Bool {
+                                self?.isAdSkippable = skippable
+                            }
                             if let urlStr = dict["advertiserURL"] as? String, !urlStr.isEmpty {
                                 self?.advertiserURL = URL(string: urlStr)
                             } else {

--- a/Shared/Strings/Integrations.xcstrings
+++ b/Shared/Strings/Integrations.xcstrings
@@ -2124,6 +2124,65 @@
           }
         }
       }
+    },
+    "YouTube.Ad.Skip": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anzeige überspringen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skip Ad"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ignorer la pub"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Salta annuncio"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "広告をスキップ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "광고 건너뛰기"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bỏ qua quảng cáo"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "跳过广告"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "略過廣告"
+          }
+        }
+      }
     }
   },
   "version": "1.1"


### PR DESCRIPTION
## Summary

### Stop the pause at the source
YouTube's player calls `video.pause()` itself on visibility changes, PiP transitions, and a few other internal hooks. Instead of reacting to those pauses (which always leaves a small audio gap), `pauseOverride` is injected at document start and replaces `HTMLMediaElement.prototype.pause`. It's a no-op unless Swift has first set `window.__ytUserPaused = true` (which both `togglePlayPause` and `pauseForOtherPlayer` already do before pausing) or the video has ended. With no pause ever happening, there's nothing to fade back from. The `pauseGuard` script stays as a safety net for native pauses that bypass JS (e.g. WebKit suspending media).

### Don't interrupt other apps until the user actually plays
Split the audio helper into three calls:

- `prepare()` – set `.playback` / `.moviePlayback`. Doesn't interrupt other audio on its own.
- `activate()` – `setActive(true)`. Called when the player view appears (autoplay starts playback).
- `deactivate()` – `setActive(false, .notifyOthersOnDeactivation)` – called on `onDisappear` when PiP isn't holding the video open, so other apps' audio resumes after the user leaves the player.

Scene-phase transitions no longer re-apply `setCategory` / `setActive`, which removes the audio routing blip.

### Native Skip Ad button
The playback observer now reports whether the YouTube skip button is present and visible, and exposes an `isAdSkippable` binding. When an ad is skippable:

- a native "Skip Ad" capsule appears in the bottom-right of the video area,
- the fast-forward button swaps to `forward.end.fill` and triggers the skip (works in PiP too since Sakura's transport controls are still visible below the PiP placeholder).

The actual skip is routed through YouTube's own button via `.click()`, so we don't reimplement their skip flow — we just drive their handler from a nicer UI. YouTube's skip button is no longer rendered as a full-width strip; it's parked offscreen so `.click()` still fires its handler, but the user only sees Sakura's button. Non-skippable ads leave the fast-forward button disabled as before. Localized for all existing languages.

## Test plan
- [ ] Start a YouTube video, background the app. Audio plays continuously with no fade-out/fade-in.
- [ ] Enter PiP, then background. Audio is continuous.
- [ ] Tap pause while playing. Video stays paused (`__ytUserPaused === true`, override calls through).
- [ ] Play another YouTube article – first video pauses and stays paused.
- [ ] Let a video play to the end. It stays ended (override respects `video.ended`).
- [ ] Start Spotify/Apple Music, open a YouTube article (music interrupted as expected), dismiss the view – the other app resumes.
- [ ] Open article with a skippable ad. The "Skip Ad" capsule appears after the countdown. Tapping skips the ad. The fast-forward button's icon switches to `forward.end.fill` and also skips.
- [ ] Non-skippable ad: no Skip Ad capsule, fast-forward stays disabled.
- [ ] Skippable ad while in PiP: fast-forward on Sakura's UI still skips.

https://claude.ai/code/session_01RdqhEaqcikqMKLyzkZ6P6e