### PR TITLE
Debounce mark-as-read DB writes to 250ms during scroll

### DIFF
--- a/SakuraRSS/Classes/Feed Manager/FeedManager+PendingReads.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+PendingReads.swift
@@ -2,6 +2,8 @@ import Foundation
 
 extension FeedManager {
 
+    static let pendingReadsDebounceInterval: DispatchTimeInterval = .milliseconds(250)
+
     /// True if persisted as read or queued for the next flush.
     func isRead(_ article: Article) -> Bool {
         article.isRead || pendingReadIDs.contains(article.id)
@@ -12,9 +14,12 @@ extension FeedManager {
               pendingReadIDs.insert(article.id).inserted else { return }
         decrementUnreadCount(feedID: article.feedID)
         updateBadgeCount()
+        schedulePendingReadsFlush()
     }
 
     func flushDebouncedReads() {
+        pendingReadsFlushWorkItem?.cancel()
+        pendingReadsFlushWorkItem = nil
         guard !pendingReadIDs.isEmpty else { return }
         let ids = pendingReadIDs
         pendingReadIDs.removeAll()
@@ -27,6 +32,20 @@ extension FeedManager {
         Task.detached(priority: .utility) {
             try? dbm.updateLastAccessed(articleIDs: idArray)
         }
+    }
+
+    /// Coalesces rapid scroll-driven mark-read events into one DB write per debounce window.
+    private func schedulePendingReadsFlush() {
+        guard pendingReadsFlushWorkItem == nil else { return }
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            self.flushDebouncedReads()
+        }
+        pendingReadsFlushWorkItem = workItem
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + Self.pendingReadsDebounceInterval,
+            execute: workItem
+        )
     }
 
 }

--- a/SakuraRSS/Classes/Feed Manager/FeedManager.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager.swift
@@ -34,11 +34,12 @@ final class FeedManager {
     private(set) var unreadCounts: [Int64: Int] = [:]
     private(set) var feedsByID: [Int64: Feed] = [:]
 
-    /// Queued mark-read IDs; flushed on scroll idle or backgrounding.
+    /// Queued mark-read IDs; flushed every 250ms while scrolling, on idle, or on backgrounding.
     var pendingReadIDs: Set<Int64> = []
     @ObservationIgnored var refreshTask: Task<Void, Never>?
 
     @ObservationIgnored var currentScrollPhase: ScrollPhase = .idle
+    @ObservationIgnored var pendingReadsFlushWorkItem: DispatchWorkItem?
 
     let database = DatabaseManager.shared
 


### PR DESCRIPTION
## Summary

- Scroll-driven mark-as-read events are now coalesced through a 250ms `DispatchWorkItem` so the SQLite `UPDATE` runs at most four times per second during continuous scrolling, instead of accumulating until scroll-idle and writing one large batch.
- `flushDebouncedReads()` cancels any pending timer, so the existing eager flushes (`onScrollPhaseChange == .idle`, `UIApplication.willResignActiveNotification`) still drain the queue immediately.
- No changes to the queueing semantics: `pendingReadIDs` still backs `isRead(_:)`, the unread-count decrement, and the badge update.

## Implementation notes

- New `pendingReadsFlushWorkItem` lives on `FeedManager` as `@ObservationIgnored` to avoid spurious view invalidations.
- Debounce interval is exposed as `FeedManager.pendingReadsDebounceInterval` (250ms) for clarity.
- Timer is scheduled on the main queue, matching how `markReadOnScroll` and `flushDebouncedReads` were already invoked.

## Test plan

- [ ] Enable Display.ScrollMarkAsRead, then fast-scroll a long feed; confirm articles are marked read in batches and no duplicate DB writes occur per ID.
- [ ] Slow-scroll past a few articles and stop; confirm the queue flushes within ~250ms (debounce) or immediately on scroll-idle.
- [ ] Background the app mid-scroll; confirm queued IDs persist via the `willResignActive` flush.
- [ ] Verify unread badge / per-feed unread counts decrement immediately when scrolling past, regardless of when the DB write lands.

https://claude.ai/code/session_014GVEJ4WbJshku52hBi2Ub6

---
_Generated by [Claude Code](https://claude.ai/code/session_014GVEJ4WbJshku52hBi2Ub6)_