### PR TITLE
Prompt to refresh after fetch instead of auto-updating list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,5 @@
+# Rules
+
 1. Do not add verbose comments.
    - You may write simple summarized docstrings.
 2. Do not create large .swift files.
@@ -7,3 +9,8 @@
    - Generate the object for each string in a separate file, then use Python to set the object as the value for localization keys in the xcstrings file.
    - Do not make large edits.
    - Do not generate localization strings as part of Python scripts.
+
+# Copywriting
+
+- Always use 'Web Feeds' when referring to the Petal feature
+- Always use the term 'content' and never 'article', 'article' is used internally only

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+Refresh.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+Refresh.swift
@@ -60,85 +60,105 @@ extension FeedManager {
 
         let database = database
         try await Task.detached {
-            guard let url = URL(string: feed.url) else { return }
-            let fetchURL = RedirectDomains.redirectedURL(url)
-
-            let (data, _) = try await URLSession.shared.data(for: .sakura(url: fetchURL, timeoutInterval: 5))
-            let parser = RSSParser()
-            guard let parsed = parser.parse(data: data) else { return }
-
-            let feedDomain = feed.domain
-            let preparedArticles = parsed.articles.map { article in
-                BodyPriorityDomains.applying(to: article, feedDomain: feedDomain)
-            }
-
-            let existingURLs = (try? database.existingArticleURLs(forFeedID: feed.id)) ?? []
-            let metadataImages: [String: String]
-            if skipImageFetch {
-                metadataImages = [:]
-            } else {
-                metadataImages = await FeedManager.fetchMetadataImages(
-                    for: preparedArticles, skippingURLs: existingURLs
-                )
-            }
-
-            let redditImages: [String: String] = (!skipImageFetch && feed.isRedditFeed)
-                ? await FeedManager.fetchRedditImages(forFeedURL: feed.url)
-                : [:]
-
-            let articleTuples = preparedArticles.map { article in
-                let redditImage = FeedManager.redditImageURL(
-                    for: article.url, in: redditImages
-                )
-                let resolvedImageURL = redditImage
-                    ?? article.imageURL
-                    ?? metadataImages[article.url]
-                return ArticleInsertItem(
-                    title: article.title,
-                    url: article.url,
-                    data: ArticleInsertData(
-                        author: article.author,
-                        summary: article.summary,
-                        content: article.content,
-                        imageURL: resolvedImageURL,
-                        publishedDate: article.publishedDate,
-                        audioURL: article.audioURL,
-                        duration: article.duration
-                    )
-                )
-            }
-
-            let feedTitleForIndex = parsed.title.isEmpty ? feed.title : parsed.title
-            let insertedIDs = (try? database.insertArticles(
-                feedID: feed.id, articles: articleTuples
-            )) ?? []
-
-            await FeedManager.runPostInsertPipeline(
-                insertedIDs: insertedIDs,
-                feedTitle: feedTitleForIndex,
+            try await FeedManager.runStandardFeedPipeline(
+                feed: feed,
+                database: database,
+                updateTitle: updateTitle,
+                skipImageFetch: skipImageFetch,
                 skipImagePreload: skipImagePreload,
                 runNLP: runNLP
             )
-
-            if feed.lastFetched == nil {
-                if parsed.isPodcast && !feed.isPodcast {
-                    try database.updateFeedIsPodcast(id: feed.id, isPodcast: true)
-                } else if !parsed.isPodcast && feed.isPodcast {
-                    try database.updateFeedIsPodcast(id: feed.id, isPodcast: false)
-                }
-                if updateTitle, !feed.isTitleCustomized,
-                   !parsed.title.isEmpty, parsed.title != feed.title {
-                    try database.updateFeed(
-                        id: feed.id, title: parsed.title, category: feed.category
-                    )
-                }
-            }
-            try database.updateFeedLastFetched(id: feed.id, date: Date())
         }.value
         await MainActor.run { self.bumpDataRevision() }
         if reloadData {
             await loadFromDatabaseInBackground(animated: true)
         }
+    }
+
+    /// Fetches and parses an RSS feed, resolves images, inserts new articles,
+    /// runs the post-insert pipeline, and updates feed metadata.
+    nonisolated static func runStandardFeedPipeline(
+        feed: Feed,
+        database: DatabaseManager,
+        updateTitle: Bool,
+        skipImageFetch: Bool,
+        skipImagePreload: Bool,
+        runNLP: Bool
+    ) async throws {
+        guard let url = URL(string: feed.url) else { return }
+        let fetchURL = RedirectDomains.redirectedURL(url)
+
+        let (data, _) = try await URLSession.shared.data(for: .sakura(url: fetchURL, timeoutInterval: 5))
+        let parser = RSSParser()
+        guard let parsed = parser.parse(data: data) else { return }
+
+        let feedDomain = feed.domain
+        let preparedArticles = parsed.articles.map { article in
+            BodyPriorityDomains.applying(to: article, feedDomain: feedDomain)
+        }
+
+        let existingURLs = (try? database.existingArticleURLs(forFeedID: feed.id)) ?? []
+        let metadataImages: [String: String]
+        if skipImageFetch {
+            metadataImages = [:]
+        } else {
+            metadataImages = await FeedManager.fetchMetadataImages(
+                for: preparedArticles, skippingURLs: existingURLs
+            )
+        }
+
+        let redditImages: [String: String] = (!skipImageFetch && feed.isRedditFeed)
+            ? await FeedManager.fetchRedditImages(forFeedURL: feed.url)
+            : [:]
+
+        let articleTuples = preparedArticles.map { article in
+            let redditImage = FeedManager.redditImageURL(
+                for: article.url, in: redditImages
+            )
+            let resolvedImageURL = redditImage
+                ?? article.imageURL
+                ?? metadataImages[article.url]
+            return ArticleInsertItem(
+                title: article.title,
+                url: article.url,
+                data: ArticleInsertData(
+                    author: article.author,
+                    summary: article.summary,
+                    content: article.content,
+                    imageURL: resolvedImageURL,
+                    publishedDate: article.publishedDate,
+                    audioURL: article.audioURL,
+                    duration: article.duration
+                )
+            )
+        }
+
+        let feedTitleForIndex = parsed.title.isEmpty ? feed.title : parsed.title
+        let insertedIDs = (try? database.insertArticles(
+            feedID: feed.id, articles: articleTuples
+        )) ?? []
+
+        await FeedManager.runPostInsertPipeline(
+            insertedIDs: insertedIDs,
+            feedTitle: feedTitleForIndex,
+            skipImagePreload: skipImagePreload,
+            runNLP: runNLP
+        )
+
+        if feed.lastFetched == nil {
+            if parsed.isPodcast && !feed.isPodcast {
+                try database.updateFeedIsPodcast(id: feed.id, isPodcast: true)
+            } else if !parsed.isPodcast && feed.isPodcast {
+                try database.updateFeedIsPodcast(id: feed.id, isPodcast: false)
+            }
+            if updateTitle, !feed.isTitleCustomized,
+               !parsed.title.isEmpty, parsed.title != feed.title {
+                try database.updateFeed(
+                    id: feed.id, title: parsed.title, category: feed.category
+                )
+            }
+        }
+        try database.updateFeedLastFetched(id: feed.id, date: Date())
     }
 
     /// Spotlight indexing, image preloading, and NLP for the articles a feed

--- a/SakuraRSS/Views/Feeds/FeedArticlesView.swift
+++ b/SakuraRSS/Views/Feeds/FeedArticlesView.swift
@@ -51,9 +51,17 @@ struct FeedArticlesView: View {
 
     private func performRefresh() async {
         feedManager.flushDebouncedReads()
-        visibility.capture(from: rawArticles, isEnabled: hideViewedContent)
+        visibility.beginRefresh(from: rawArticles, isEnabled: hideViewedContent)
         try? await feedManager.refreshFeed(feed)
-        visibility.extend(from: rawArticles, isEnabled: hideViewedContent)
+        withAnimation(.smooth.speed(2.0)) {
+            visibility.endRefresh(from: rawArticles, isEnabled: hideViewedContent)
+        }
+    }
+
+    private func acceptPendingRefresh() {
+        withAnimation(.smooth.speed(2.0)) {
+            visibility.acceptPendingRefresh()
+        }
     }
 
     var body: some View {
@@ -89,6 +97,15 @@ struct FeedArticlesView: View {
             loadedCount: loadedCount,
             rawArticles: { rawArticles }
         )
+        .trackBackgroundRefresh(
+            $visibility,
+            isLoading: feedManager.isLoading,
+            hideViewedContent: hideViewedContent,
+            rawArticles: { rawArticles }
+        )
+        .refreshPromptOverlay(isVisible: visibility.hasPendingRefresh) {
+            acceptPendingRefresh()
+        }
         .onChange(of: batchingMode) { _, newMode in
             loadedSinceDate = newMode.initialSinceDate()
             loadedCount = newMode.initialCount()

--- a/SakuraRSS/Views/Home/AllArticlesView.swift
+++ b/SakuraRSS/Views/Home/AllArticlesView.swift
@@ -142,19 +142,29 @@ struct AllArticlesView: View {
 
     private func performRefresh() async {
         feedManager.flushDebouncedReads()
-        visibility.capture(from: rawArticles, isEnabled: hideViewedContent)
+        visibility.beginRefresh(from: rawArticles, isEnabled: hideViewedContent)
         await feedManager.refreshAllFeeds()
-        visibility.extend(from: rawArticles, isEnabled: hideViewedContent)
+        withAnimation(.smooth.speed(2.0)) {
+            visibility.endRefresh(from: rawArticles, isEnabled: hideViewedContent)
+        }
     }
 
     /// Kicks off a refresh and returns immediately so SwiftUI dismisses the
     /// pull-to-refresh indicator; in-flight progress shows via the toolbar donut.
     private func startRefreshWithoutBlocking() {
         feedManager.flushDebouncedReads()
-        visibility.capture(from: rawArticles, isEnabled: hideViewedContent)
+        visibility.beginRefresh(from: rawArticles, isEnabled: hideViewedContent)
         Task { @MainActor in
             await feedManager.refreshAllFeeds()
-            visibility.extend(from: rawArticles, isEnabled: hideViewedContent)
+            withAnimation(.smooth.speed(2.0)) {
+                visibility.endRefresh(from: rawArticles, isEnabled: hideViewedContent)
+            }
+        }
+    }
+
+    private func acceptPendingRefresh() {
+        withAnimation(.smooth.speed(2.0)) {
+            visibility.acceptPendingRefresh()
         }
     }
 
@@ -346,5 +356,14 @@ struct AllArticlesView: View {
             loadedCount: loadedCount,
             rawArticles: { rawArticles }
         )
+        .trackBackgroundRefresh(
+            $visibility,
+            isLoading: feedManager.isLoading,
+            hideViewedContent: hideViewedContent,
+            rawArticles: { rawArticles }
+        )
+        .refreshPromptOverlay(isVisible: visibility.hasPendingRefresh) {
+            acceptPendingRefresh()
+        }
     }
 }

--- a/SakuraRSS/Views/Home/HomeSectionView.swift
+++ b/SakuraRSS/Views/Home/HomeSectionView.swift
@@ -29,19 +29,29 @@ struct HomeSectionView: View {
 
     private func performRefresh() async {
         feedManager.flushDebouncedReads()
-        visibility.capture(from: rawArticles, isEnabled: hideViewedContent)
+        visibility.beginRefresh(from: rawArticles, isEnabled: hideViewedContent)
         await feedManager.refreshAllFeeds()
-        visibility.extend(from: rawArticles, isEnabled: hideViewedContent)
+        withAnimation(.smooth.speed(2.0)) {
+            visibility.endRefresh(from: rawArticles, isEnabled: hideViewedContent)
+        }
     }
 
     /// Kicks off a refresh and returns immediately so SwiftUI dismisses the
     /// pull-to-refresh indicator; in-flight progress shows via the toolbar donut.
     private func startRefreshWithoutBlocking() {
         feedManager.flushDebouncedReads()
-        visibility.capture(from: rawArticles, isEnabled: hideViewedContent)
+        visibility.beginRefresh(from: rawArticles, isEnabled: hideViewedContent)
         Task { @MainActor in
             await feedManager.refreshAllFeeds()
-            visibility.extend(from: rawArticles, isEnabled: hideViewedContent)
+            withAnimation(.smooth.speed(2.0)) {
+                visibility.endRefresh(from: rawArticles, isEnabled: hideViewedContent)
+            }
+        }
+    }
+
+    private func acceptPendingRefresh() {
+        withAnimation(.smooth.speed(2.0)) {
+            visibility.acceptPendingRefresh()
         }
     }
 
@@ -91,6 +101,15 @@ struct HomeSectionView: View {
             loadedCount: loadedCount,
             rawArticles: { rawArticles }
         )
+        .trackBackgroundRefresh(
+            $visibility,
+            isLoading: feedManager.isLoading,
+            hideViewedContent: hideViewedContent,
+            rawArticles: { rawArticles }
+        )
+        .refreshPromptOverlay(isVisible: visibility.hasPendingRefresh) {
+            acceptPendingRefresh()
+        }
         .onChange(of: batchingMode) { _, newMode in
             loadedSinceDate = newMode.initialSinceDate()
             loadedCount = newMode.initialCount()

--- a/SakuraRSS/Views/Home/ListSectionView.swift
+++ b/SakuraRSS/Views/Home/ListSectionView.swift
@@ -22,19 +22,29 @@ struct ListSectionView: View {
 
     private func performRefresh() async {
         feedManager.flushDebouncedReads()
-        visibility.capture(from: rawArticles, isEnabled: hideViewedContent)
+        visibility.beginRefresh(from: rawArticles, isEnabled: hideViewedContent)
         await feedManager.refreshAllFeeds()
-        visibility.extend(from: rawArticles, isEnabled: hideViewedContent)
+        withAnimation(.smooth.speed(2.0)) {
+            visibility.endRefresh(from: rawArticles, isEnabled: hideViewedContent)
+        }
     }
 
     /// Kicks off a refresh and returns immediately so SwiftUI dismisses the
     /// pull-to-refresh indicator; in-flight progress shows via the toolbar donut.
     private func startRefreshWithoutBlocking() {
         feedManager.flushDebouncedReads()
-        visibility.capture(from: rawArticles, isEnabled: hideViewedContent)
+        visibility.beginRefresh(from: rawArticles, isEnabled: hideViewedContent)
         Task { @MainActor in
             await feedManager.refreshAllFeeds()
-            visibility.extend(from: rawArticles, isEnabled: hideViewedContent)
+            withAnimation(.smooth.speed(2.0)) {
+                visibility.endRefresh(from: rawArticles, isEnabled: hideViewedContent)
+            }
+        }
+    }
+
+    private func acceptPendingRefresh() {
+        withAnimation(.smooth.speed(2.0)) {
+            visibility.acceptPendingRefresh()
         }
     }
 
@@ -81,6 +91,15 @@ struct ListSectionView: View {
             loadedCount: loadedCount,
             rawArticles: { rawArticles }
         )
+        .trackBackgroundRefresh(
+            $visibility,
+            isLoading: feedManager.isLoading,
+            hideViewedContent: hideViewedContent,
+            rawArticles: { rawArticles }
+        )
+        .refreshPromptOverlay(isVisible: visibility.hasPendingRefresh) {
+            acceptPendingRefresh()
+        }
         .onChange(of: batchingMode) { _, newMode in
             loadedSinceDate = newMode.initialSinceDate()
             loadedCount = newMode.initialCount()

--- a/SakuraRSS/Views/Shared/Articles/ArticleVisibilityTracker.swift
+++ b/SakuraRSS/Views/Shared/Articles/ArticleVisibilityTracker.swift
@@ -1,18 +1,31 @@
 import SwiftUI
 
-/// Tracks which article IDs are visible when Hide Viewed Content is on.
-/// The snapshot is captured on first load and on refresh, extended on pagination,
-/// and preserved across read-state changes so read articles remain visible until
-/// the next explicit refresh.
+/// Tracks which article IDs are visible when Hide Viewed Content is on, and
+/// holds back articles that arrive during a refresh until the user accepts
+/// them via the refresh prompt button.
 struct ArticleVisibilityTracker {
     var visibleIDs: Set<Int64>?
+    /// Article IDs that arrived during the most recent refresh and haven't
+    /// been released yet. Filtered out of the displayed list until the user
+    /// taps the refresh prompt.
+    var pendingIDs: Set<Int64> = []
     /// True once a backwards pagination produced no new unread articles, so
     /// the load-more sentinel can be hidden until the next refresh / mode change.
     var hasReachedEnd: Bool = false
+    private var preRefreshIDs: Set<Int64> = []
+    private var activeRefreshCount: Int = 0
+
+    var hasPendingRefresh: Bool { !pendingIDs.isEmpty }
 
     func filter(_ articles: [Article], isEnabled: Bool) -> [Article] {
-        guard isEnabled, let visibleIDs else { return articles }
-        return articles.filter { visibleIDs.contains($0.id) }
+        var result = articles
+        if isEnabled, let visibleIDs {
+            result = result.filter { visibleIDs.contains($0.id) }
+        }
+        if !pendingIDs.isEmpty {
+            result = result.filter { !pendingIDs.contains($0.id) }
+        }
+        return result
     }
 
     mutating func capture(from articles: [Article], isEnabled: Bool) {
@@ -37,6 +50,45 @@ struct ArticleVisibilityTracker {
         let didGrow = merged.count > previous.count
         visibleIDs = merged
         return didGrow
+    }
+
+    /// Snapshots the current article IDs so a later `endRefresh` can compute
+    /// what arrived during the refresh. When Hide Viewed Content is on, the
+    /// visible set is also recaptured so newly-read items disappear immediately.
+    mutating func beginRefresh(from articles: [Article], isEnabled: Bool) {
+        if activeRefreshCount == 0 {
+            hasReachedEnd = false
+            preRefreshIDs = Set(articles.map(\.id)).union(visibleIDs ?? []).union(pendingIDs)
+            if isEnabled {
+                visibleIDs = Set(articles.filter { !$0.isRead }.map(\.id))
+            } else {
+                visibleIDs = nil
+            }
+        }
+        activeRefreshCount += 1
+    }
+
+    /// Computes the set of article IDs that arrived during the refresh and
+    /// stores them as pending until the user taps the refresh prompt.
+    mutating func endRefresh(from articles: [Article], isEnabled: Bool) {
+        guard activeRefreshCount > 0 else { return }
+        activeRefreshCount -= 1
+        guard activeRefreshCount == 0 else { return }
+        let currentIDs = Set(articles.map(\.id))
+        let newIDs = currentIDs.subtracting(preRefreshIDs)
+        if !newIDs.isEmpty {
+            pendingIDs.formUnion(newIDs)
+        }
+        preRefreshIDs = []
+    }
+
+    /// Releases any pending articles into the visible list.
+    mutating func acceptPendingRefresh() {
+        guard !pendingIDs.isEmpty else { return }
+        if visibleIDs != nil {
+            visibleIDs = (visibleIDs ?? []).union(pendingIDs)
+        }
+        pendingIDs = []
     }
 }
 
@@ -90,6 +142,49 @@ extension View {
             hideViewedContent: hideViewedContent,
             loadedSinceDate: loadedSinceDate,
             loadedCount: loadedCount,
+            rawArticles: rawArticles
+        ))
+    }
+}
+
+private struct TrackBackgroundRefreshModifier: ViewModifier {
+    @Binding var tracker: ArticleVisibilityTracker
+    let isLoading: Bool
+    let hideViewedContent: Bool
+    let rawArticles: () -> [Article]
+
+    func body(content: Content) -> some View {
+        content
+            .task {
+                if isLoading {
+                    tracker.beginRefresh(from: rawArticles(), isEnabled: hideViewedContent)
+                }
+            }
+            .onChange(of: isLoading) { _, newValue in
+                if newValue {
+                    tracker.beginRefresh(from: rawArticles(), isEnabled: hideViewedContent)
+                } else {
+                    withAnimation(.smooth.speed(2.0)) {
+                        tracker.endRefresh(from: rawArticles(), isEnabled: hideViewedContent)
+                    }
+                }
+            }
+    }
+}
+
+extension View {
+    /// Observes a background refresh signal and snapshots / computes pending
+    /// articles so the refresh prompt button can appear once new content arrives.
+    func trackBackgroundRefresh(
+        _ tracker: Binding<ArticleVisibilityTracker>,
+        isLoading: Bool,
+        hideViewedContent: Bool,
+        rawArticles: @escaping () -> [Article]
+    ) -> some View {
+        modifier(TrackBackgroundRefreshModifier(
+            tracker: tracker,
+            isLoading: isLoading,
+            hideViewedContent: hideViewedContent,
             rawArticles: rawArticles
         ))
     }

--- a/SakuraRSS/Views/Shared/Articles/RefreshPromptButton.swift
+++ b/SakuraRSS/Views/Shared/Articles/RefreshPromptButton.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+
+/// Capsule Liquid Glass button that appears at the top of an article list when
+/// new content has arrived during a refresh. Tapping it releases the pending
+/// articles into the visible list.
+struct RefreshPromptButton: View {
+
+    let action: () -> Void
+
+    var body: some View {
+        Button {
+            action()
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: "arrow.clockwise")
+                    .font(.system(size: 13.0, weight: .semibold))
+                Text(String(localized: "Refresh.NewArticles", table: "Articles"))
+                    .font(.subheadline.weight(.semibold))
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 8)
+        }
+        .buttonStyle(.glassProminent)
+        .buttonBorderShape(.capsule)
+        .shadow(color: Color.black.opacity(0.15), radius: 8, x: 0, y: 2)
+    }
+}
+
+private struct RefreshPromptOverlay: ViewModifier {
+    let isVisible: Bool
+    let action: () -> Void
+
+    func body(content: Content) -> some View {
+        content
+            .safeAreaInset(edge: .top, spacing: 0) {
+                ZStack {
+                    if isVisible {
+                        RefreshPromptButton(action: action)
+                            .padding(.top, 8)
+                            .padding(.bottom, 4)
+                            .transition(
+                                .move(edge: .top)
+                                    .combined(with: .opacity)
+                            )
+                    }
+                }
+                .frame(maxWidth: .infinity)
+                .animation(.smooth.speed(2.0), value: isVisible)
+            }
+    }
+}
+
+extension View {
+    func refreshPromptOverlay(
+        isVisible: Bool,
+        action: @escaping () -> Void
+    ) -> some View {
+        modifier(RefreshPromptOverlay(isVisible: isVisible, action: action))
+    }
+}

--- a/SakuraRSS/Views/Shared/Articles/RefreshPromptButton.swift
+++ b/SakuraRSS/Views/Shared/Articles/RefreshPromptButton.swift
@@ -1,8 +1,8 @@
 import SwiftUI
 
-/// Capsule Liquid Glass button that appears at the top of an article list when
-/// new content has arrived during a refresh. Tapping it releases the pending
-/// articles into the visible list.
+/// Button that appears at the top of an article list when new content has
+/// arrived during a refresh. Tapping it releases the pending articles into
+/// the visible list.
 struct RefreshPromptButton: View {
 
     let action: () -> Void
@@ -11,16 +11,12 @@ struct RefreshPromptButton: View {
         Button {
             action()
         } label: {
-            HStack(spacing: 6) {
-                Image(systemName: "arrow.clockwise")
-                    .font(.system(size: 13.0, weight: .semibold))
-                Text(String(localized: "Refresh.NewArticles", table: "Articles"))
-                    .font(.subheadline.weight(.semibold))
-            }
-            .padding(.horizontal, 14)
-            .padding(.vertical, 8)
+            Text(String(localized: "Refresh.NewArticles", table: "Articles"))
+                .font(.subheadline.weight(.semibold))
+                .padding(.horizontal, 10)
+                .padding(.vertical, 4)
         }
-        .buttonStyle(.glassProminent)
+        .buttonStyle(.glass)
         .buttonBorderShape(.capsule)
         .shadow(color: Color.black.opacity(0.15), radius: 8, x: 0, y: 2)
     }

--- a/SakuraRSS/Views/Shared/Articles/RefreshPromptButton.swift
+++ b/SakuraRSS/Views/Shared/Articles/RefreshPromptButton.swift
@@ -11,7 +11,7 @@ struct RefreshPromptButton: View {
         Button {
             action()
         } label: {
-            Text(String(localized: "Refresh.NewArticles", table: "Articles"))
+            Text(String(localized: "Refresh.NewContent", table: "Articles"))
                 .font(.subheadline.weight(.semibold))
                 .padding(.horizontal, 10)
                 .padding(.vertical, 4)

--- a/Shared/Strings/Articles.xcstrings
+++ b/Shared/Strings/Articles.xcstrings
@@ -857,13 +857,13 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "有料記事 — タップでSafariで開く"
+            "value": "有料コンテンツ — タップでSafariで開く"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "유료 기사 — Safari에서 열려면 탭하세요"
+            "value": "유료 콘텐츠 — Safari에서 열려면 탭하세요"
           }
         },
         "vi": {
@@ -1305,55 +1305,55 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nachfolgend ist der vollständige Text eines Artikels. Fassen Sie ihn zusammen, indem Sie die wichtigsten Punkte aus jedem Absatz extrahieren. Antworten Sie in derselben Sprache wie der Artikel. Verwenden Sie einfache Sprache. Sie dürfen **fett** verwenden, um wichtige Begriffe hervorzuheben. Fügen Sie keine Einleitung oder kein Fazit hinzu. Geben Sie nur die wichtigsten Punkte als knappe Aufzählungspunkte aus.\n\nArtikel:"
+            "value": "Nachfolgend ist der vollständige Text des Inhalts. Fassen Sie ihn zusammen, indem Sie die wichtigsten Punkte aus jedem Absatz extrahieren. Antworten Sie in derselben Sprache wie der Inhalt. Verwenden Sie einfache Sprache. Sie dürfen **fett** verwenden, um wichtige Begriffe hervorzuheben. Fügen Sie keine Einleitung oder kein Fazit hinzu. Geben Sie nur die wichtigsten Punkte als knappe Aufzählungspunkte aus.\n\nInhalt:"
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Below is the full text of an article. Summarize it by extracting the key points from each paragraph. Respond in the same language as the article. Use plain language. You may use **bold** to emphasize key terms. Do not include any introduction or conclusion. Only output the key points as concise bullet points.\n\nArticle:"
+            "value": "Below is the full text of the content. Summarize it by extracting the key points from each paragraph. Respond in the same language as the content. Use plain language. You may use **bold** to emphasize key terms. Do not include any introduction or conclusion. Only output the key points as concise bullet points.\n\nContent:"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ci-dessous se trouve le texte complet d'un article. Résumez-le en extrayant les points clés de chaque paragraphe. Répondez dans la même langue que l'article. Utilisez un langage simple. Vous pouvez utiliser le **gras** pour mettre en valeur les termes clés. N'incluez aucune introduction ni conclusion. Donnez uniquement les points clés sous forme de puces concises.\n\nArticle :"
+            "value": "Ci-dessous se trouve le texte complet du contenu. Résumez-le en extrayant les points clés de chaque paragraphe. Répondez dans la même langue que le contenu. Utilisez un langage simple. Vous pouvez utiliser le **gras** pour mettre en valeur les termes clés. N'incluez aucune introduction ni conclusion. Donnez uniquement les points clés sous forme de puces concises.\n\nContenu :"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Di seguito è riportato il testo completo di un articolo. Riassumilo estraendo i punti chiave da ogni paragrafo. Rispondi nella stessa lingua dell'articolo. Usa un linguaggio semplice. Puoi usare il **grassetto** per evidenziare i termini chiave. Non includere introduzione o conclusione. Riporta solo i punti chiave come elenco puntato conciso.\n\nArticolo:"
+            "value": "Di seguito è riportato il testo completo del contenuto. Riassumilo estraendo i punti chiave da ogni paragrafo. Rispondi nella stessa lingua del contenuto. Usa un linguaggio semplice. Puoi usare il **grassetto** per evidenziare i termini chiave. Non includere introduzione o conclusione. Riporta solo i punti chiave come elenco puntato conciso.\n\nContenuto:"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "以下は記事の全文です。各段落の要点を抽出して要約してください。記事と同じ言語で回答してください。平易な言葉を使ってください。重要な用語を強調するために**太字**を使用できます。導入文やまとめは含めないでください。簡潔な箇条書きで要点のみを出力してください。\n\n記事:"
+            "value": "以下はコンテンツの全文です。各段落の要点を抽出して要約してください。コンテンツと同じ言語で回答してください。平易な言葉を使ってください。重要な用語を強調するために**太字**を使用できます。導入文やまとめは含めないでください。簡潔な箇条書きで要点のみを出力してください。\n\nコンテンツ:"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "아래는 기사의 전문입니다. 각 단락에서 핵심 내용을 추출하여 요약하세요. 기사와 같은 언어로 응답하세요. 쉬운 언어를 사용하세요. 핵심 용어를 강조하기 위해 **굵게**를 사용할 수 있습니다. 서론이나 결론을 포함하지 마세요. 핵심 내용만 간결한 글머리 기호로 출력하세요.\n\n기사:"
+            "value": "아래는 콘텐츠의 전문입니다. 각 단락에서 핵심 내용을 추출하여 요약하세요. 콘텐츠와 같은 언어로 응답하세요. 쉬운 언어를 사용하세요. 핵심 용어를 강조하기 위해 **굵게**를 사용할 수 있습니다. 서론이나 결론을 포함하지 마세요. 핵심 내용만 간결한 글머리 기호로 출력하세요.\n\n콘텐츠:"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Dưới đây là toàn bộ nội dung của một bài viết. Hãy tóm tắt bằng cách trích xuất các ý chính từ mỗi đoạn. Trả lời bằng tiếng Việt. Sử dụng ngôn ngữ đơn giản. Bạn có thể sử dụng **in đậm** để nhấn mạnh các thuật ngữ quan trọng. Không viết phần mở đầu hay kết luận. Chỉ xuất các ý chính dưới dạng gạch đầu dòng ngắn gọn.\n\nBài viết:"
+            "value": "Dưới đây là toàn bộ nội dung. Hãy tóm tắt bằng cách trích xuất các ý chính từ mỗi đoạn. Trả lời bằng ngôn ngữ tương tự nội dung. Sử dụng ngôn ngữ đơn giản. Bạn có thể sử dụng **in đậm** để nhấn mạnh các thuật ngữ quan trọng. Không viết phần mở đầu hay kết luận. Chỉ xuất các ý chính dưới dạng gạch đầu dòng ngắn gọn.\n\nNội dung:"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "以下是一篇文章的全文。请提取每个段落的要点进行总结。用与文章相同的语言回答。使用简洁的语言。可以使用**粗体**来强调关键术语。不要包含任何引言或结论。仅输出简洁的要点列表。\n\n文章："
+            "value": "以下是内容全文。请提取每个段落的要点进行总结。用与内容相同的语言回答。使用简洁的语言。可以使用**粗体**来强调关键术语。不要包含任何引言或结论。仅输出简洁的要点列表。\n\n内容："
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "以下是一篇文章的全文。請從每個段落中提取重點來進行摘要。用與文章相同的語言回答。使用淺顯易懂的語言。可以使用**粗體**來強調關鍵術語。不要包含任何引言或結論。只輸出簡潔的重點條列。\n\n文章："
+            "value": "以下是內容全文。請從每個段落中提取重點來進行摘要。用與內容相同的語言回答。使用淺顯易懂的語言。可以使用**粗體**來強調關鍵術語。不要包含任何引言或結論。只輸出簡潔的重點條列。\n\n內容："
           }
         }
       }
@@ -2780,55 +2780,55 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "In Artikeln erwähnte Personen werden hier nach der Verarbeitung angezeigt. Aktivieren Sie „Themen & Personen“ in den Einstellungen für Geräteintelligenz."
+            "value": "In Inhalten erwähnte Personen werden hier nach der Verarbeitung angezeigt. Aktivieren Sie „Themen & Personen“ in den Einstellungen für Geräteintelligenz."
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "People mentioned in articles will appear here after processing. Enable Topics & People in On-Device Intelligence settings."
+            "value": "People mentioned in content will appear here after processing. Enable Topics & People in On-Device Intelligence settings."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Les personnes mentionnées dans les articles apparaîtront ici après traitement. Activez Sujets et personnes dans les réglages Intelligence sur l’appareil."
+            "value": "Les personnes mentionnées dans le contenu apparaîtront ici après traitement. Activez Sujets et personnes dans les réglages Intelligence sur l’appareil."
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Le persone menzionate negli articoli appariranno qui dopo l’elaborazione. Abilita Argomenti e persone nelle impostazioni Intelligenza sul dispositivo."
+            "value": "Le persone menzionate nei contenuti appariranno qui dopo l’elaborazione. Abilita Argomenti e persone nelle impostazioni Intelligenza sul dispositivo."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "記事で言及された人物が処理後にここに表示されます。オンデバイスインテリジェンス設定で「トピックと人物」を有効にしてください。"
+            "value": "コンテンツ内で言及された人物が処理後にここに表示されます。オンデバイスインテリジェンス設定で「トピックと人物」を有効にしてください。"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "기사에서 언급된 인물이 처리 후 여기에 표시됩니다. 온디바이스 인텔리전스 설정에서 주제 및 인물을 활성화하세요."
+            "value": "콘텐츠에서 언급된 인물이 처리 후 여기에 표시됩니다. 온디바이스 인텔리전스 설정에서 주제 및 인물을 활성화하세요."
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Những người được nhắc đến trong bài viết sẽ xuất hiện ở đây sau khi xử lý. Bật Chủ đề và Nhân vật trong cài đặt Trí tuệ trên thiết bị."
+            "value": "Những người được nhắc đến trong nội dung sẽ xuất hiện ở đây sau khi xử lý. Bật Chủ đề và Nhân vật trong cài đặt Trí tuệ trên thiết bị."
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "文章中提到的人物将在处理后显示在此。请在设备端智能设置中启用话题与人物。"
+            "value": "内容中提到的人物将在处理后显示在此。请在设备端智能设置中启用话题与人物。"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "文章中提到的人物將在處理後顯示於此。請在裝置端智慧設定中啟用話題與人物。"
+            "value": "內容中提到的人物將在處理後顯示於此。請在裝置端智慧設定中啟用話題與人物。"
           }
         }
       }
