### PR TITLE
Hide scroll-read articles when swipe-refreshing with Hide Viewed Content on

### DIFF
--- a/SakuraRSS/Views/Feeds/FeedArticlesView.swift
+++ b/SakuraRSS/Views/Feeds/FeedArticlesView.swift
@@ -49,6 +49,7 @@ struct FeedArticlesView: View {
     }
 
     private func performRefresh() async {
+        feedManager.flushDebouncedReads()
         visibility.capture(from: rawArticles, isEnabled: hideViewedContent)
         try? await feedManager.refreshFeed(feed)
         visibility.extend(from: rawArticles, isEnabled: hideViewedContent)

--- a/SakuraRSS/Views/Home/AllArticlesView.swift
+++ b/SakuraRSS/Views/Home/AllArticlesView.swift
@@ -141,6 +141,7 @@ struct AllArticlesView: View {
     }
 
     private func performRefresh() async {
+        feedManager.flushDebouncedReads()
         visibility.capture(from: rawArticles, isEnabled: hideViewedContent)
         await feedManager.refreshAllFeeds()
         visibility.extend(from: rawArticles, isEnabled: hideViewedContent)

--- a/SakuraRSS/Views/Home/HomeSectionView.swift
+++ b/SakuraRSS/Views/Home/HomeSectionView.swift
@@ -28,6 +28,7 @@ struct HomeSectionView: View {
     }
 
     private func performRefresh() async {
+        feedManager.flushDebouncedReads()
         visibility.capture(from: rawArticles, isEnabled: hideViewedContent)
         await feedManager.refreshAllFeeds()
         visibility.extend(from: rawArticles, isEnabled: hideViewedContent)

--- a/SakuraRSS/Views/Home/ListSectionView.swift
+++ b/SakuraRSS/Views/Home/ListSectionView.swift
@@ -21,6 +21,7 @@ struct ListSectionView: View {
     }
 
     private func performRefresh() async {
+        feedManager.flushDebouncedReads()
         visibility.capture(from: rawArticles, isEnabled: hideViewedContent)
         await feedManager.refreshAllFeeds()
         visibility.extend(from: rawArticles, isEnabled: hideViewedContent)


### PR DESCRIPTION
## Summary
- Flush `pendingReadIDs` before the visibility snapshot captures on pull-to-refresh, so articles marked read via scroll-past are persisted and excluded from the new snapshot.
- Without the flush, `ArticleVisibilityTracker.capture` saw `article.isRead == false` for in-session scroll reads and kept them visible even with Hide Viewed Content on.
- Applied to `FeedArticlesView`, `AllArticlesView`, `HomeSectionView`, and `ListSectionView` — the four places that wire `.refreshable` through `performRefresh`.

## Test plan
- [ ] Enable Hide Viewed Content in Browsing settings.
- [ ] On Home, scroll past several articles (mark-read-on-scroll enabled) without tapping anything, then swipe to refresh — verify those articles disappear immediately.
- [ ] Repeat inside an individual feed (`FeedArticlesView`).
- [ ] Repeat on a custom list (`ListSectionView`) and a section like Social/Videos/Audio (`HomeSectionView`).
- [ ] Confirm newly fetched unread articles still appear after the refresh completes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UCWagYfcS4YRmy8KnzNaaV)_