### PR TITLE
Fix stuck Loading Older Content sentinel when feed has no scrollable space

### DIFF
--- a/SakuraRSS/Views/Shared/Articles/LoadPreviousArticlesButton.swift
+++ b/SakuraRSS/Views/Shared/Articles/LoadPreviousArticlesButton.swift
@@ -31,6 +31,8 @@ struct LoadPreviousArticlesButton: View {
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, 12)
+        .onAppear { isOnScreen = true }
+        .onDisappear { isOnScreen = false }
         .onScrollVisibilityChange(threshold: 0.05) { visible in
             isOnScreen = visible
         }


### PR DESCRIPTION
## Summary

Fixes a bug where the "Loading older content…" sentinel keeps spinning indefinitely when opening a feed with Hide Read Content on if the unread articles don't fill the screen.

## Root cause

When a feed renders fewer items than fit on screen, the underlying List isn't scrollable, and `onScrollVisibilityChange` doesn't reliably report the sentinel as visible. With `isOnScreen` stuck at `false`, the auto-load `.task` guard blocks `action()` from ever firing, so `loadedSinceDate`/`loadedCount` never change, the `hasReachedEnd` flag set in `TrackArticleVisibilityModifier` is never reached, and the sentinel sits there showing "Loading…" forever.

PR #199 originally addressed this exact scenario by combining `onAppear`/`onDisappear` with `onScrollVisibilityChange`, but the fix was lost during the #204 refactor that extracted `LoadPreviousArticlesButton` into its own file.

## Fix

Restore the `onAppear { isOnScreen = true }` / `onDisappear { isOnScreen = false }` fallback on the auto-loading indicator so the sentinel still triggers `action()` once when the list is non-scrollable. After the action fires, the existing flow in `ArticleVisibilityTracker.extend()` correctly sets `hasReachedEnd` and `loadMoreAction` returns `nil`, hiding the sentinel.

## Test plan

- [ ] Open a feed with very few unread items so they don't fill the screen, with Hide Read Content on and Auto Load While Scrolling on — sentinel should briefly appear and then disappear instead of spinning forever.
- [ ] Open a feed with many articles — auto-load should still trigger when scrolling to the bottom and continue paging until exhausted.
- [ ] With Hide Read Content off, opening any feed should still scroll/paginate normally.
- [ ] Manual mode (Auto Load While Scrolling off) — "Show Older Content" button still appears and works as before.

---
_Generated by [Claude Code](https://claude.ai/code/session_014pE74hewbiyyxotH6a2XuK)_