@@ -2892,61 +2892,61 @@
         }
       }
     },
-    "Refresh.NewArticles": {
+    "Refresh.NewContent": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Neue Artikel"
+            "value": "Neue Inhalte"
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "New Articles"
+            "value": "New Content"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nouveaux articles"
+            "value": "Nouveau contenu"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nuovi articoli"
+            "value": "Nuovi contenuti"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "新しい記事"
+            "value": "新しいコンテンツ"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "새로운 기사"
+            "value": "새로운 콘텐츠"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Bài viết mới"
+            "value": "Nội dung mới"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "新文章"
+            "value": "新内容"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "新文章"
+            "value": "新內容"
           }
         }
       }
@@ -2957,55 +2957,55 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Lade ältere Artikel, um weiter zu scrollen."
+            "value": "Lade ältere Inhalte, um weiter zu scrollen."
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Load older articles to keep scrolling."
+            "value": "Load older content to keep scrolling."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Chargez des articles plus anciens pour continuer à défiler."
+            "value": "Chargez du contenu plus ancien pour continuer à défiler."
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Carica articoli più vecchi per continuare a scorrere."
+            "value": "Carica contenuti più vecchi per continuare a scorrere."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "続きを閲覧するには、過去の記事を読み込んでください。"
+            "value": "続きを閲覧するには、過去のコンテンツを読み込んでください。"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "계속 스크롤하려면 이전 기사를 불러오세요."
+            "value": "계속 스크롤하려면 이전 콘텐츠를 불러오세요."
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tải thêm bài viết cũ hơn để tiếp tục cuộn."
+            "value": "Tải thêm nội dung cũ hơn để tiếp tục cuộn."
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "加载更早的文章以继续滚动。"
+            "value": "加载更早的内容以继续滚动。"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "載入較舊的文章以繼續捲動。"
+            "value": "載入較舊的內容以繼續捲動。"
           }
         }
       }
