### PR TITLE
Hide load-more sentinel when no older unread remain

### DIFF
--- a/SakuraRSS/Views/Feeds/FeedArticlesView.swift
+++ b/SakuraRSS/Views/Feeds/FeedArticlesView.swift
@@ -18,6 +18,7 @@ struct FeedArticlesView: View {
     }
 
     private var loadMoreAction: (() -> Void)? {
+        if hideViewedContent && visibility.hasReachedEnd { return nil }
         if let days = batchingMode.chunkDays {
             guard let next = feedManager.nextArticleChunk(for: feed,
                                                           before: loadedSinceDate,

--- a/SakuraRSS/Views/Home/AllArticlesView.swift
+++ b/SakuraRSS/Views/Home/AllArticlesView.swift
@@ -159,6 +159,7 @@ struct AllArticlesView: View {
     }
 
     private var loadMoreAction: (() -> Void)? {
+        if hideViewedContent && visibility.hasReachedEnd { return nil }
         if let days = batchingMode.chunkDays {
             guard let next = feedManager.nextArticleChunk(before: loadedSinceDate, chunkDays: days) else {
                 return nil

--- a/SakuraRSS/Views/Home/HomeSectionView.swift
+++ b/SakuraRSS/Views/Home/HomeSectionView.swift
@@ -46,6 +46,7 @@ struct HomeSectionView: View {
     }
 
     private var loadMoreAction: (() -> Void)? {
+        if hideViewedContent && visibility.hasReachedEnd { return nil }
         if let days = batchingMode.chunkDays {
             guard let next = feedManager.nextArticleChunk(for: section,
                                                           before: loadedSinceDate,

--- a/SakuraRSS/Views/Home/ListSectionView.swift
+++ b/SakuraRSS/Views/Home/ListSectionView.swift
@@ -39,6 +39,7 @@ struct ListSectionView: View {
     }
 
     private var loadMoreAction: (() -> Void)? {
+        if hideViewedContent && visibility.hasReachedEnd { return nil }
         if let days = batchingMode.chunkDays {
             guard let next = feedManager.nextArticleChunk(for: list,
                                                           before: loadedSinceDate,

--- a/SakuraRSS/Views/Shared/Articles/ArticleVisibilityTracker.swift
+++ b/SakuraRSS/Views/Shared/Articles/ArticleVisibilityTracker.swift
@@ -6,6 +6,9 @@ import SwiftUI
 /// the next explicit refresh.
 struct ArticleVisibilityTracker {
     var visibleIDs: Set<Int64>?
+    /// True once a backwards pagination produced no new unread articles, so
+    /// the load-more sentinel can be hidden until the next refresh / mode change.
+    var hasReachedEnd: Bool = false
 
     func filter(_ articles: [Article], isEnabled: Bool) -> [Article] {
         guard isEnabled, let visibleIDs else { return articles }
@@ -13,6 +16,7 @@ struct ArticleVisibilityTracker {
     }
 
     mutating func capture(from articles: [Article], isEnabled: Bool) {
+        hasReachedEnd = false
         guard isEnabled else {
             visibleIDs = nil
             return
@@ -20,13 +24,19 @@ struct ArticleVisibilityTracker {
         visibleIDs = Set(articles.filter { !$0.isRead }.map(\.id))
     }
 
-    mutating func extend(from articles: [Article], isEnabled: Bool) {
+    /// Returns true if at least one new unread ID was added.
+    @discardableResult
+    mutating func extend(from articles: [Article], isEnabled: Bool) -> Bool {
         guard isEnabled else {
             visibleIDs = nil
-            return
+            return false
         }
         let unreadIDs = Set(articles.filter { !$0.isRead }.map(\.id))
-        visibleIDs = (visibleIDs ?? []).union(unreadIDs)
+        let previous = visibleIDs ?? []
+        let merged = previous.union(unreadIDs)
+        let didGrow = merged.count > previous.count
+        visibleIDs = merged
+        return didGrow
     }
 }
 
@@ -44,17 +54,24 @@ private struct TrackArticleVisibilityModifier: ViewModifier {
                     tracker.capture(from: rawArticles(), isEnabled: hideViewedContent)
                 }
             }
-            .onChange(of: loadedSinceDate) { _, _ in
-                tracker.extend(from: rawArticles(), isEnabled: hideViewedContent)
+            .onChange(of: loadedSinceDate) { oldDate, newDate in
+                let didGrow = tracker.extend(from: rawArticles(), isEnabled: hideViewedContent)
+                if hideViewedContent, newDate < oldDate, !didGrow {
+                    tracker.hasReachedEnd = true
+                }
             }
-            .onChange(of: loadedCount) { _, _ in
-                tracker.extend(from: rawArticles(), isEnabled: hideViewedContent)
+            .onChange(of: loadedCount) { oldCount, newCount in
+                let didGrow = tracker.extend(from: rawArticles(), isEnabled: hideViewedContent)
+                if hideViewedContent, newCount > oldCount, !didGrow {
+                    tracker.hasReachedEnd = true
+                }
             }
             .onChange(of: hideViewedContent) { _, newValue in
                 if newValue {
                     tracker.capture(from: rawArticles(), isEnabled: newValue)
                 } else {
                     tracker.visibleIDs = nil
+                    tracker.hasReachedEnd = false
                 }
             }
     }


### PR DESCRIPTION
## Summary
- A feed with only a few unread items at the top kept the auto-load spinner ("過去のコンテンツを読み込み中...") on screen forever when **Hide Viewed Content** was on. `nextArticleChunk` would walk back to a chunk that contained articles, but those articles were already read, so `ArticleVisibilityTracker.extend(...)` added no new IDs and the sentinel was never removed.
- The tracker now records whether a backwards pagination actually grew the visible-ID set. Once a backwards step produces no new unread, the four feed views (`FeedArticlesView`, `AllArticlesView`, `HomeSectionView`, `ListSectionView`) return `nil` from `loadMoreAction`, which removes the sentinel.
- The flag resets on capture (refresh, batching-mode change) and when Hide Viewed Content is toggled off, so subsequent legitimate paginations still work.

## Test plan
- [ ] Open a feed that has a small number of unread items above a long tail of read items, with **Hide Viewed Content** on — the bottom spinner should disappear after one auto-load attempt instead of spinning indefinitely.
- [ ] Open a feed with several unread items spread across multiple days — auto-load should continue to walk back until it stops finding unread content.
- [ ] Pull-to-refresh on a feed where the sentinel had been hidden — sentinel should appear again if the refresh brings new unread.
- [ ] Toggle **Hide Viewed Content** off and on — load-more should still work in both modes.
- [ ] Verify count-based batching modes (e.g. `items50`) behave the same way.

https://claude.ai/code/session_015Hp6bwTB1uR2wMnJ3rZjqQ

---
_Generated by [Claude Code](https://claude.ai/code/session_015Hp6bwTB1uR2wMnJ3rZjqQ)_