### PR TITLE
Batch article inserts across feeds during refresh

### DIFF
--- a/SakuraRSS/Classes/Feed Manager/FeedManager+ArticleInsertCollector.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+ArticleInsertCollector.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// Accumulates parsed articles across a multi-feed refresh so they can be written
+/// to the database in a single transaction at the end. This avoids per-feed inserts
+/// causing the home article list to re-sort/jump around during eager reloads.
+actor ArticleInsertCollector {
+
+    struct Pending: Sendable {
+        let feedID: Int64
+        let items: [ArticleInsertItem]
+        let feedTitleForSpotlight: String
+    }
+
+    private var pending: [Pending] = []
+
+    func add(feedID: Int64, items: [ArticleInsertItem], feedTitleForSpotlight: String) {
+        guard !items.isEmpty else { return }
+        pending.append(Pending(
+            feedID: feedID, items: items, feedTitleForSpotlight: feedTitleForSpotlight
+        ))
+    }
+
+    func drain() -> [Pending] {
+        let out = pending
+        pending.removeAll(keepingCapacity: false)
+        return out
+    }
+
+    var isEmpty: Bool { pending.isEmpty }
+}

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+InstagramProfile.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+InstagramProfile.swift
@@ -12,7 +12,11 @@ extension FeedManager {
         instagramRefreshInterval + TimeInterval.random(in: 0...(10 * 60))
     }
 
