### PR TITLE
Suppress inherited scale animation on async image load

### DIFF
--- a/SakuraRSS/Views/Shared/CachedAsyncImage.swift
+++ b/SakuraRSS/Views/Shared/CachedAsyncImage.swift
@@ -57,7 +57,9 @@ struct CachedAsyncImage<Placeholder: View>: View {
     }
 
     var body: some View {
-        Group {
+        ZStack {
+            placeholder()
+                .opacity(image == nil ? 1 : 0)
             if let image {
                 Color.clear
                     .overlay(alignment: alignment) {
@@ -66,9 +68,11 @@ struct CachedAsyncImage<Placeholder: View>: View {
                             .aspectRatio(contentMode: .fill)
                     }
                     .clipped()
-            } else {
-                placeholder()
             }
+        }
+        .transaction { transaction in
+            transaction.animation = nil
+            transaction.disablesAnimations = true
         }
         .task(id: url, priority: .utility) {
             guard let url else {


### PR DESCRIPTION
## Summary
- `CachedAsyncImage` swapped between placeholder and image via a `Group { if let image ... else ... }`. That structural change inherited any animation in scope from parent contexts (list scroll, navigation transitions, feed refresh), producing an ugly scale animation as images loaded in.
- Switched to a stable `ZStack` where the placeholder is always present and hidden via opacity once the image arrives, and added a `.transaction` that nils out inherited animations on this view's state changes.
- Net effect: images appear instantly when they finish decoding, with no scale or transition artifact.

## Test plan
- [ ] Scroll through a feed in `Feed`, `Grid`, `Photos`, `Magazine`, `Cards`, and `Inbox` styles while images are still loading — no scale animation as they appear.
- [ ] Open `Article Detail` for an article with a hero image — image fills the slot without animating in.
- [ ] Confirm placeholders still render correctly while loading.
- [ ] Verify cached images appear immediately (no flash).

https://claude.ai/code/session_01PPWuhyvsAjyuGvWrKAwhFj

---
_Generated by [Claude Code](https://claude.ai/code/session_01PPWuhyvsAjyuGvWrKAwhFj)_