### PR TITLE
Fix auto load-more still not triggering on single-post feeds (#199)

### DIFF
--- a/SakuraRSS/Views/Shared/Articles/ArticlesView.swift
+++ b/SakuraRSS/Views/Shared/Articles/ArticlesView.swift
@@ -221,7 +221,6 @@ struct LoadPreviousArticlesButton: View {
     let action: () -> Void
 
     @AppStorage("Articles.AutoLoadWhileScrolling") private var autoLoadWhileScrolling: Bool = false
-    @State private var isVisible: Bool = false
 
     var body: some View {
         Group {
@@ -234,14 +233,8 @@ struct LoadPreviousArticlesButton: View {
                 }
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 12)
-                .onAppear { isVisible = true }
-                .onDisappear { isVisible = false }
-                .onScrollVisibilityChange(threshold: 0.1) { visible in
-                    isVisible = visible
-                }
-                .task(id: isVisible) {
-                    guard isVisible else { return }
-                    while !Task.isCancelled, isVisible {
+                .task {
+                    while !Task.isCancelled {
                         await MainActor.run {
                             withAnimation(.smooth.speed(2.0)) {
                                 action()


### PR DESCRIPTION
## Summary
- Follow-up to #199. The previous fix added `onAppear`/`onDisappear` alongside `onScrollVisibilityChange`, but the two callbacks race on initial layout: `onAppear` sets `isVisible = true` and `onScrollVisibilityChange` immediately fires with `false` (the scroll geometry hasn't settled yet), so `task(id: isVisible)` is cancelled before `action()` ever runs.
- Drop the `isVisible` state entirely and drive the auto-load loop from the view's own lifecycle via a plain `.task`. List's lazy cell rendering already keeps the loader cell out of the view tree until it's near the viewport, so we get the "only fire when visible" behavior without the race.

## Test plan
- [ ] Open a feed that contains a single post with auto-load-while-scrolling enabled and confirm older content loads automatically.
- [ ] Open a feed with many posts and confirm auto-load only kicks in once the loader scrolls into the visible area.
- [ ] Toggle auto-load off and confirm the manual "Show Older Content" button still works.

https://claude.ai/code/session_01BwQNZv3Tagsa82rZdhBd3u

---
_Generated by [Claude Code](https://claude.ai/code/session_01DTrW68hL8W6CAHrrPUSaYh)_