-    func refreshInstagramFeed(_ feed: Feed, reloadData: Bool = true) async throws {
+    func refreshInstagramFeed(
+        _ feed: Feed,
+        reloadData: Bool = true,
+        articleInsertCollector: ArticleInsertCollector? = nil
+    ) async throws {
         let effectiveInterval = Self.jitteredRefreshInterval()
         if let lastFetched = feed.lastFetched,
            Date().timeIntervalSince(lastFetched) < effectiveInterval {
@@ -59,12 +63,22 @@ extension FeedManager {
 
         let database = database
         try await Task.detached {
-            let insertedIDs = try database.insertArticles(feedID: feed.id, articles: postTuples)
-            try database.updateFeedLastFetched(id: feed.id, date: Date())
-            if !insertedIDs.isEmpty {
-                let articlesToIndex = try database.articles(withIDs: insertedIDs)
-                SpotlightIndexer.indexArticles(articlesToIndex, feedTitle: feedTitle)
+            if let articleInsertCollector {
+                await articleInsertCollector.add(
+                    feedID: feed.id,
+                    items: postTuples,
+                    feedTitleForSpotlight: feedTitle
+                )
+            } else {
+                let insertedIDs = try database.insertArticles(
+                    feedID: feed.id, articles: postTuples
+                )
+                if !insertedIDs.isEmpty {
+                    let articlesToIndex = try database.articles(withIDs: insertedIDs)
+                    SpotlightIndexer.indexArticles(articlesToIndex, feedTitle: feedTitle)
+                }
             }
+            try database.updateFeedLastFetched(id: feed.id, date: Date())
         }.value
 
         await applyScraperMetadataRefresh(

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+Petal.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+Petal.swift
@@ -58,7 +58,11 @@ extension FeedManager {
     }
 
     /// Mirror of `refreshFeed(_:)` that drives `PetalEngine` instead of the RSS path.
-    func refreshPetalFeed(_ feed: Feed, reloadData: Bool) async throws {
+    func refreshPetalFeed(
+        _ feed: Feed,
+        reloadData: Bool,
+        articleInsertCollector: ArticleInsertCollector? = nil
+    ) async throws {
         guard UserDefaults.standard.bool(forKey: "Labs.PetalRecipes") else {
             return
         }
@@ -77,6 +81,7 @@ extension FeedManager {
 
         let database = database
         let feedID = feed.id
+        let feedTitle = feed.title
         try await Task.detached {
             let articleItems = parsed.map { article in
                 ArticleInsertItem(
@@ -93,7 +98,15 @@ extension FeedManager {
                     )
                 )
             }
-            try database.insertArticles(feedID: feedID, articles: articleItems)
+            if let articleInsertCollector {
+                await articleInsertCollector.add(
+                    feedID: feedID,
+                    items: articleItems,
+                    feedTitleForSpotlight: feedTitle
+                )
+            } else {
+                try database.insertArticles(feedID: feedID, articles: articleItems)
+            }
             try database.updateFeedLastFetched(id: feedID, date: Date())
         }.value
 

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+Refresh.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+Refresh.swift
@@ -9,27 +9,36 @@ extension FeedManager {
         updateTitle: Bool = true,
         reloadData: Bool = true,
         skipImageFetch: Bool = false,
-        imagePreloadCollector: ImagePreloadCollector? = nil
+        imagePreloadCollector: ImagePreloadCollector? = nil,
+        articleInsertCollector: ArticleInsertCollector? = nil
     ) async throws {
         if PetalRecipe.isPetalFeedURL(feed.url) {
-            try await refreshPetalFeed(feed, reloadData: reloadData)
+            try await refreshPetalFeed(
+                feed, reloadData: reloadData, articleInsertCollector: articleInsertCollector
+            )
             return
         }
 
         if feed.isXFeed {
             guard UserDefaults.standard.bool(forKey: "Labs.XProfileFeeds") else { return }
-            try await refreshXFeed(feed, reloadData: reloadData)
+            try await refreshXFeed(
+                feed, reloadData: reloadData, articleInsertCollector: articleInsertCollector
+            )
             return
         }
 
         if feed.isInstagramFeed {
             guard UserDefaults.standard.bool(forKey: "Labs.InstagramProfileFeeds") else { return }
-            try await refreshInstagramFeed(feed, reloadData: reloadData)
+            try await refreshInstagramFeed(
+                feed, reloadData: reloadData, articleInsertCollector: articleInsertCollector
+            )
             return
         }
 
         if feed.isYouTubePlaylistFeed {
-            try await refreshYouTubePlaylistFeed(feed, reloadData: reloadData)
+            try await refreshYouTubePlaylistFeed(
+                feed, reloadData: reloadData, articleInsertCollector: articleInsertCollector
+            )
             return
         }
 
@@ -83,18 +92,30 @@ extension FeedManager {
                 )
             }
 
-            let insertedIDs = try database.insertArticles(feedID: feed.id, articles: articleTuples)
+            let feedTitleForIndex = parsed.title.isEmpty ? feed.title : parsed.title
 
-            if !insertedIDs.isEmpty {
-                let insertedArticles = (try? database.articles(withIDs: insertedIDs)) ?? []
-                if !ProcessInfo.processInfo.isLowPowerModeEnabled {
-                    let feedTitleForIndex = parsed.title.isEmpty ? feed.title : parsed.title
-                    SpotlightIndexer.indexArticles(insertedArticles, feedTitle: feedTitleForIndex)
-                }
-                if let imagePreloadCollector {
-                    let imageURLs = insertedArticles.compactMap { $0.imageURL }
-                    if !imageURLs.isEmpty {
-                        await imagePreloadCollector.add(imageURLs)
+            if let articleInsertCollector {
+                await articleInsertCollector.add(
+                    feedID: feed.id,
+                    items: articleTuples,
+                    feedTitleForSpotlight: feedTitleForIndex
+                )
+            } else {
+                let insertedIDs = try database.insertArticles(
+                    feedID: feed.id, articles: articleTuples
+                )
+                if !insertedIDs.isEmpty {
+                    let insertedArticles = (try? database.articles(withIDs: insertedIDs)) ?? []
+                    if !ProcessInfo.processInfo.isLowPowerModeEnabled {
+                        SpotlightIndexer.indexArticles(
+                            insertedArticles, feedTitle: feedTitleForIndex
+                        )
+                    }
+                    if let imagePreloadCollector {
+                        let imageURLs = insertedArticles.compactMap { $0.imageURL }
+                        if !imageURLs.isEmpty {
+                            await imagePreloadCollector.add(imageURLs)
+                        }
                     }
                 }
             }
@@ -221,6 +242,7 @@ extension FeedManager {
         let imagePreloadCollector: ImagePreloadCollector? = (
             !skipImagePreload && preloadMode != .off
         ) ? ImagePreloadCollector() : nil
+        let articleInsertCollector = ArticleInsertCollector()
 
         let currentFeeds = feeds
         let feedsToRefresh = currentFeeds.filter { feed in
@@ -262,15 +284,22 @@ extension FeedManager {
                 slowFeeds,
                 maxConcurrent: 2,
                 skipImageFetch: skipImageFetch,
-                imagePreloadCollector: imagePreloadCollector
+                imagePreloadCollector: imagePreloadCollector,
+                articleInsertCollector: articleInsertCollector
             )
             async let regular: Void = self.runBoundedRefresh(
                 regularFeeds,
                 maxConcurrent: 8,
                 skipImageFetch: skipImageFetch,
-                imagePreloadCollector: imagePreloadCollector
+                imagePreloadCollector: imagePreloadCollector,
+                articleInsertCollector: articleInsertCollector
             )
             _ = await (slow, regular)
+
+            await self.flushArticleInsertCollector(
+                articleInsertCollector,
+                imagePreloadCollector: imagePreloadCollector
+            )
 
             if runNLPAfter, !Task.isCancelled,
                !ProcessInfo.processInfo.isLowPowerModeEnabled {
@@ -303,7 +332,8 @@ extension FeedManager {
         _ feeds: [Feed],
         maxConcurrent: Int,
         skipImageFetch: Bool,
-        imagePreloadCollector: ImagePreloadCollector?
+        imagePreloadCollector: ImagePreloadCollector?,
+        articleInsertCollector: ArticleInsertCollector?
     ) async {
         guard !feeds.isEmpty else { return }
         await withTaskGroup(of: Void.self) { group in
@@ -316,7 +346,8 @@ extension FeedManager {
                         feed,
                         reloadData: false,
                         skipImageFetch: skipImageFetch,
-                        imagePreloadCollector: imagePreloadCollector
+                        imagePreloadCollector: imagePreloadCollector,
+                        articleInsertCollector: articleInsertCollector
                     )
                     if !Task.isCancelled {
                         await MainActor.run { self.refreshCompleted += 1 }
@@ -336,7 +367,8 @@ extension FeedManager {
                             feed,
                             reloadData: false,
                             skipImageFetch: skipImageFetch,
-                            imagePreloadCollector: imagePreloadCollector
+                            imagePreloadCollector: imagePreloadCollector,
+                            articleInsertCollector: articleInsertCollector
                         )
                         if !Task.isCancelled {
                             await MainActor.run { self.refreshCompleted += 1 }
@@ -345,6 +377,52 @@ extension FeedManager {
                 }
             }
         }
+    }
+
+    /// Writes all collected article inserts in a single transaction, then runs Spotlight
+    /// indexing and image-preload aggregation against whatever was actually inserted.
+    fileprivate func flushArticleInsertCollector(
+        _ collector: ArticleInsertCollector,
+        imagePreloadCollector: ImagePreloadCollector?
+    ) async {
+        let pending = await collector.drain()
+        guard !pending.isEmpty else { return }
+        let database = database
+        let lowPower = ProcessInfo.processInfo.isLowPowerModeEnabled
+        await Task.detached {
+            let groups: [(feedID: Int64, items: [ArticleInsertItem])] = pending.map { entry in
+                (feedID: entry.feedID, items: entry.items)
+            }
+            let insertedByFeed: [Int64: [Int64]]
+            do {
+                insertedByFeed = try database.insertArticles(byFeed: groups)
+            } catch {
+                return
+            }
+            guard !insertedByFeed.isEmpty else { return }
+
+            let allInsertedIDs = insertedByFeed.values.flatMap { $0 }
+            let insertedArticles = (try? database.articles(withIDs: allInsertedIDs)) ?? []
+            let articlesByFeedID = Dictionary(grouping: insertedArticles, by: { $0.feedID })
+
+            if !lowPower {
+                for entry in pending {
+                    guard let articles = articlesByFeedID[entry.feedID], !articles.isEmpty else {
+                        continue
+                    }
+                    SpotlightIndexer.indexArticles(
+                        articles, feedTitle: entry.feedTitleForSpotlight
+                    )
+                }
+            }
+
+            if let imagePreloadCollector {
+                let imageURLs = insertedArticles.compactMap { $0.imageURL }
+                if !imageURLs.isEmpty {
+                    await imagePreloadCollector.add(imageURLs)
+                }
+            }
+        }.value
     }
 
     fileprivate func processNewArticlesWithProgress() async {
@@ -367,13 +445,19 @@ extension FeedManager {
             generateAcronymIcon(feedID: feed.id, title: feed.title)
         }
 
+        let articleInsertCollector = ArticleInsertCollector()
         await withTaskGroup(of: Void.self) { group in
             for feed in unfetched {
                 group.addTask {
-                    try? await self.refreshFeed(feed, reloadData: false)
+                    try? await self.refreshFeed(
+                        feed,
+                        reloadData: false,
+                        articleInsertCollector: articleInsertCollector
+                    )
                 }
             }
         }
+        await flushArticleInsertCollector(articleInsertCollector, imagePreloadCollector: nil)
         await loadFromDatabaseInBackground(animated: true)
     }
 
@@ -394,6 +478,7 @@ extension FeedManager {
         }
 
         let maxConcurrent = 8
+        let articleInsertCollector = ArticleInsertCollector()
         let work = Task { [weak self] in
             guard let self else { return }
             async let feedRefresh: Void = withTaskGroup(of: Void.self) { group in
@@ -402,7 +487,12 @@ extension FeedManager {
                 while submitted < maxConcurrent, !Task.isCancelled, let feed = iterator.next() {
                     group.addTask {
                         guard !Task.isCancelled else { return }
-                        try? await self.refreshFeed(feed, updateTitle: false, reloadData: false)
+                        try? await self.refreshFeed(
+                            feed,
+                            updateTitle: false,
+                            reloadData: false,
+                            articleInsertCollector: articleInsertCollector
+                        )
                         if !Task.isCancelled {
                             await MainActor.run { self.refreshCompleted += 1 }
                         }
@@ -417,7 +507,12 @@ extension FeedManager {
                     if let feed = iterator.next() {
                         group.addTask {
                             guard !Task.isCancelled else { return }
-                            try? await self.refreshFeed(feed, updateTitle: false, reloadData: false)
+                            try? await self.refreshFeed(
+                                feed,
+                                updateTitle: false,
+                                reloadData: false,
+                                articleInsertCollector: articleInsertCollector
+                            )
                             if !Task.isCancelled {
                                 await MainActor.run { self.refreshCompleted += 1 }
                             }
@@ -429,6 +524,9 @@ extension FeedManager {
                 for: currentFeeds.map { ($0.domain, $0.siteURL as String?) }
             )
             _ = await (feedRefresh, faviconRefresh)
+            await self.flushArticleInsertCollector(
+                articleInsertCollector, imagePreloadCollector: nil
+            )
         }
         await MainActor.run { self.refreshTask = work }
         _ = await work.value

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+XProfile.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+XProfile.swift
@@ -8,7 +8,11 @@ extension FeedManager {
     /// Minimum interval between X API calls per feed (30 minutes).
     static let xRefreshInterval: TimeInterval = 30 * 60
 
-    func refreshXFeed(_ feed: Feed, reloadData: Bool = true) async throws {
+    func refreshXFeed(
+        _ feed: Feed,
+        reloadData: Bool = true,
+        articleInsertCollector: ArticleInsertCollector? = nil
+    ) async throws {
         if let lastFetched = feed.lastFetched,
            Date().timeIntervalSince(lastFetched) < Self.xRefreshInterval {
             #if DEBUG
@@ -54,12 +58,22 @@ extension FeedManager {
 
         let database = database
         try await Task.detached {
-            let insertedIDs = try database.insertArticles(feedID: feed.id, articles: tweetTuples)
-            try database.updateFeedLastFetched(id: feed.id, date: Date())
-            if !insertedIDs.isEmpty {
-                let articlesToIndex = try database.articles(withIDs: insertedIDs)
-                SpotlightIndexer.indexArticles(articlesToIndex, feedTitle: feedTitle)
+            if let articleInsertCollector {
+                await articleInsertCollector.add(
+                    feedID: feed.id,
+                    items: tweetTuples,
+                    feedTitleForSpotlight: feedTitle
+                )
+            } else {
+                let insertedIDs = try database.insertArticles(
+                    feedID: feed.id, articles: tweetTuples
+                )
+                if !insertedIDs.isEmpty {
+                    let articlesToIndex = try database.articles(withIDs: insertedIDs)
+                    SpotlightIndexer.indexArticles(articlesToIndex, feedTitle: feedTitle)
+                }
             }
+            try database.updateFeedLastFetched(id: feed.id, date: Date())
         }.value
 
         await applyScraperMetadataRefresh(

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+YouTubePlaylist.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+YouTubePlaylist.swift
@@ -8,7 +8,11 @@ extension FeedManager {
     /// Minimum interval between YouTube playlist fetches per feed (30 minutes).
     private static let youTubePlaylistRefreshInterval: TimeInterval = 30 * 60
 
-    func refreshYouTubePlaylistFeed(_ feed: Feed, reloadData: Bool = true) async throws {
+    func refreshYouTubePlaylistFeed(
+        _ feed: Feed,
+        reloadData: Bool = true,
+        articleInsertCollector: ArticleInsertCollector? = nil
+    ) async throws {
         if let lastFetched = feed.lastFetched,
            Date().timeIntervalSince(lastFetched) < Self.youTubePlaylistRefreshInterval {
             #if DEBUG
@@ -50,12 +54,22 @@ extension FeedManager {
 
         let database = database
         try await Task.detached {
-            let insertedIDs = try database.insertArticles(feedID: feed.id, articles: articleTuples)
-            try database.updateFeedLastFetched(id: feed.id, date: Date())
-            if !insertedIDs.isEmpty {
-                let articlesToIndex = try database.articles(withIDs: insertedIDs)
-                SpotlightIndexer.indexArticles(articlesToIndex, feedTitle: feedTitle)
+            if let articleInsertCollector {
+                await articleInsertCollector.add(
+                    feedID: feed.id,
+                    items: articleTuples,
+                    feedTitleForSpotlight: feedTitle
+                )
+            } else {
+                let insertedIDs = try database.insertArticles(
+                    feedID: feed.id, articles: articleTuples
+                )
+                if !insertedIDs.isEmpty {
+                    let articlesToIndex = try database.articles(withIDs: insertedIDs)
+                    SpotlightIndexer.indexArticles(articlesToIndex, feedTitle: feedTitle)
+                }
             }
+            try database.updateFeedLastFetched(id: feed.id, date: Date())
         }.value
 
         await applyScraperMetadataRefresh(

--- a/Shared/Database Manager/DatabaseManager+Articles.swift
+++ b/Shared/Database Manager/DatabaseManager+Articles.swift
@@ -12,7 +12,7 @@ struct ArticleInsertData: Sendable {
     var duration: Int?
 }
 
-struct ArticleInsertItem {
+struct ArticleInsertItem: Sendable {
     var title: String
     var url: String
     var data: ArticleInsertData
@@ -51,37 +51,72 @@ nonisolated extension DatabaseManager {
     @discardableResult
     func insertArticles(feedID fid: Int64, articles items: [ArticleInsertItem]) throws -> [Int64] {
         guard !items.isEmpty else { return [] }
-        let cutoffTimestamp = UserDefaults.standard.double(forKey: "Content.CutoffDate")
-        let cutoffDate: Date? = cutoffTimestamp > 0
-            ? Date(timeIntervalSince1970: cutoffTimestamp) : nil
+        let cutoffDate = articleCutoffDate()
         var insertedIDs: [Int64] = []
         try database.transaction {
-            for item in items {
-                if let cutoff = cutoffDate, let published = item.data.publishedDate,
-                   published < cutoff {
-                    continue
+            insertedIDs = try insertArticleItems(feedID: fid, items: items, cutoffDate: cutoffDate)
+        }
+        return insertedIDs
+    }
+
+    /// Batched counterpart of `insertArticles(feedID:articles:)` that inserts every feed's
+    /// articles inside one transaction, so the UI sees a single mutation instead of one per feed.
+    @discardableResult
+    func insertArticles(
+        byFeed groups: [(feedID: Int64, items: [ArticleInsertItem])]
+    ) throws -> [Int64: [Int64]] {
+        guard !groups.isEmpty else { return [:] }
+        let cutoffDate = articleCutoffDate()
+        var insertedByFeed: [Int64: [Int64]] = [:]
+        try database.transaction {
+            for group in groups where !group.items.isEmpty {
+                let ids = try insertArticleItems(
+                    feedID: group.feedID, items: group.items, cutoffDate: cutoffDate
+                )
+                if !ids.isEmpty {
+                    insertedByFeed[group.feedID, default: []].append(contentsOf: ids)
                 }
-                let carouselValue = item.data.carouselImageURLs.isEmpty
-                    ? nil : item.data.carouselImageURLs.joined(separator: "\n")
-                let rowid = try database.run(articles.insert(or: .ignore,
-                    articleFeedID <- fid,
-                    articleTitle <- item.title,
-                    articleURL <- item.url,
-                    articleAuthor <- item.data.author,
-                    articleSummary <- item.data.summary,
-                    articleContent <- item.data.content,
-                    articleImageURL <- item.data.imageURL,
-                    articleCarouselURLs <- carouselValue,
-                    articlePublishedDate <- item.data.publishedDate?.timeIntervalSince1970,
-                    articleIsRead <- false,
-                    articleIsBookmarked <- false,
-                    articleAudioURL <- item.data.audioURL,
-                    articleDuration <- item.data.duration
-                ))
-                // INSERT OR IGNORE leaves sqlite3_changes() unchanged on conflict, so gate on per-statement change count rather than rowid.
-                if database.changes > 0 {
-                    insertedIDs.append(rowid)
-                }
+            }
+        }
+        return insertedByFeed
+    }
+
+    private func articleCutoffDate() -> Date? {
+        let cutoffTimestamp = UserDefaults.standard.double(forKey: "Content.CutoffDate")
+        return cutoffTimestamp > 0 ? Date(timeIntervalSince1970: cutoffTimestamp) : nil
+    }
+
+    private func insertArticleItems(
+        feedID fid: Int64,
+        items: [ArticleInsertItem],
+        cutoffDate: Date?
+    ) throws -> [Int64] {
+        var insertedIDs: [Int64] = []
+        for item in items {
+            if let cutoff = cutoffDate, let published = item.data.publishedDate,
+               published < cutoff {
+                continue
+            }
+            let carouselValue = item.data.carouselImageURLs.isEmpty
+                ? nil : item.data.carouselImageURLs.joined(separator: "\n")
+            let rowid = try database.run(articles.insert(or: .ignore,
+                articleFeedID <- fid,
+                articleTitle <- item.title,
+                articleURL <- item.url,
+                articleAuthor <- item.data.author,
+                articleSummary <- item.data.summary,
+                articleContent <- item.data.content,
+                articleImageURL <- item.data.imageURL,
+                articleCarouselURLs <- carouselValue,
+                articlePublishedDate <- item.data.publishedDate?.timeIntervalSince1970,
+                articleIsRead <- false,
+                articleIsBookmarked <- false,
+                articleAudioURL <- item.data.audioURL,
+                articleDuration <- item.data.duration
+            ))
+            // INSERT OR IGNORE leaves sqlite3_changes() unchanged on conflict, so gate on per-statement change count rather than rowid.
+            if database.changes > 0 {
+                insertedIDs.append(rowid)
             }
         }
         return insertedIDs


### PR DESCRIPTION
## Summary

- During a multi-feed refresh, parsed articles are now collected into an `ArticleInsertCollector` actor instead of being inserted per feed as each task finishes.
- After all bounded refresh tasks complete, the collector is drained and every feed's articles are written in a single SQLite transaction (new `DatabaseManager.insertArticles(byFeed:)`), then Spotlight indexing and image-preload aggregation run against the actually-inserted rows.
- This avoids the home/article list re-sorting and content "jumping around" during eager reloads while individual feeds trickle in.
- Single-feed refreshes (`FeedArticlesView`, add-feed, etc.) keep their original direct-insert path because the collector parameter defaults to `nil`.

The collector is plumbed through `refreshFeed`, `runBoundedRefresh`, `refreshAllFeeds`, `refreshUnfetchedFeeds`, `refreshAllFeedsAndFavicons`, and the per-platform refreshes (Petal, X, Instagram, YouTube playlist).

## Test plan

- [ ] `refreshAllFeeds` with a mix of fast and slow feeds — confirm the article list updates once at the end with a smooth animation rather than re-shuffling per feed.
- [ ] `refreshUnfetchedFeeds` after adding several new feeds at once — confirm articles all appear together.
- [ ] `refreshAllFeedsAndFavicons` from settings — confirm both favicons and articles refresh and the list reload is single-shot.
- [ ] Pull-to-refresh on a single feed (`FeedArticlesView`) — confirm behavior is unchanged (uses non-collector path).
- [ ] Background refresh (`respectCooldown: true`) — confirm cooldown filtering still works and inserts batch correctly.
- [ ] Cancel a refresh mid-flight — confirm the partial collector state is dropped without crashing.
- [ ] Spotlight search after refresh — confirm new articles are indexed with the correct feed title.
- [ ] Image preloading — confirm images for newly inserted articles are still queued for preload.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VjnoiAkNXrM17gPD8nKXvM)_