### PR TITLE
Hide load-previous sentinel when feed has no articles

### DIFF
--- a/SakuraRSS/Views/Shared/Articles/LoadPreviousArticlesButton.swift
+++ b/SakuraRSS/Views/Shared/Articles/LoadPreviousArticlesButton.swift
@@ -12,10 +12,12 @@ struct LoadPreviousArticlesButton: View {
 
     var body: some View {
         Group {
-            if autoLoadWhileScrolling {
-                autoLoadingIndicator
-            } else {
-                manualButton
+            if articleCount > 0 {
+                if autoLoadWhileScrolling {
+                    autoLoadingIndicator
+                } else {
+                    manualButton
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- The "Loading older content…" sentinel was rendering even when a feed had zero articles, sitting alongside the empty-state `ContentUnavailableView`.
- Gate `LoadPreviousArticlesButton`'s body on `articleCount > 0` so the sentinel disappears whenever there's nothing to page back from. All call sites already pass `articles.count`, so no other changes are needed.

## Test plan
- [ ] Open a feed that has no articles yet (e.g. a freshly added source) and confirm only the empty state is shown.
- [ ] Open a feed with articles and confirm the load-previous sentinel/button still appears and triggers older-content loads as before (both auto-load and manual-button modes).
- [ ] Pull-to-refresh on an empty feed and confirm no stray sentinel flashes in.

https://claude.ai/code/session_01Ssk4YeGvrtMsUPLnFgin7R

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ssk4YeGvrtMsUPLnFgin7R)_