@@ -4432,55 +4432,55 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Themen erscheinen, nachdem Artikel verarbeitet wurden. Aktivieren Sie „Themen & Personen“ in den Einstellungen für Geräteintelligenz."
+            "value": "Themen erscheinen, nachdem Inhalte verarbeitet wurden. Aktivieren Sie „Themen & Personen“ in den Einstellungen für Geräteintelligenz."
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Topics will appear after articles are processed. Enable Topics & People in On-Device Intelligence settings."
+            "value": "Topics will appear after content is processed. Enable Topics & People in On-Device Intelligence settings."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Les sujets apparaîtront après le traitement des articles. Activez Sujets et personnes dans les réglages Intelligence sur l’appareil."
+            "value": "Les sujets apparaîtront après le traitement du contenu. Activez Sujets et personnes dans les réglages Intelligence sur l’appareil."
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Gli argomenti appariranno dopo l’elaborazione degli articoli. Abilita Argomenti e persone nelle impostazioni Intelligenza sul dispositivo."
+            "value": "Gli argomenti appariranno dopo l’elaborazione dei contenuti. Abilita Argomenti e persone nelle impostazioni Intelligenza sul dispositivo."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "記事が処理された後にトピックが表示されます。オンデバイスインテリジェンス設定で「トピックと人物」を有効にしてください。"
+            "value": "コンテンツが処理された後にトピックが表示されます。オンデバイスインテリジェンス設定で「トピックと人物」を有効にしてください。"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "기사가 처리된 후 주제가 표시됩니다. 온디바이스 인텔리전스 설정에서 주제 및 인물을 활성화하세요."
+            "value": "콘텐츠가 처리된 후 주제가 표시됩니다. 온디바이스 인텔리전스 설정에서 주제 및 인물을 활성화하세요."
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Chủ đề sẽ xuất hiện sau khi bài viết được xử lý. Bật Chủ đề và Nhân vật trong cài đặt Trí tuệ trên thiết bị."
+            "value": "Chủ đề sẽ xuất hiện sau khi nội dung được xử lý. Bật Chủ đề và Nhân vật trong cài đặt Trí tuệ trên thiết bị."
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "文章处理后将显示话题。请在设备端智能设置中启用话题与人物。"
+            "value": "内容处理后将显示话题。请在设备端智能设置中启用话题与人物。"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "文章處理後將顯示話題。請在裝置端智慧設定中啟用話題與人物。"
+            "value": "內容處理後將顯示話題。請在裝置端智慧設定中啟用話題與人物。"
           }
         }
       }

