### PR TITLE
Stop auto-load spinner loop and skip data-revision bump on scroll-mark-read

### DIFF
--- a/SakuraRSS/Classes/Feed Manager/FeedManager+Articles.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+Articles.swift
@@ -149,7 +149,8 @@ extension FeedManager {
     }
 
     func toggleRead(_ article: Article) {
-        try? database.markArticleRead(id: article.id, read: !article.isRead)
+        let currentReadState = isRead(article)
+        try? database.markArticleRead(id: article.id, read: !currentReadState)
         loadFromDatabase()
         updateBadgeCount()
     }

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+PendingReads.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+PendingReads.swift
@@ -12,21 +12,30 @@ extension FeedManager {
     func markReadOnScroll(_ article: Article) {
         guard !article.isRead,
               pendingReadIDs.insert(article.id).inserted else { return }
-        decrementUnreadCount(feedID: article.feedID)
-        updateBadgeCount()
+        pendingReadDecrements[article.feedID, default: 0] += 1
         schedulePendingReadsFlush()
     }
 
+    /// Persists queued mark-read IDs, applies the batched unread-count
+    /// decrements, and refreshes the badge once per flush.
+    /// Crucially, this does NOT call `bumpDataRevision()` and does NOT clear
+    /// `pendingReadIDs` — the IDs remain in the set so `isRead(_:)` keeps
+    /// masking them as read until the next legitimate `loadFromDatabase`.
+    /// This avoids forcing every `_ = dataRevision` consumer (notably
+    /// `nextArticleChunk`, which walks up to 730 chunks per call) to
+    /// recompute on the main thread every 250 ms while the user is scrolling.
     func flushDebouncedReads() {
         pendingReadsFlushWorkItem?.cancel()
         pendingReadsFlushWorkItem = nil
         guard !pendingReadIDs.isEmpty else { return }
-        let ids = pendingReadIDs
-        pendingReadIDs.removeAll()
-        let idArray = Array(ids)
+        let decrements = pendingReadDecrements
+        pendingReadDecrements.removeAll()
 
+        applyUnreadDecrements(decrements)
+        updateBadgeCount()
+
+        let idArray = Array(pendingReadIDs)
         try? database.markArticlesRead(ids: idArray, read: true)
-        bumpDataRevision()
 
         let dbm = database
         Task.detached(priority: .utility) {

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+PendingReads.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+PendingReads.swift
@@ -16,14 +16,8 @@ extension FeedManager {
         schedulePendingReadsFlush()
     }
 
-    /// Persists queued mark-read IDs, applies the batched unread-count
-    /// decrements, and refreshes the badge once per flush.
-    /// Crucially, this does NOT call `bumpDataRevision()` and does NOT clear
-    /// `pendingReadIDs` — the IDs remain in the set so `isRead(_:)` keeps
-    /// masking them as read until the next legitimate `loadFromDatabase`.
-    /// This avoids forcing every `_ = dataRevision` consumer (notably
-    /// `nextArticleChunk`, which walks up to 730 chunks per call) to
-    /// recompute on the main thread every 250 ms while the user is scrolling.
+    /// IDs stay in `pendingReadIDs` past the flush so `isRead(_:)` keeps masking them
+    /// without bumping `dataRevision`; cleared on the next `loadFromDatabase`.
     func flushDebouncedReads() {
         pendingReadsFlushWorkItem?.cancel()
         pendingReadsFlushWorkItem = nil

--- a/SakuraRSS/Classes/Feed Manager/FeedManager.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager.swift
@@ -26,7 +26,11 @@ final class FeedManager {
     private(set) var feedsByID: [Int64: Feed] = [:]
 
     /// Queued mark-read IDs; flushed every 250ms while scrolling, on idle, or on backgrounding.
+    /// Once flushed, IDs persist here until the next `loadFromDatabase` so views keep
+    /// rendering them as read without forcing a full data revision bump every flush.
     var pendingReadIDs: Set<Int64> = []
+    /// Per-feed unread decrements accumulated between flushes.
+    @ObservationIgnored var pendingReadDecrements: [Int64: Int] = [:]
     @ObservationIgnored var refreshTask: Task<Void, Never>?
 
     @ObservationIgnored var currentScrollPhase: ScrollPhase = .idle
@@ -45,6 +49,8 @@ final class FeedManager {
             articles = try database.allArticles(limit: 200)
             unreadCounts = (try? database.allUnreadCounts()) ?? [:]
             lists = (try? database.allLists()) ?? []
+            pendingReadIDs.removeAll()
+            pendingReadDecrements.removeAll()
             dataRevision += 1
         } catch {
             print("Failed to load from database: \(error)")
@@ -68,6 +74,8 @@ final class FeedManager {
                     self.articles = loadedArticles
                     self.unreadCounts = loadedUnreadCounts
                     self.lists = loadedLists
+                    self.pendingReadIDs.removeAll()
+                    self.pendingReadDecrements.removeAll()
                     self.dataRevision += 1
                 }
                 if animated {

--- a/SakuraRSS/Classes/Feed Manager/FeedManager.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager.swift
@@ -26,10 +26,7 @@ final class FeedManager {
     private(set) var feedsByID: [Int64: Feed] = [:]
 
     /// Queued mark-read IDs; flushed every 250ms while scrolling, on idle, or on backgrounding.
-    /// Once flushed, IDs persist here until the next `loadFromDatabase` so views keep
-    /// rendering them as read without forcing a full data revision bump every flush.
     var pendingReadIDs: Set<Int64> = []
-    /// Per-feed unread decrements accumulated between flushes.
     @ObservationIgnored var pendingReadDecrements: [Int64: Int] = [:]
     @ObservationIgnored var refreshTask: Task<Void, Never>?
 

--- a/SakuraRSS/Views/Shared/Articles/LoadPreviousArticlesButton.swift
+++ b/SakuraRSS/Views/Shared/Articles/LoadPreviousArticlesButton.swift
@@ -1,10 +1,6 @@
 import SwiftUI
 
 /// Sentinel pinned to the bottom of an article list.
-/// Manual mode shows a tap-to-load button. Auto mode fires `action()` once
-/// when the sentinel becomes visible, and re-fires only after `articleCount`
-/// changes — so a feed whose loaded chunks contain no new visible articles
-/// can't get stuck spinning indefinitely.
 struct LoadPreviousArticlesButton: View {
 
     let action: () -> Void

--- a/SakuraRSS/Views/Shared/Articles/LoadPreviousArticlesButton.swift
+++ b/SakuraRSS/Views/Shared/Articles/LoadPreviousArticlesButton.swift
@@ -1,16 +1,18 @@
 import SwiftUI
 
 /// Sentinel pinned to the bottom of an article list.
-/// Manual mode shows a tap-to-load button. Auto mode keeps firing `action()`
-/// while the sentinel is on-screen, so it works whether the user has to scroll
-/// to reveal it or whether it was visible from the start because the feed
-/// didn't fill the viewport.
+/// Manual mode shows a tap-to-load button. Auto mode fires `action()` once
+/// when the sentinel becomes visible, and re-fires only after `articleCount`
+/// changes — so a feed whose loaded chunks contain no new visible articles
+/// can't get stuck spinning indefinitely.
 struct LoadPreviousArticlesButton: View {
 
     let action: () -> Void
+    var articleCount: Int = 0
 
     @AppStorage("Articles.AutoLoadWhileScrolling") private var autoLoadWhileScrolling: Bool = false
     @State private var isOnScreen = false
+    @State private var lastFiredAtCount: Int? = nil
 
     var body: some View {
         Group {
@@ -34,13 +36,14 @@ struct LoadPreviousArticlesButton: View {
         .onScrollVisibilityChange(threshold: 0.05) { visible in
             isOnScreen = visible
         }
-        .task(id: isOnScreen) {
-            guard isOnScreen else { return }
-            while !Task.isCancelled {
-                withAnimation(.smooth.speed(2.0)) {
-                    action()
-                }
-                try? await Task.sleep(for: .milliseconds(500))
+        .task(id: AutoLoadKey(isOnScreen: isOnScreen, count: articleCount)) {
+            guard isOnScreen,
+                  lastFiredAtCount != articleCount else { return }
+            lastFiredAtCount = articleCount
+            try? await Task.sleep(for: .milliseconds(50))
+            guard !Task.isCancelled else { return }
+            withAnimation(.smooth.speed(2.0)) {
+                action()
             }
         }
     }
@@ -62,4 +65,9 @@ struct LoadPreviousArticlesButton: View {
         .buttonStyle(.bordered)
         .tint(.secondary)
     }
+}
+
+private struct AutoLoadKey: Equatable {
+    let isOnScreen: Bool
+    let count: Int
 }

--- a/SakuraRSS/Views/Shared/Feed Display Styles/Compact/CompactStyleView.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/Compact/CompactStyleView.swift
@@ -63,7 +63,7 @@ struct CompactStyleView: View {
                 }
             }
             if let onLoadMore {
-                LoadPreviousArticlesButton(action: onLoadMore)
+                LoadPreviousArticlesButton(action: onLoadMore, articleCount: articles.count)
                     .listRowBackground(Color.clear)
                     .listRowSeparator(.hidden)
             }

--- a/SakuraRSS/Views/Shared/Feed Display Styles/Feed/FeedStyleView.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/Feed/FeedStyleView.swift
@@ -52,7 +52,7 @@ struct FeedStyleView: View {
                 }
             }
             if let onLoadMore {
-                LoadPreviousArticlesButton(action: onLoadMore)
+                LoadPreviousArticlesButton(action: onLoadMore, articleCount: articles.count)
                     .listRowBackground(Color.clear)
                     .listRowSeparator(.hidden)
             }

--- a/SakuraRSS/Views/Shared/Feed Display Styles/Grid/GridStyleView.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/Grid/GridStyleView.swift
@@ -53,7 +53,7 @@ struct GridStyleView: View {
                 }
             }
             if let onLoadMore {
-                LoadPreviousArticlesButton(action: onLoadMore)
+                LoadPreviousArticlesButton(action: onLoadMore, articleCount: articles.count)
                     .padding(.horizontal, 16)
                     .padding(.vertical, 12)
             }

--- a/SakuraRSS/Views/Shared/Feed Display Styles/Inbox/InboxStyleView.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/Inbox/InboxStyleView.swift
@@ -44,7 +44,7 @@ struct InboxStyleView: View {
                 .listRowInsets(EdgeInsets(top: 8, leading: 12, bottom: 8, trailing: 12))
             }
             if let onLoadMore {
-                LoadPreviousArticlesButton(action: onLoadMore)
+                LoadPreviousArticlesButton(action: onLoadMore, articleCount: articles.count)
                     .listRowBackground(Color.clear)
                     .listRowSeparator(.hidden)
             }

--- a/SakuraRSS/Views/Shared/Feed Display Styles/Magazine/MagazineStyleView.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/Magazine/MagazineStyleView.swift
@@ -54,7 +54,7 @@ struct MagazineStyleView: View {
                 }
                 .padding(.horizontal, 16)
                 if let onLoadMore {
-                    LoadPreviousArticlesButton(action: onLoadMore)
+                    LoadPreviousArticlesButton(action: onLoadMore, articleCount: articles.count)
                         .padding(.horizontal, 16)
                 }
             }

--- a/SakuraRSS/Views/Shared/Feed Display Styles/Photos/PhotosStyleView.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/Photos/PhotosStyleView.swift
@@ -17,7 +17,7 @@ struct PhotosStyleView: View {
                         .markReadOnScroll(article: article)
                 }
                 if let onLoadMore {
-                    LoadPreviousArticlesButton(action: onLoadMore)
+                    LoadPreviousArticlesButton(action: onLoadMore, articleCount: articles.count)
                         .padding(.horizontal, 16)
                         .padding(.vertical, 20)
                 }

--- a/SakuraRSS/Views/Shared/Feed Display Styles/Podcast/PodcastStyleView.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/Podcast/PodcastStyleView.swift
@@ -84,7 +84,7 @@ struct PodcastStyleView: View {
                 }
             }
             if let onLoadMore {
-                LoadPreviousArticlesButton(action: onLoadMore)
+                LoadPreviousArticlesButton(action: onLoadMore, articleCount: articles.count)
                     .listRowBackground(Color.clear)
                     .listRowSeparator(.hidden)
             }

--- a/SakuraRSS/Views/Shared/Feed Display Styles/Timeline/TimelineStyleView.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/Timeline/TimelineStyleView.swift
@@ -47,7 +47,7 @@ struct TimelineStyleView: View {
             }
 
             if let onLoadMore {
-                LoadPreviousArticlesButton(action: onLoadMore)
+                LoadPreviousArticlesButton(action: onLoadMore, articleCount: articles.count)
                     .listRowBackground(Color.clear)
                     .listRowSeparator(.hidden)
             }

--- a/SakuraRSS/Views/Shared/Feed Display Styles/Video/VideoStyleView.swift
+++ b/SakuraRSS/Views/Shared/Feed Display Styles/Video/VideoStyleView.swift
@@ -76,7 +76,7 @@ struct VideoStyleView: View {
             }
             .padding(.bottom)
             if let onLoadMore {
-                LoadPreviousArticlesButton(action: onLoadMore)
+                LoadPreviousArticlesButton(action: onLoadMore, articleCount: articles.count)
                     .padding(.horizontal, 16)
                     .padding(.bottom)
             }


### PR DESCRIPTION
## Summary

Two bugs in the feed-articles flow on the Following tab:

### Activity indicator stuck spinning when content is all read
`LoadPreviousArticlesButton` was running a `while` loop that fired `action()` every 500 ms while the sentinel was on screen. On a feed where every loaded chunk contains no *visible* articles (e.g. all content read with Hide Viewed Content on), the indicator stayed visible after each load and just kept walking backwards through history.

Now the button takes the visible `articleCount` from its parent and re-fires only when that count actually grows. Visibility flipping false→true still triggers a single fire, so scroll-to-bottom in a normal feed continues to chain loads — the loop just terminates when nothing new is appearing.

### Mark-as-read-on-scroll lag
Every 250 ms `flushDebouncedReads()` was calling `bumpDataRevision()`, which forces every `_ = dataRevision` consumer to recompute. That includes `nextArticleChunk(for:before:chunkDays:)` which walks up to 730 chunks with DB queries per call — on the main thread, in the middle of a scroll.

- Persist mark-read IDs in `pendingReadIDs` past the flush so `isRead(_:)` keeps masking them as read; clear the set on `loadFromDatabase` / `loadFromDatabaseInBackground` instead. No more revision bump per flush, no more chunk walk per scroll tick.
- Batch the unread-count decrements and badge update: `markReadOnScroll` now just queues a per-feed counter, and the flush applies them in one `applyUnreadDecrements` + one `updateBadgeCount` call instead of one of each per scrolled article.
- `toggleRead` now reads through `isRead(_:)` so a swipe right after a scroll-mark still flips to the correct state (the in-memory Article struct's `isRead` is stale until the next data refresh, but `isRead(_:)` accounts for `pendingReadIDs`).

## Test plan
- [ ] Open a feed under Following with all content already read and Hide Viewed Content on — confirm the auto-load spinner stops on its own instead of churning through years of history.
- [ ] Scroll a feed normally with auto-load on — chunks should still load as you reach the bottom.
- [ ] Toggle the manual "Load previous" button — still loads on tap.
- [ ] Enable Display.ScrollMarkAsRead and scroll quickly through a feed — frame rate should stay smooth, articles still get marked as read.
- [ ] Swipe to toggle an article that was just marked read by scroll — should flip to unread.
- [ ] Pull-to-refresh — `pendingReadIDs` clears and articles reflect their persisted state.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Kau7ZhiHVGMquvbKVzBxBB)_