### PR TITLE
Hide viewed content in feeds

### DIFF
--- a/SakuraRSS/Views/Feeds/FeedArticlesView.swift
+++ b/SakuraRSS/Views/Feeds/FeedArticlesView.swift
@@ -74,8 +74,9 @@ struct FeedArticlesView: View {
     }
 
     private func performRefresh() async {
-        try? await feedManager.refreshFeed(feed)
         captureVisibleSnapshot()
+        try? await feedManager.refreshFeed(feed)
+        extendVisibleSnapshot()
     }
 
     var body: some View {

--- a/SakuraRSS/Views/Feeds/FeedArticlesView.swift
+++ b/SakuraRSS/Views/Feeds/FeedArticlesView.swift
@@ -11,7 +11,7 @@ struct FeedArticlesView: View {
     @AppStorage("Display.MarkAllReadPosition") private var markAllReadPosition: MarkAllReadPosition = .bottom
     @AppStorage("Instagram.HideReels") private var hideReels: Bool = false
     @AppStorage("Articles.HideViewedContent") private var hideViewedContent: Bool = false
-    @State private var visibleArticleIDs: Set<Int64>?
+    @State private var visibility = ArticleVisibilityTracker()
 
     private var currentFeed: Feed {
         feedManager.feeds.first(where: { $0.id == feed.id }) ?? feed
@@ -48,40 +48,15 @@ struct FeedArticlesView: View {
         return articles
     }
 
-    private var filteredArticles: [Article] {
-        let articles = rawArticles
-        if hideViewedContent, let visibleArticleIDs {
-            return articles.filter { visibleArticleIDs.contains($0.id) }
-        }
-        return articles
-    }
-
-    private func captureVisibleSnapshot() {
-        guard hideViewedContent else {
-            visibleArticleIDs = nil
-            return
-        }
-        visibleArticleIDs = Set(rawArticles.filter { !$0.isRead }.map(\.id))
-    }
-
-    private func extendVisibleSnapshot() {
-        guard hideViewedContent else {
-            visibleArticleIDs = nil
-            return
-        }
-        let unreadIDs = Set(rawArticles.filter { !$0.isRead }.map(\.id))
-        visibleArticleIDs = (visibleArticleIDs ?? []).union(unreadIDs)
-    }
-
     private func performRefresh() async {
-        captureVisibleSnapshot()
+        visibility.capture(from: rawArticles, isEnabled: hideViewedContent)
         try? await feedManager.refreshFeed(feed)
-        extendVisibleSnapshot()
+        visibility.extend(from: rawArticles, isEnabled: hideViewedContent)
     }
 
     var body: some View {
         ArticlesView(
-            articles: filteredArticles,
+            articles: visibility.filter(rawArticles, isEnabled: hideViewedContent),
             title: currentFeed.title,
             subtitle: currentFeed.domain,
             feedKey: String(feed.id),
@@ -105,28 +80,17 @@ struct FeedArticlesView: View {
         .markAllReadToolbar(show: markAllReadPosition == .bottom) {
             feedManager.markAllRead(feed: feed)
         }
-        .task {
-            if visibleArticleIDs == nil {
-                captureVisibleSnapshot()
-            }
-        }
+        .trackArticleVisibility(
+            $visibility,
+            hideViewedContent: hideViewedContent,
+            loadedSinceDate: loadedSinceDate,
+            loadedCount: loadedCount,
+            rawArticles: { rawArticles }
+        )
         .onChange(of: batchingMode) { _, newMode in
             loadedSinceDate = newMode.initialSinceDate()
             loadedCount = newMode.initialCount()
-            captureVisibleSnapshot()
-        }
-        .onChange(of: loadedSinceDate) { _, _ in
-            extendVisibleSnapshot()
-        }
-        .onChange(of: loadedCount) { _, _ in
-            extendVisibleSnapshot()
-        }
-        .onChange(of: hideViewedContent) { _, newValue in
-            if newValue {
-                captureVisibleSnapshot()
-            } else {
-                visibleArticleIDs = nil
-            }
+            visibility.capture(from: rawArticles, isEnabled: hideViewedContent)
         }
     }
 }

--- a/SakuraRSS/Views/Feeds/FeedArticlesView.swift
+++ b/SakuraRSS/Views/Feeds/FeedArticlesView.swift
@@ -10,6 +10,8 @@ struct FeedArticlesView: View {
     @State private var loadedCount: Int = BatchingMode.current().initialCount()
     @AppStorage("Display.MarkAllReadPosition") private var markAllReadPosition: MarkAllReadPosition = .bottom
     @AppStorage("Instagram.HideReels") private var hideReels: Bool = false
+    @AppStorage("Articles.HideViewedContent") private var hideViewedContent: Bool = false
+    @State private var visibleArticleIDs: Set<Int64>?
 
     private var currentFeed: Feed {
         feedManager.feeds.first(where: { $0.id == feed.id }) ?? feed
@@ -31,7 +33,7 @@ struct FeedArticlesView: View {
         return nil
     }
 
-    private var filteredArticles: [Article] {
+    private var rawArticles: [Article] {
         var articles: [Article]
         if batchingMode.isCountBased {
             articles = feedManager.undatedArticles(for: feed)
@@ -44,6 +46,36 @@ struct FeedArticlesView: View {
             articles = articles.filter { !$0.url.contains("/reel/") }
         }
         return articles
+    }
+
+    private var filteredArticles: [Article] {
+        let articles = rawArticles
+        if hideViewedContent, let visibleArticleIDs {
+            return articles.filter { visibleArticleIDs.contains($0.id) }
+        }
+        return articles
+    }
+
+    private func captureVisibleSnapshot() {
+        guard hideViewedContent else {
+            visibleArticleIDs = nil
+            return
+        }
+        visibleArticleIDs = Set(rawArticles.filter { !$0.isRead }.map(\.id))
+    }
+
+    private func extendVisibleSnapshot() {
+        guard hideViewedContent else {
+            visibleArticleIDs = nil
+            return
+        }
+        let unreadIDs = Set(rawArticles.filter { !$0.isRead }.map(\.id))
+        visibleArticleIDs = (visibleArticleIDs ?? []).union(unreadIDs)
+    }
+
+    private func performRefresh() async {
+        try? await feedManager.refreshFeed(feed)
+        captureVisibleSnapshot()
     }
 
     var body: some View {
@@ -59,22 +91,41 @@ struct FeedArticlesView: View {
             isFeedCompactViewDomain: feed.isFeedCompactViewDomain,
             isTimelineViewDomain: feed.isTimelineViewDomain,
             onLoadMore: loadMoreAction,
-            onRefresh: { [feed] in
-                try? await feedManager.refreshFeed(feed)
+            onRefresh: {
+                await performRefresh()
             },
             onMarkAllRead: {
                 feedManager.markAllRead(feed: feed)
             }
         )
         .refreshable {
-            try? await feedManager.refreshFeed(feed)
+            await performRefresh()
         }
         .markAllReadToolbar(show: markAllReadPosition == .bottom) {
             feedManager.markAllRead(feed: feed)
         }
+        .task {
+            if visibleArticleIDs == nil {
+                captureVisibleSnapshot()
+            }
+        }
         .onChange(of: batchingMode) { _, newMode in
             loadedSinceDate = newMode.initialSinceDate()
             loadedCount = newMode.initialCount()
+            captureVisibleSnapshot()
+        }
+        .onChange(of: loadedSinceDate) { _, _ in
+            extendVisibleSnapshot()
+        }
+        .onChange(of: loadedCount) { _, _ in
+            extendVisibleSnapshot()
+        }
+        .onChange(of: hideViewedContent) { _, newValue in
+            if newValue {
+                captureVisibleSnapshot()
+            } else {
+                visibleArticleIDs = nil
+            }
         }
     }
 }

--- a/SakuraRSS/Views/Home/AllArticlesView.swift
+++ b/SakuraRSS/Views/Home/AllArticlesView.swift
@@ -108,7 +108,7 @@ struct AllArticlesView: View {
     @AppStorage("TodaysSummary.DismissedDate") private var todaysSummaryDismissedDate: String = ""
     @AppStorage("Instagram.HideReels") private var hideInstagramReels: Bool = false
     @AppStorage("Articles.HideViewedContent") private var hideViewedContent: Bool = false
-    @State private var visibleArticleIDs: Set<Int64>?
+    @State private var visibility = ArticleVisibilityTracker()
     @State private var whileYouSleptAvailable = false
     @State private var todaysSummaryAvailable = false
 
@@ -137,34 +137,13 @@ struct AllArticlesView: View {
     }
 
     private var displayedArticles: [Article] {
-        let articles = rawArticles
-        if hideViewedContent, let visibleArticleIDs {
-            return articles.filter { visibleArticleIDs.contains($0.id) }
-        }
-        return articles
-    }
-
-    private func captureVisibleSnapshot() {
-        guard hideViewedContent else {
-            visibleArticleIDs = nil
-            return
-        }
-        visibleArticleIDs = Set(rawArticles.filter { !$0.isRead }.map(\.id))
-    }
-
-    private func extendVisibleSnapshot() {
-        guard hideViewedContent else {
-            visibleArticleIDs = nil
-            return
-        }
-        let unreadIDs = Set(rawArticles.filter { !$0.isRead }.map(\.id))
-        visibleArticleIDs = (visibleArticleIDs ?? []).union(unreadIDs)
+        visibility.filter(rawArticles, isEnabled: hideViewedContent)
     }
 
     private func performRefresh() async {
-        captureVisibleSnapshot()
+        visibility.capture(from: rawArticles, isEnabled: hideViewedContent)
         await feedManager.refreshAllFeeds()
-        extendVisibleSnapshot()
+        visibility.extend(from: rawArticles, isEnabled: hideViewedContent)
     }
 
     private var loadMoreAction: (() -> Void)? {
@@ -271,7 +250,7 @@ struct AllArticlesView: View {
         .onChange(of: batchingMode) { _, newMode in
             loadedSinceDate = newMode.initialSinceDate()
             loadedCount = newMode.initialCount()
-            captureVisibleSnapshot()
+            visibility.capture(from: rawArticles, isEnabled: hideViewedContent)
         }
         .onAppear {
             refreshBookmarksTip()
@@ -347,23 +326,12 @@ struct AllArticlesView: View {
         .markAllReadToolbar(show: markAllReadPosition == .bottom) {
             feedManager.markAllRead()
         }
-        .task {
-            if visibleArticleIDs == nil {
-                captureVisibleSnapshot()
-            }
-        }
-        .onChange(of: loadedSinceDate) { _, _ in
-            extendVisibleSnapshot()
-        }
-        .onChange(of: loadedCount) { _, _ in
-            extendVisibleSnapshot()
-        }
-        .onChange(of: hideViewedContent) { _, newValue in
-            if newValue {
-                captureVisibleSnapshot()
-            } else {
-                visibleArticleIDs = nil
-            }
-        }
+        .trackArticleVisibility(
+            $visibility,
+            hideViewedContent: hideViewedContent,
+            loadedSinceDate: loadedSinceDate,
+            loadedCount: loadedCount,
+            rawArticles: { rawArticles }
+        )
     }
 }

--- a/SakuraRSS/Views/Home/AllArticlesView.swift
+++ b/SakuraRSS/Views/Home/AllArticlesView.swift
@@ -107,6 +107,8 @@ struct AllArticlesView: View {
     @AppStorage("WhileYouSlept.DismissedDate") private var whileYouSleptDismissedDate: String = ""
     @AppStorage("TodaysSummary.DismissedDate") private var todaysSummaryDismissedDate: String = ""
     @AppStorage("Instagram.HideReels") private var hideInstagramReels: Bool = false
+    @AppStorage("Articles.HideViewedContent") private var hideViewedContent: Bool = false
+    @State private var visibleArticleIDs: Set<Int64>?
     @State private var whileYouSleptAvailable = false
     @State private var todaysSummaryAvailable = false
 
@@ -121,7 +123,7 @@ struct AllArticlesView: View {
         || (todaysSummaryDismissedDate == todayDateKey && todaysSummaryAvailable)
     }
 
-    private var displayedArticles: [Article] {
+    private var rawArticles: [Article] {
         var articles: [Article]
         if batchingMode.isCountBased {
             articles = feedManager.articles(limit: loadedCount)
@@ -132,6 +134,37 @@ struct AllArticlesView: View {
             articles = articles.filter { !$0.url.contains("/reel/") }
         }
         return articles
+    }
+
+    private var displayedArticles: [Article] {
+        let articles = rawArticles
+        if hideViewedContent, let visibleArticleIDs {
+            return articles.filter { visibleArticleIDs.contains($0.id) }
+        }
+        return articles
+    }
+
+    private func captureVisibleSnapshot() {
+        guard hideViewedContent else {
+            visibleArticleIDs = nil
+            return
+        }
+        visibleArticleIDs = Set(rawArticles.filter { !$0.isRead }.map(\.id))
+    }
+
+    private func extendVisibleSnapshot() {
+        guard hideViewedContent else {
+            visibleArticleIDs = nil
+            return
+        }
+        let unreadIDs = Set(rawArticles.filter { !$0.isRead }.map(\.id))
+        visibleArticleIDs = (visibleArticleIDs ?? []).union(unreadIDs)
+    }
+
+    private func performRefresh() async {
+        captureVisibleSnapshot()
+        await feedManager.refreshAllFeeds()
+        extendVisibleSnapshot()
     }
 
     private var loadMoreAction: (() -> Void)? {
@@ -238,6 +271,7 @@ struct AllArticlesView: View {
         .onChange(of: batchingMode) { _, newMode in
             loadedSinceDate = newMode.initialSinceDate()
             loadedCount = newMode.initialCount()
+            captureVisibleSnapshot()
         }
         .onAppear {
             refreshBookmarksTip()
@@ -288,7 +322,7 @@ struct AllArticlesView: View {
             },
             onLoadMore: loadMoreAction,
             onRefresh: {
-                await feedManager.refreshAllFeeds()
+                await performRefresh()
             },
             onMarkAllRead: {
                 feedManager.markAllRead()
@@ -308,10 +342,28 @@ struct AllArticlesView: View {
             .padding(.bottom, 8)
         }
         .refreshable {
-            await feedManager.refreshAllFeeds()
+            await performRefresh()
         }
         .markAllReadToolbar(show: markAllReadPosition == .bottom) {
             feedManager.markAllRead()
+        }
+        .task {
+            if visibleArticleIDs == nil {
+                captureVisibleSnapshot()
+            }
+        }
+        .onChange(of: loadedSinceDate) { _, _ in
+            extendVisibleSnapshot()
+        }
+        .onChange(of: loadedCount) { _, _ in
+            extendVisibleSnapshot()
+        }
+        .onChange(of: hideViewedContent) { _, newValue in
+            if newValue {
+                captureVisibleSnapshot()
+            } else {
+                visibleArticleIDs = nil
+            }
         }
     }
 }

--- a/SakuraRSS/Views/Home/HomeSectionView.swift
+++ b/SakuraRSS/Views/Home/HomeSectionView.swift
@@ -11,8 +11,10 @@ struct HomeSectionView: View {
     @State private var loadedCount: Int = BatchingMode.current().initialCount()
     @AppStorage("Display.MarkAllReadPosition") private var markAllReadPosition: MarkAllReadPosition = .bottom
     @AppStorage("Instagram.HideReels") private var hideInstagramReels: Bool = false
+    @AppStorage("Articles.HideViewedContent") private var hideViewedContent: Bool = false
+    @State private var visibleArticleIDs: Set<Int64>?
 
-    private var displayedArticles: [Article] {
+    private var rawArticles: [Article] {
         var articles: [Article]
         if batchingMode.isCountBased {
             articles = feedManager.articles(for: section, limit: loadedCount)
@@ -23,6 +25,37 @@ struct HomeSectionView: View {
             articles = articles.filter { !$0.url.contains("/reel/") }
         }
         return articles
+    }
+
+    private var displayedArticles: [Article] {
+        let articles = rawArticles
+        if hideViewedContent, let visibleArticleIDs {
+            return articles.filter { visibleArticleIDs.contains($0.id) }
+        }
+        return articles
+    }
+
+    private func captureVisibleSnapshot() {
+        guard hideViewedContent else {
+            visibleArticleIDs = nil
+            return
+        }
+        visibleArticleIDs = Set(rawArticles.filter { !$0.isRead }.map(\.id))
+    }
+
+    private func extendVisibleSnapshot() {
+        guard hideViewedContent else {
+            visibleArticleIDs = nil
+            return
+        }
+        let unreadIDs = Set(rawArticles.filter { !$0.isRead }.map(\.id))
+        visibleArticleIDs = (visibleArticleIDs ?? []).union(unreadIDs)
+    }
+
+    private func performRefresh() async {
+        captureVisibleSnapshot()
+        await feedManager.refreshAllFeeds()
+        extendVisibleSnapshot()
     }
 
     private var loadMoreAction: (() -> Void)? {
@@ -51,21 +84,40 @@ struct HomeSectionView: View {
             isFeedViewDomain: section == .social,
             onLoadMore: loadMoreAction,
             onRefresh: {
-                await feedManager.refreshAllFeeds()
+                await performRefresh()
             },
             onMarkAllRead: {
                 feedManager.markAllRead(for: section)
             }
         )
         .refreshable {
-            await feedManager.refreshAllFeeds()
+            await performRefresh()
         }
         .markAllReadToolbar(show: markAllReadPosition == .bottom) {
             feedManager.markAllRead(for: section)
         }
+        .task {
+            if visibleArticleIDs == nil {
+                captureVisibleSnapshot()
+            }
+        }
         .onChange(of: batchingMode) { _, newMode in
             loadedSinceDate = newMode.initialSinceDate()
             loadedCount = newMode.initialCount()
+            captureVisibleSnapshot()
+        }
+        .onChange(of: loadedSinceDate) { _, _ in
+            extendVisibleSnapshot()
+        }
+        .onChange(of: loadedCount) { _, _ in
+            extendVisibleSnapshot()
+        }
+        .onChange(of: hideViewedContent) { _, newValue in
+            if newValue {
+                captureVisibleSnapshot()
+            } else {
+                visibleArticleIDs = nil
+            }
         }
     }
 }

--- a/SakuraRSS/Views/Home/HomeSectionView.swift
+++ b/SakuraRSS/Views/Home/HomeSectionView.swift
@@ -12,7 +12,7 @@ struct HomeSectionView: View {
     @AppStorage("Display.MarkAllReadPosition") private var markAllReadPosition: MarkAllReadPosition = .bottom
     @AppStorage("Instagram.HideReels") private var hideInstagramReels: Bool = false
     @AppStorage("Articles.HideViewedContent") private var hideViewedContent: Bool = false
-    @State private var visibleArticleIDs: Set<Int64>?
+    @State private var visibility = ArticleVisibilityTracker()
 
     private var rawArticles: [Article] {
         var articles: [Article]
@@ -27,35 +27,10 @@ struct HomeSectionView: View {
         return articles
     }
 
-    private var displayedArticles: [Article] {
-        let articles = rawArticles
-        if hideViewedContent, let visibleArticleIDs {
-            return articles.filter { visibleArticleIDs.contains($0.id) }
-        }
-        return articles
-    }
-
-    private func captureVisibleSnapshot() {
-        guard hideViewedContent else {
-            visibleArticleIDs = nil
-            return
-        }
-        visibleArticleIDs = Set(rawArticles.filter { !$0.isRead }.map(\.id))
-    }
-
-    private func extendVisibleSnapshot() {
-        guard hideViewedContent else {
-            visibleArticleIDs = nil
-            return
-        }
-        let unreadIDs = Set(rawArticles.filter { !$0.isRead }.map(\.id))
-        visibleArticleIDs = (visibleArticleIDs ?? []).union(unreadIDs)
-    }
-
     private func performRefresh() async {
-        captureVisibleSnapshot()
+        visibility.capture(from: rawArticles, isEnabled: hideViewedContent)
         await feedManager.refreshAllFeeds()
-        extendVisibleSnapshot()
+        visibility.extend(from: rawArticles, isEnabled: hideViewedContent)
     }
 
     private var loadMoreAction: (() -> Void)? {
@@ -76,7 +51,7 @@ struct HomeSectionView: View {
 
     var body: some View {
         ArticlesView(
-            articles: displayedArticles,
+            articles: visibility.filter(rawArticles, isEnabled: hideViewedContent),
             title: section.localizedTitle,
             feedKey: "home.\(section.rawValue)",
             isVideoFeed: section == .video,
@@ -96,28 +71,17 @@ struct HomeSectionView: View {
         .markAllReadToolbar(show: markAllReadPosition == .bottom) {
             feedManager.markAllRead(for: section)
         }
-        .task {
-            if visibleArticleIDs == nil {
-                captureVisibleSnapshot()
-            }
-        }
+        .trackArticleVisibility(
+            $visibility,
+            hideViewedContent: hideViewedContent,
+            loadedSinceDate: loadedSinceDate,
+            loadedCount: loadedCount,
+            rawArticles: { rawArticles }
+        )
         .onChange(of: batchingMode) { _, newMode in
             loadedSinceDate = newMode.initialSinceDate()
             loadedCount = newMode.initialCount()
-            captureVisibleSnapshot()
-        }
-        .onChange(of: loadedSinceDate) { _, _ in
-            extendVisibleSnapshot()
-        }
-        .onChange(of: loadedCount) { _, _ in
-            extendVisibleSnapshot()
-        }
-        .onChange(of: hideViewedContent) { _, newValue in
-            if newValue {
-                captureVisibleSnapshot()
-            } else {
-                visibleArticleIDs = nil
-            }
+            visibility.capture(from: rawArticles, isEnabled: hideViewedContent)
         }
     }
 }

--- a/SakuraRSS/Views/Home/ListSectionView.swift
+++ b/SakuraRSS/Views/Home/ListSectionView.swift
@@ -10,12 +10,45 @@ struct ListSectionView: View {
     @State private var loadedSinceDate: Date = BatchingMode.current().initialSinceDate()
     @State private var loadedCount: Int = BatchingMode.current().initialCount()
     @AppStorage("Display.MarkAllReadPosition") private var markAllReadPosition: MarkAllReadPosition = .bottom
+    @AppStorage("Articles.HideViewedContent") private var hideViewedContent: Bool = false
+    @State private var visibleArticleIDs: Set<Int64>?
 
-    private var displayedArticles: [Article] {
+    private var rawArticles: [Article] {
         if batchingMode.isCountBased {
             return feedManager.articles(for: list, limit: loadedCount)
         }
         return feedManager.articles(for: list, since: loadedSinceDate)
+    }
+
+    private var displayedArticles: [Article] {
+        let articles = rawArticles
+        if hideViewedContent, let visibleArticleIDs {
+            return articles.filter { visibleArticleIDs.contains($0.id) }
+        }
+        return articles
+    }
+
+    private func captureVisibleSnapshot() {
+        guard hideViewedContent else {
+            visibleArticleIDs = nil
+            return
+        }
+        visibleArticleIDs = Set(rawArticles.filter { !$0.isRead }.map(\.id))
+    }
+
+    private func extendVisibleSnapshot() {
+        guard hideViewedContent else {
+            visibleArticleIDs = nil
+            return
+        }
+        let unreadIDs = Set(rawArticles.filter { !$0.isRead }.map(\.id))
+        visibleArticleIDs = (visibleArticleIDs ?? []).union(unreadIDs)
+    }
+
+    private func performRefresh() async {
+        captureVisibleSnapshot()
+        await feedManager.refreshAllFeeds()
+        extendVisibleSnapshot()
     }
 
     private var loadMoreAction: (() -> Void)? {
@@ -41,21 +74,40 @@ struct ListSectionView: View {
             feedKey: "list.\(list.id)",
             onLoadMore: loadMoreAction,
             onRefresh: {
-                await feedManager.refreshAllFeeds()
+                await performRefresh()
             },
             onMarkAllRead: {
                 feedManager.markAllRead(for: list)
             }
         )
         .refreshable {
-            await feedManager.refreshAllFeeds()
+            await performRefresh()
         }
         .markAllReadToolbar(show: markAllReadPosition == .bottom) {
             feedManager.markAllRead(for: list)
         }
+        .task {
+            if visibleArticleIDs == nil {
+                captureVisibleSnapshot()
+            }
+        }
         .onChange(of: batchingMode) { _, newMode in
             loadedSinceDate = newMode.initialSinceDate()
             loadedCount = newMode.initialCount()
+            captureVisibleSnapshot()
+        }
+        .onChange(of: loadedSinceDate) { _, _ in
+            extendVisibleSnapshot()
+        }
+        .onChange(of: loadedCount) { _, _ in
+            extendVisibleSnapshot()
+        }
+        .onChange(of: hideViewedContent) { _, newValue in
+            if newValue {
+                captureVisibleSnapshot()
+            } else {
+                visibleArticleIDs = nil
+            }
         }
     }
 }

--- a/SakuraRSS/Views/Home/ListSectionView.swift
+++ b/SakuraRSS/Views/Home/ListSectionView.swift
@@ -11,7 +11,7 @@ struct ListSectionView: View {
     @State private var loadedCount: Int = BatchingMode.current().initialCount()
     @AppStorage("Display.MarkAllReadPosition") private var markAllReadPosition: MarkAllReadPosition = .bottom
     @AppStorage("Articles.HideViewedContent") private var hideViewedContent: Bool = false
-    @State private var visibleArticleIDs: Set<Int64>?
+    @State private var visibility = ArticleVisibilityTracker()
 
     private var rawArticles: [Article] {
         if batchingMode.isCountBased {
@@ -20,35 +20,10 @@ struct ListSectionView: View {
         return feedManager.articles(for: list, since: loadedSinceDate)
     }
 
-    private var displayedArticles: [Article] {
-        let articles = rawArticles
-        if hideViewedContent, let visibleArticleIDs {
-            return articles.filter { visibleArticleIDs.contains($0.id) }
-        }
-        return articles
-    }
-
-    private func captureVisibleSnapshot() {
-        guard hideViewedContent else {
-            visibleArticleIDs = nil
-            return
-        }
-        visibleArticleIDs = Set(rawArticles.filter { !$0.isRead }.map(\.id))
-    }
-
-    private func extendVisibleSnapshot() {
-        guard hideViewedContent else {
-            visibleArticleIDs = nil
-            return
-        }
-        let unreadIDs = Set(rawArticles.filter { !$0.isRead }.map(\.id))
-        visibleArticleIDs = (visibleArticleIDs ?? []).union(unreadIDs)
-    }
-
     private func performRefresh() async {
-        captureVisibleSnapshot()
+        visibility.capture(from: rawArticles, isEnabled: hideViewedContent)
         await feedManager.refreshAllFeeds()
-        extendVisibleSnapshot()
+        visibility.extend(from: rawArticles, isEnabled: hideViewedContent)
     }
 
     private var loadMoreAction: (() -> Void)? {
@@ -69,7 +44,7 @@ struct ListSectionView: View {
 
     var body: some View {
         ArticlesView(
-            articles: displayedArticles,
+            articles: visibility.filter(rawArticles, isEnabled: hideViewedContent),
             title: list.name,
             feedKey: "list.\(list.id)",
             onLoadMore: loadMoreAction,
@@ -86,28 +61,17 @@ struct ListSectionView: View {
         .markAllReadToolbar(show: markAllReadPosition == .bottom) {
             feedManager.markAllRead(for: list)
         }
-        .task {
-            if visibleArticleIDs == nil {
-                captureVisibleSnapshot()
-            }
-        }
+        .trackArticleVisibility(
+            $visibility,
+            hideViewedContent: hideViewedContent,
+            loadedSinceDate: loadedSinceDate,
+            loadedCount: loadedCount,
+            rawArticles: { rawArticles }
+        )
         .onChange(of: batchingMode) { _, newMode in
             loadedSinceDate = newMode.initialSinceDate()
             loadedCount = newMode.initialCount()
-            captureVisibleSnapshot()
-        }
-        .onChange(of: loadedSinceDate) { _, _ in
-            extendVisibleSnapshot()
-        }
-        .onChange(of: loadedCount) { _, _ in
-            extendVisibleSnapshot()
-        }
-        .onChange(of: hideViewedContent) { _, newValue in
-            if newValue {
-                captureVisibleSnapshot()
-            } else {
-                visibleArticleIDs = nil
-            }
+            visibility.capture(from: rawArticles, isEnabled: hideViewedContent)
         }
     }
 }

--- a/SakuraRSS/Views/More/Settings/BrowsingSettingsView.swift
+++ b/SakuraRSS/Views/More/Settings/BrowsingSettingsView.swift
@@ -4,11 +4,14 @@ struct BrowsingSettingsView: View {
 
     @AppStorage("Articles.BatchingMode") private var batchingMode: BatchingMode = .day1
     @AppStorage("Articles.AutoLoadWhileScrolling") private var autoLoadWhileScrolling: Bool = false
+    @AppStorage("Articles.HideViewedContent") private var hideViewedContent: Bool = false
     @AppStorage("Display.ScrollMarkAsRead") private var scrollMarkAsRead: Bool = false
 
     var body: some View {
         List {
             Section {
+                Toggle(String(localized: "HideViewedContent", table: "Settings"),
+                       isOn: $hideViewedContent)
                 Picker(selection: $batchingMode) {
                     Section {
                         Text(String(localized: "Batching.Day1", table: "Settings"))
@@ -34,7 +37,7 @@ struct BrowsingSettingsView: View {
                     Text(String(localized: "BatchingMode", table: "Settings"))
                 }
             } header: {
-                Text(String(localized: "Section.ContentGrouping", table: "Settings"))
+                Text(String(localized: "Section.Feeds", table: "Settings"))
             } footer: {
                 Text(String(localized: "Batching.Footer", table: "Settings"))
             }

--- a/SakuraRSS/Views/Shared/Articles/ArticleVisibilityTracker.swift
+++ b/SakuraRSS/Views/Shared/Articles/ArticleVisibilityTracker.swift
@@ -1,0 +1,79 @@
+import SwiftUI
+
+/// Tracks which article IDs are visible when Hide Viewed Content is on.
+/// The snapshot is captured on first load and on refresh, extended on pagination,
+/// and preserved across read-state changes so read articles remain visible until
+/// the next explicit refresh.
+struct ArticleVisibilityTracker {
+    var visibleIDs: Set<Int64>?
+
+    func filter(_ articles: [Article], isEnabled: Bool) -> [Article] {
+        guard isEnabled, let visibleIDs else { return articles }
+        return articles.filter { visibleIDs.contains($0.id) }
+    }
+
+    mutating func capture(from articles: [Article], isEnabled: Bool) {
+        guard isEnabled else {
+            visibleIDs = nil
+            return
+        }
+        visibleIDs = Set(articles.filter { !$0.isRead }.map(\.id))
+    }
+
+    mutating func extend(from articles: [Article], isEnabled: Bool) {
+        guard isEnabled else {
+            visibleIDs = nil
+            return
+        }
+        let unreadIDs = Set(articles.filter { !$0.isRead }.map(\.id))
+        visibleIDs = (visibleIDs ?? []).union(unreadIDs)
+    }
+}
+
+private struct TrackArticleVisibilityModifier: ViewModifier {
+    @Binding var tracker: ArticleVisibilityTracker
+    let hideViewedContent: Bool
+    let loadedSinceDate: Date
+    let loadedCount: Int
+    let rawArticles: () -> [Article]
+
+    func body(content: Content) -> some View {
+        content
+            .task {
+                if tracker.visibleIDs == nil {
+                    tracker.capture(from: rawArticles(), isEnabled: hideViewedContent)
+                }
+            }
+            .onChange(of: loadedSinceDate) { _, _ in
+                tracker.extend(from: rawArticles(), isEnabled: hideViewedContent)
+            }
+            .onChange(of: loadedCount) { _, _ in
+                tracker.extend(from: rawArticles(), isEnabled: hideViewedContent)
+            }
+            .onChange(of: hideViewedContent) { _, newValue in
+                if newValue {
+                    tracker.capture(from: rawArticles(), isEnabled: newValue)
+                } else {
+                    tracker.visibleIDs = nil
+                }
+            }
+    }
+}
+
+extension View {
+    func trackArticleVisibility(
+        _ tracker: Binding<ArticleVisibilityTracker>,
+        hideViewedContent: Bool,
+        loadedSinceDate: Date,
+        loadedCount: Int,
+        rawArticles: @escaping () -> [Article]
+    ) -> some View {
+        modifier(TrackArticleVisibilityModifier(
+            tracker: tracker,
+            hideViewedContent: hideViewedContent,
+            loadedSinceDate: loadedSinceDate,
+            loadedCount: loadedCount,
+            rawArticles: rawArticles
+        ))
+    }
+}

--- a/Shared/Strings/Settings.xcstrings
+++ b/Shared/Strings/Settings.xcstrings
@@ -5016,65 +5016,6 @@
         }
       }
     },
-    "Section.ContentGrouping": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Inhaltsgruppierung"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Content Grouping"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Regroupement du contenu"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Raggruppamento contenuti"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "コンテンツのグループ化"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "콘텐츠 그룹화"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nhóm nội dung"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "内容分组"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "內容分組"
-          }
-        }
-      }
-    },
     "Section.Data": {
       "extractionState": "manual",
       "localizations": {
@@ -5897,6 +5838,124 @@
           "stringUnit": {
             "state": "translated",
             "value": "閱讀服務"
+          }
+        }
+      }
+    },
+    "Section.Feeds": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Feeds"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Feeds"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Flux"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Feed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フィード"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "피드"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nguồn cấp"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "订阅源"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "訂閱源"
+          }
+        }
+      }
+    },
+    "HideViewedContent": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gesehene Inhalte ausblenden"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide Viewed Content"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Masquer le contenu consulté"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nascondi contenuti visti"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "閲覧済みのコンテンツを非表示"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "본 콘텐츠 숨기기"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ẩn nội dung đã xem"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隐藏已阅内容"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隱藏已閱內容"
           }
         }
       }


### PR DESCRIPTION
## Summary
- Renamed the **Content Grouping** section in Profile > Reading to **Feeds** and added a **Hide Viewed Content** toggle as its first item.
- When enabled, opening a feed snapshots the IDs of articles that are unread at load time and filters the visible list to that snapshot. Articles the user reads during the current session stay visible until the next manual refresh, at which point the snapshot is recomputed and read content is hidden.
- Loading more batches extends the snapshot with newly fetched unread articles so pagination keeps working.
- Localized the new `Section.Feeds` and `HideViewedContent` strings into every supported language and removed the now-unused `Section.ContentGrouping` key.

## Test plan
- [ ] In Profile > Reading, confirm the section header reads "Feeds" and the first row is the new "Hide Viewed Content" toggle.
- [ ] With the toggle off, verify feed article lists behave as before.
- [ ] With the toggle on, open a feed with mixed read/unread articles and confirm only unread items are shown on first appearance.
- [ ] Read an article from that list and return; verify it remains visible until a pull-to-refresh is performed.
- [ ] Pull to refresh and confirm previously read articles disappear.
- [ ] Tap "Load more" and confirm additional unread articles from the extended range appear without removing currently visible items.
- [ ] Switch batching modes and confirm the filter behaves correctly after the mode change.
- [ ] Toggle Hide Viewed Content off and on again inside a feed and confirm the snapshot is cleared/recaptured accordingly.

https://claude.ai/code/session_01V6XDScY269gcYZpPgVpvAH

---
_Generated by [Claude Code](https://claude.ai/code/session_01V6XDScY269gcYZpPgVpvAH)_