### PR TITLE
Fix auto load-more not triggering on single-post feeds

### DIFF
--- a/SakuraRSS/Views/Shared/Articles/ArticlesView.swift
+++ b/SakuraRSS/Views/Shared/Articles/ArticlesView.swift
@@ -234,6 +234,8 @@ struct LoadPreviousArticlesButton: View {
                 }
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 12)
+                .onAppear { isVisible = true }
+                .onDisappear { isVisible = false }
                 .onScrollVisibilityChange(threshold: 0.1) { visible in
                     isVisible = visible
                 }


### PR DESCRIPTION
## Summary
- When a feed contains only one article, the `LoadPreviousArticlesButton` (in auto-load-while-scrolling mode) showed the spinner and "Loading older content…" label but never actually called the load action.
- Root cause: the trigger relied solely on `onScrollVisibilityChange`, which doesn't fire when the content fits on screen (no scrolling occurs), leaving `isVisible` stuck at `false` and the `task(id:)` guard short-circuiting before invoking `action()`.
- Drive `isVisible` from `onAppear`/`onDisappear` in addition to scroll visibility, so the load triggers even when the content fits on screen.

## Test plan
- [ ] Open a feed that contains a single post with auto-load-while-scrolling enabled and confirm older content loads automatically.
- [ ] Open a feed with many posts and confirm auto-load still kicks in only when the loader scrolls into view.
- [ ] Toggle auto-load off and confirm the manual "Show Older Content" button still works.

https://claude.ai/code/session_01BwQNZv3Tagsa82rZdhBd3u

---
_Generated by [Claude Code](https://claude.ai/code/session_01BwQNZv3Tagsa82rZdhBd3u)_