### PR TITLE
Fix article images overflowing and overlapping body text

### DIFF
--- a/SakuraRSS/Views/Shared/Article Detail/ArticleDetailView.swift
+++ b/SakuraRSS/Views/Shared/Article Detail/ArticleDetailView.swift
@@ -135,10 +135,8 @@ struct ArticleDetailView: View {
                 }, placeholder: {
                     Rectangle()
                         .fill(.secondary.opacity(0.1))
-                        .frame(height: 200)
                 })
-                .aspectRatio(heroImageAspectRatio, contentMode: .fill)
-                .clipped()
+                .aspectRatio(heroImageAspectRatio ?? (16.0 / 9.0), contentMode: .fit)
                 .clipShape(RoundedRectangle(cornerRadius: 12))
                 .matchedTransitionSource(id: url, in: imageViewerNamespace)
                 .onTapGesture { imageViewerURL = url }
@@ -256,44 +254,34 @@ struct FitWidthImage: View {
     @Environment(\.openURL) private var openURL
 
     var body: some View {
-        GeometryReader { geo in
-            let maxWidth = geo.size.width
-            let naturalWidth = imageSize?.width ?? maxWidth
-            let displayWidth = min(naturalWidth, maxWidth)
-
-            CachedAsyncImage(url: url, onImageLoaded: { image in
-                aspectRatio = image.size.width / image.size.height
-                imageSize = image.size
-            }, placeholder: {
-                Rectangle()
-                    .fill(.secondary.opacity(0.1))
-                    .frame(height: 200)
-            })
-            .aspectRatio(aspectRatio, contentMode: .fill)
-            .frame(width: displayWidth)
-            .clipped()
-            .clipShape(RoundedRectangle(cornerRadius: 12))
-            .overlay(alignment: .bottomTrailing) {
-                if let link, displayWidth >= 120 {
-                    Button {
-                        openURL(link)
-                    } label: {
-                        Label("Shared.Link", systemImage: "link")
-                            .font(.caption)
-                            .fontWeight(.medium)
-                            .padding(.horizontal, 10)
-                            .padding(.vertical, 6)
-                            .background(.ultraThinMaterial, in: Capsule())
-                    }
-                    .buttonStyle(.plain)
-                    .padding(8)
-                }
-            }
-            .matchedTransitionSource(id: url, in: namespace)
-            .onTapGesture { onTap?() }
-            .frame(maxWidth: .infinity, alignment: .center)
-        }
-        .aspectRatio(aspectRatio, contentMode: .fit)
+        CachedAsyncImage(url: url, onImageLoaded: { image in
+            aspectRatio = image.size.width / image.size.height
+            imageSize = image.size
+        }, placeholder: {
+            Rectangle()
+                .fill(.secondary.opacity(0.1))
+        })
+        .aspectRatio(aspectRatio ?? (16.0 / 9.0), contentMode: .fit)
         .frame(maxWidth: imageSize?.width)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .overlay(alignment: .bottomTrailing) {
+            if let link, (imageSize?.width ?? 120) >= 120 {
+                Button {
+                    openURL(link)
+                } label: {
+                    Label("Shared.Link", systemImage: "link")
+                        .font(.caption)
+                        .fontWeight(.medium)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 6)
+                        .background(.ultraThinMaterial, in: Capsule())
+                }
+                .buttonStyle(.plain)
+                .padding(8)
+            }
+        }
+        .matchedTransitionSource(id: url, in: namespace)
+        .onTapGesture { onTap?() }
+        .frame(maxWidth: .infinity, alignment: .center)
     }
 }


### PR DESCRIPTION
## Summary

Article images with low natural height were being forcibly scaled up to a 200pt minimum, overflowing their layout slot and rendering on top of subsequent body text.

Two layout problems combined to cause this in `ArticleDetailView`:

1. **Placeholder forced minimum height.** Both `FitWidthImage` and the hero image used a placeholder `Rectangle().frame(height: 200)`. After the image loaded, the placeholder stayed in the `ZStack` at opacity 0 but still demanded 200pt of vertical space, so the underlying `CachedAsyncImage` was always at least 200pt tall regardless of the real image dimensions.
2. **`.fill` content mode + conflicting outer frame.** The view used `.aspectRatio(_, contentMode: .fill)` on the inner image while the outer `GeometryReader` was wrapped in `.aspectRatio(_, contentMode: .fit) + .frame(maxWidth: imageSize?.width)`. For a wide-but-short image (e.g. 800×100), the outer container reserved a small slot like 350×44, but the inner placeholder kept the rendered ZStack at 200pt — that 200pt overflowed into the next view, drawing the image behind the article body text.

### Fix

- Drop the placeholder's fixed `frame(height: 200)`; let the placeholder rectangle inherit the image's aspect-ratio frame.
- Switch the image's content mode from `.fill` to `.fit` so it can never overflow the slot it's been given.
- Use the image's natural aspect ratio once loaded; before load, fall back to `16:9` so the placeholder still has a sensible shape.
- Remove the now-redundant `GeometryReader` wrapper around `FitWidthImage`; `.frame(maxWidth: imageSize?.width)` already prevents small images from being stretched beyond their natural width.
- Apply the same shape (`.aspectRatio(.fit)` + sizeless placeholder) to the hero lead image so it has consistent behavior.

## Test plan

- [ ] Open an article that contains a wide-but-short banner image (e.g. the Hacker News "Firefox Has Integrated Brave's Adblock Engine" article from the bug report) and verify the image is rendered at its real height with no overflow into the body text.
- [ ] Open an article whose hero/lead image is short and wide; verify it's no longer stretched to 200pt and no longer overlaps following content.
- [ ] Open an article with a tall portrait image inline; verify it sizes correctly and remains tappable for the image viewer.
- [ ] Open an article with a small image carrying an `IMGLINK`; verify the link button still appears for reasonably sized images and is hidden for tiny ones.
- [ ] Tap any inline image and confirm the matched-transition zoom into the image viewer still works.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GGRywE962bA27oh3pjUnUy)_