--- a/Shared/Strings/Articles.xcstrings
+++ b/Shared/Strings/Articles.xcstrings
@@ -2892,6 +2892,65 @@
         }
       }
     },
+    "Refresh.NewArticles": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Neue Artikel"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New Articles"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nouveaux articles"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nuovi articoli"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新しい記事"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "새로운 기사"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bài viết mới"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新文章"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新文章"
+          }
+        }
+      }
+    },
     "Scroll.EndOfFeed.Description": {
       "extractionState": "manual",
       "localizations": {


### PR DESCRIPTION
## Summary

When a refresh finishes (startup, swipe-to-refresh, or background fetch on All Articles / Home sections / Lists / individual feeds), articles that arrived during the refresh are now held back. A capsule Liquid Glass button slides in from the top showing **New Articles**; tapping it releases the pending articles into the visible list.

Swipe-to-refresh still flushes debounced reads and immediately hides read content when Hide Viewed Content is on — only the *new* articles are gated behind the prompt.

### Implementation

- `ArticleVisibilityTracker` gains `pendingIDs`, `beginRefresh`, `endRefresh`, and `acceptPendingRefresh`. The filter excludes pending IDs until they are accepted. A reference-counted `activeRefreshCount` lets concurrent refresh signals (explicit `performRefresh` + observed `feedManager.isLoading`) compose without double-resetting state.
- New `RefreshPromptButton` view + `refreshPromptOverlay` modifier render the capsule glass prompt as a top `safeAreaInset` with a slide-down/opacity transition.
- New `trackBackgroundRefresh` modifier observes `feedManager.isLoading` so background-initiated refreshes (notably the startup `refreshAllFeeds`) also produce a prompt.
- Wired into `FeedArticlesView`, `AllArticlesView` (feed tab), `HomeSectionView`, and `ListSectionView`.
- Added `Refresh.NewArticles` to `Articles.xcstrings` localized for de, en, fr, it, ja, ko, vi, zh-Hans, zh-Hant.

## Test plan

- [ ] Cold launch with `App.FetchOnStartup` enabled — verify the prompt slides in at the top of All Articles after startup refresh completes
- [ ] Swipe-to-refresh on All Articles and an individual feed — verify the indicator dismisses immediately, and a prompt appears once new content arrives
- [ ] With Hide Viewed Content ON, swipe to refresh — verify read articles are hidden immediately and the new articles remain hidden until tapping the prompt
- [ ] Tap the prompt — verify the new articles fade into the list and the prompt disappears
- [ ] Refresh with no new content — verify the prompt does not appear
- [ ] Verify localization renders correctly in non-English locales

https://claude.ai/code/session_01PpjMbhdhj9KhK9geswoCJV

---
_Generated by [Claude Code](https://claude.ai/code/session_01PpjMbhdhj9KhK9geswoCJV)_