### PR TITLE
Fix refresh prompt, scroll jank, and auto-load behavior

### DIFF
--- a/SakuraRSS/Classes/Feed Manager/FeedManager+Batching.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+Batching.swift
@@ -26,6 +26,28 @@ extension FeedManager {
         return applyAllRules(all).count > count
     }
 
+    /// Walks forward in `batchSize` increments until the newly-revealed range
+    /// contains at least one unread article. Returns nil when there is no
+    /// further content to surface. With `requireUnread: false` any growth
+    /// suffices, matching the simple `count + batchSize` increment.
+    func nextLoadedCount(after count: Int, batchSize: Int, requireUnread: Bool = false) -> Int? {
+        _ = dataRevision
+        let maxIterations = 100
+        var newCount = count + batchSize
+        for _ in 0..<maxIterations {
+            let revealedRange = self.articles(limit: newCount)
+            guard revealedRange.count > count else { return nil }
+            if !requireUnread {
+                return newCount
+            }
+            if revealedRange.suffix(revealedRange.count - count).contains(where: { !$0.isRead }) {
+                return newCount
+            }
+            newCount += batchSize
+        }
+        return nil
+    }
+
     // MARK: - Count-based Batches (Section)
 
     func articles(for section: FeedSection, limit: Int) -> [Article] {
@@ -41,12 +63,48 @@ extension FeedManager {
         return filtered.count > count
     }
 
+    func nextLoadedCount(for section: FeedSection, after count: Int, batchSize: Int, requireUnread: Bool = false) -> Int? {
+        let maxIterations = 100
+        var newCount = count + batchSize
+        for _ in 0..<maxIterations {
+            let revealedRange = self.articles(for: section, limit: newCount)
+            guard revealedRange.count > count else { return nil }
+            if !requireUnread {
+                return newCount
+            }
+            if revealedRange.suffix(revealedRange.count - count).contains(where: { !$0.isRead }) {
+                return newCount
+            }
+            newCount += batchSize
+        }
+        return nil
+    }
+
     // MARK: - Count-based Batches (Feed)
 
     func hasMoreArticles(for feed: Feed, beyond count: Int) -> Bool {
         _ = dataRevision
         let all = (try? database.articles(forFeedID: feed.id, limit: count + 1)) ?? []
         return applyRules(all, feedID: feed.id).count > count
+    }
+
+    func nextLoadedCount(for feed: Feed, after count: Int, batchSize: Int, requireUnread: Bool = false) -> Int? {
+        _ = dataRevision
+        let maxIterations = 100
+        var newCount = count + batchSize
+        for _ in 0..<maxIterations {
+            let all = (try? database.articles(forFeedID: feed.id, limit: newCount)) ?? []
+            let revealedRange = applyRules(all, feedID: feed.id)
+            guard revealedRange.count > count else { return nil }
+            if !requireUnread {
+                return newCount
+            }
+            if revealedRange.suffix(revealedRange.count - count).contains(where: { !$0.isRead }) {
+                return newCount
+            }
+            newCount += batchSize
+        }
+        return nil
     }
 
     // MARK: - Count-based Batches (List)
@@ -63,6 +121,23 @@ extension FeedManager {
         guard !listFeedIDs.isEmpty else { return false }
         let pooled = articles(limit: (count + 1) * 3).filter { listFeedIDs.contains($0.feedID) }
         return applyListRules(pooled, listID: list.id).count > count
+    }
+
+    func nextLoadedCount(for list: FeedList, after count: Int, batchSize: Int, requireUnread: Bool = false) -> Int? {
+        let maxIterations = 100
+        var newCount = count + batchSize
+        for _ in 0..<maxIterations {
+            let revealedRange = self.articles(for: list, limit: newCount)
+            guard revealedRange.count > count else { return nil }
+            if !requireUnread {
+                return newCount
+            }
+            if revealedRange.suffix(revealedRange.count - count).contains(where: { !$0.isRead }) {
+                return newCount
+            }
+            newCount += batchSize
+        }
+        return nil
     }
 
     // MARK: - Date-based Batches (List)

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+Batching.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+Batching.swift
@@ -79,49 +79,32 @@ extension FeedManager {
         let listFeedIDs = feedIDs(for: list)
         guard !listFeedIDs.isEmpty else { return nil }
         let calendar = Calendar.current
+        guard (try? database.earliestArticleDate(before: date)) ?? nil != nil else { return nil }
+        guard let newStart = calendar.date(byAdding: .day, value: -days, to: date) else { return nil }
         let muted = mutedFeedIDs
-        var cursor = date
-        var iterations = 0
-        let maxIterations = FeedManager.chunkWalkLimit
-        while iterations < maxIterations {
-            iterations += 1
-            guard (try? database.earliestArticleDate(before: cursor)) ?? nil != nil else { return nil }
-            guard let newStart = calendar.date(byAdding: .day, value: -days, to: cursor) else { return nil }
-            let windowArticles = (try? database.allArticles(from: newStart, to: cursor, limit: 10000)) ?? []
-            var visible = muted.isEmpty ? windowArticles : windowArticles.filter { !muted.contains($0.feedID) }
-            visible = applyAllRules(visible).filter { listFeedIDs.contains($0.feedID) }
-            visible = applyListRules(visible, listID: list.id)
-            if !visible.isEmpty {
-                return newStart
-            }
-            cursor = newStart
-        }
-        return nil
+        let windowArticles = (try? database.allArticles(from: newStart, to: date, limit: 10000)) ?? []
+        var visible = muted.isEmpty ? windowArticles : windowArticles.filter { !muted.contains($0.feedID) }
+        visible = applyAllRules(visible).filter { listFeedIDs.contains($0.feedID) }
+        visible = applyListRules(visible, listID: list.id)
+        return visible.isEmpty ? nil : newStart
     }
 
     // MARK: - Date-based Batches (Arbitrary Window)
 
-    /// Walks backwards in `chunkDays` windows until a visible-article window is found.
+    /// Returns the start of the immediately preceding `chunkDays` window, or
+    /// nil if that window has no visible articles. Stopping at the first empty
+    /// window keeps the auto-load sentinel from skipping silently across long
+    /// gaps when there is no new content to surface.
     func nextArticleChunk(before date: Date, chunkDays days: Int) -> Date? {
         _ = dataRevision
         let calendar = Calendar.current
+        guard (try? database.earliestArticleDate(before: date)) ?? nil != nil else { return nil }
+        guard let newStart = calendar.date(byAdding: .day, value: -days, to: date) else { return nil }
         let muted = mutedFeedIDs
-        var cursor = date
-        var iterations = 0
-        let maxIterations = FeedManager.chunkWalkLimit
-        while iterations < maxIterations {
-            iterations += 1
-            guard (try? database.earliestArticleDate(before: cursor)) ?? nil != nil else { return nil }
-            guard let newStart = calendar.date(byAdding: .day, value: -days, to: cursor) else { return nil }
-            let windowArticles = (try? database.allArticles(from: newStart, to: cursor, limit: 10000)) ?? []
-            var visible = muted.isEmpty ? windowArticles : windowArticles.filter { !muted.contains($0.feedID) }
-            visible = applyAllRules(visible)
-            if !visible.isEmpty {
-                return newStart
-            }
-            cursor = newStart
-        }
-        return nil
+        let windowArticles = (try? database.allArticles(from: newStart, to: date, limit: 10000)) ?? []
+        var visible = muted.isEmpty ? windowArticles : windowArticles.filter { !muted.contains($0.feedID) }
+        visible = applyAllRules(visible)
+        return visible.isEmpty ? nil : newStart
     }
 
     func nextArticleChunk(for section: FeedSection, before date: Date, chunkDays days: Int) -> Date? {
@@ -129,44 +112,24 @@ extension FeedManager {
         let sectionFeedIDs = Set(feeds.filter { $0.feedSection == section }.map(\.id))
         guard !sectionFeedIDs.isEmpty else { return nil }
         let calendar = Calendar.current
+        guard (try? database.earliestArticleDate(before: date)) ?? nil != nil else { return nil }
+        guard let newStart = calendar.date(byAdding: .day, value: -days, to: date) else { return nil }
         let muted = mutedFeedIDs
-        var cursor = date
-        var iterations = 0
-        let maxIterations = FeedManager.chunkWalkLimit
-        while iterations < maxIterations {
-            iterations += 1
-            guard (try? database.earliestArticleDate(before: cursor)) ?? nil != nil else { return nil }
-            guard let newStart = calendar.date(byAdding: .day, value: -days, to: cursor) else { return nil }
-            let windowArticles = (try? database.allArticles(from: newStart, to: cursor, limit: 10000)) ?? []
-            var visible = muted.isEmpty ? windowArticles : windowArticles.filter { !muted.contains($0.feedID) }
-            visible = applyAllRules(visible).filter { sectionFeedIDs.contains($0.feedID) }
-            if !visible.isEmpty {
-                return newStart
-            }
-            cursor = newStart
-        }
-        return nil
+        let windowArticles = (try? database.allArticles(from: newStart, to: date, limit: 10000)) ?? []
+        var visible = muted.isEmpty ? windowArticles : windowArticles.filter { !muted.contains($0.feedID) }
+        visible = applyAllRules(visible).filter { sectionFeedIDs.contains($0.feedID) }
+        return visible.isEmpty ? nil : newStart
     }
 
     func nextArticleChunk(for feed: Feed, before date: Date, chunkDays days: Int) -> Date? {
         _ = dataRevision
         let calendar = Calendar.current
-        var cursor = date
-        var iterations = 0
-        let maxIterations = FeedManager.chunkWalkLimit
-        while iterations < maxIterations {
-            iterations += 1
-            guard (try? database.earliestArticleDate(forFeedID: feed.id, before: cursor)) ?? nil != nil else {
-                return nil
-            }
-            guard let newStart = calendar.date(byAdding: .day, value: -days, to: cursor) else { return nil }
-            let windowArticles = ((try? database.articles(forFeedID: feed.id, since: newStart)) ?? [])
-                .filter { ($0.publishedDate ?? .distantPast) < cursor }
-            if !applyRules(windowArticles, feedID: feed.id).isEmpty {
-                return newStart
-            }
-            cursor = newStart
+        guard (try? database.earliestArticleDate(forFeedID: feed.id, before: date)) ?? nil != nil else {
+            return nil
         }
-        return nil
+        guard let newStart = calendar.date(byAdding: .day, value: -days, to: date) else { return nil }
+        let windowArticles = ((try? database.articles(forFeedID: feed.id, since: newStart)) ?? [])
+            .filter { ($0.publishedDate ?? .distantPast) < date }
+        return applyRules(windowArticles, feedID: feed.id).isEmpty ? nil : newStart
     }
 }

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+Batching.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+Batching.swift
@@ -74,7 +74,7 @@ extension FeedManager {
         return applyListRules(filtered, listID: list.id)
     }
 
-    func nextArticleChunk(for list: FeedList, before date: Date, chunkDays days: Int) -> Date? {
+    func nextArticleChunk(for list: FeedList, before date: Date, chunkDays days: Int, requireUnread: Bool = false) -> Date? {
         _ = dataRevision
         let listFeedIDs = feedIDs(for: list)
         guard !listFeedIDs.isEmpty else { return nil }
@@ -91,6 +91,9 @@ extension FeedManager {
             var visible = muted.isEmpty ? windowArticles : windowArticles.filter { !muted.contains($0.feedID) }
             visible = applyAllRules(visible).filter { listFeedIDs.contains($0.feedID) }
             visible = applyListRules(visible, listID: list.id)
+            if requireUnread {
+                visible = visible.filter { !$0.isRead }
+            }
             if !visible.isEmpty {
                 return newStart
             }
@@ -101,8 +104,11 @@ extension FeedManager {
 
     // MARK: - Date-based Batches (Arbitrary Window)
 
-    /// Walks backwards in `chunkDays` windows until a visible-article window is found.
-    func nextArticleChunk(before date: Date, chunkDays days: Int) -> Date? {
+    /// Walks backwards in `chunkDays` windows until a visible-article window is
+    /// found. When `requireUnread` is set, chunks with only-read articles are
+    /// skipped so callers with Hide Viewed Content on don't dead-end on a
+    /// chunk whose contents would be filtered out anyway.
+    func nextArticleChunk(before date: Date, chunkDays days: Int, requireUnread: Bool = false) -> Date? {
         _ = dataRevision
         let calendar = Calendar.current
         let muted = mutedFeedIDs
@@ -116,6 +122,9 @@ extension FeedManager {
             let windowArticles = (try? database.allArticles(from: newStart, to: cursor, limit: 10000)) ?? []
             var visible = muted.isEmpty ? windowArticles : windowArticles.filter { !muted.contains($0.feedID) }
             visible = applyAllRules(visible)
+            if requireUnread {
+                visible = visible.filter { !$0.isRead }
+            }
             if !visible.isEmpty {
                 return newStart
             }
@@ -124,7 +133,7 @@ extension FeedManager {
         return nil
     }
 
-    func nextArticleChunk(for section: FeedSection, before date: Date, chunkDays days: Int) -> Date? {
+    func nextArticleChunk(for section: FeedSection, before date: Date, chunkDays days: Int, requireUnread: Bool = false) -> Date? {
         _ = dataRevision
         let sectionFeedIDs = Set(feeds.filter { $0.feedSection == section }.map(\.id))
         guard !sectionFeedIDs.isEmpty else { return nil }
@@ -140,6 +149,9 @@ extension FeedManager {
             let windowArticles = (try? database.allArticles(from: newStart, to: cursor, limit: 10000)) ?? []
             var visible = muted.isEmpty ? windowArticles : windowArticles.filter { !muted.contains($0.feedID) }
             visible = applyAllRules(visible).filter { sectionFeedIDs.contains($0.feedID) }
+            if requireUnread {
+                visible = visible.filter { !$0.isRead }
+            }
             if !visible.isEmpty {
                 return newStart
             }
@@ -148,7 +160,7 @@ extension FeedManager {
         return nil
     }
 
-    func nextArticleChunk(for feed: Feed, before date: Date, chunkDays days: Int) -> Date? {
+    func nextArticleChunk(for feed: Feed, before date: Date, chunkDays days: Int, requireUnread: Bool = false) -> Date? {
         _ = dataRevision
         let calendar = Calendar.current
         var cursor = date
@@ -162,7 +174,11 @@ extension FeedManager {
             guard let newStart = calendar.date(byAdding: .day, value: -days, to: cursor) else { return nil }
             let windowArticles = ((try? database.articles(forFeedID: feed.id, since: newStart)) ?? [])
                 .filter { ($0.publishedDate ?? .distantPast) < cursor }
-            if !applyRules(windowArticles, feedID: feed.id).isEmpty {
+            var visible = applyRules(windowArticles, feedID: feed.id)
+            if requireUnread {
+                visible = visible.filter { !$0.isRead }
+            }
+            if !visible.isEmpty {
                 return newStart
             }
             cursor = newStart

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+Batching.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+Batching.swift
@@ -79,32 +79,49 @@ extension FeedManager {
         let listFeedIDs = feedIDs(for: list)
         guard !listFeedIDs.isEmpty else { return nil }
         let calendar = Calendar.current
-        guard (try? database.earliestArticleDate(before: date)) ?? nil != nil else { return nil }
-        guard let newStart = calendar.date(byAdding: .day, value: -days, to: date) else { return nil }
         let muted = mutedFeedIDs
-        let windowArticles = (try? database.allArticles(from: newStart, to: date, limit: 10000)) ?? []
-        var visible = muted.isEmpty ? windowArticles : windowArticles.filter { !muted.contains($0.feedID) }
-        visible = applyAllRules(visible).filter { listFeedIDs.contains($0.feedID) }
-        visible = applyListRules(visible, listID: list.id)
-        return visible.isEmpty ? nil : newStart
+        var cursor = date
+        var iterations = 0
+        let maxIterations = FeedManager.chunkWalkLimit
+        while iterations < maxIterations {
+            iterations += 1
+            guard (try? database.earliestArticleDate(before: cursor)) ?? nil != nil else { return nil }
+            guard let newStart = calendar.date(byAdding: .day, value: -days, to: cursor) else { return nil }
+            let windowArticles = (try? database.allArticles(from: newStart, to: cursor, limit: 10000)) ?? []
+            var visible = muted.isEmpty ? windowArticles : windowArticles.filter { !muted.contains($0.feedID) }
+            visible = applyAllRules(visible).filter { listFeedIDs.contains($0.feedID) }
+            visible = applyListRules(visible, listID: list.id)
+            if !visible.isEmpty {
+                return newStart
+            }
+            cursor = newStart
+        }
+        return nil
     }
 
     // MARK: - Date-based Batches (Arbitrary Window)
 
-    /// Returns the start of the immediately preceding `chunkDays` window, or
-    /// nil if that window has no visible articles. Stopping at the first empty
-    /// window keeps the auto-load sentinel from skipping silently across long
-    /// gaps when there is no new content to surface.
+    /// Walks backwards in `chunkDays` windows until a visible-article window is found.
     func nextArticleChunk(before date: Date, chunkDays days: Int) -> Date? {
         _ = dataRevision
         let calendar = Calendar.current
-        guard (try? database.earliestArticleDate(before: date)) ?? nil != nil else { return nil }
-        guard let newStart = calendar.date(byAdding: .day, value: -days, to: date) else { return nil }
         let muted = mutedFeedIDs
-        let windowArticles = (try? database.allArticles(from: newStart, to: date, limit: 10000)) ?? []
-        var visible = muted.isEmpty ? windowArticles : windowArticles.filter { !muted.contains($0.feedID) }
-        visible = applyAllRules(visible)
-        return visible.isEmpty ? nil : newStart
+        var cursor = date
+        var iterations = 0
+        let maxIterations = FeedManager.chunkWalkLimit
+        while iterations < maxIterations {
+            iterations += 1
+            guard (try? database.earliestArticleDate(before: cursor)) ?? nil != nil else { return nil }
+            guard let newStart = calendar.date(byAdding: .day, value: -days, to: cursor) else { return nil }
+            let windowArticles = (try? database.allArticles(from: newStart, to: cursor, limit: 10000)) ?? []
+            var visible = muted.isEmpty ? windowArticles : windowArticles.filter { !muted.contains($0.feedID) }
+            visible = applyAllRules(visible)
+            if !visible.isEmpty {
+                return newStart
+            }
+            cursor = newStart
+        }
+        return nil
     }
 
     func nextArticleChunk(for section: FeedSection, before date: Date, chunkDays days: Int) -> Date? {
@@ -112,24 +129,44 @@ extension FeedManager {
         let sectionFeedIDs = Set(feeds.filter { $0.feedSection == section }.map(\.id))
         guard !sectionFeedIDs.isEmpty else { return nil }
         let calendar = Calendar.current
-        guard (try? database.earliestArticleDate(before: date)) ?? nil != nil else { return nil }
-        guard let newStart = calendar.date(byAdding: .day, value: -days, to: date) else { return nil }
         let muted = mutedFeedIDs
-        let windowArticles = (try? database.allArticles(from: newStart, to: date, limit: 10000)) ?? []
-        var visible = muted.isEmpty ? windowArticles : windowArticles.filter { !muted.contains($0.feedID) }
-        visible = applyAllRules(visible).filter { sectionFeedIDs.contains($0.feedID) }
-        return visible.isEmpty ? nil : newStart
+        var cursor = date
+        var iterations = 0
+        let maxIterations = FeedManager.chunkWalkLimit
+        while iterations < maxIterations {
+            iterations += 1
+            guard (try? database.earliestArticleDate(before: cursor)) ?? nil != nil else { return nil }
+            guard let newStart = calendar.date(byAdding: .day, value: -days, to: cursor) else { return nil }
+            let windowArticles = (try? database.allArticles(from: newStart, to: cursor, limit: 10000)) ?? []
+            var visible = muted.isEmpty ? windowArticles : windowArticles.filter { !muted.contains($0.feedID) }
+            visible = applyAllRules(visible).filter { sectionFeedIDs.contains($0.feedID) }
+            if !visible.isEmpty {
+                return newStart
+            }
+            cursor = newStart
+        }
+        return nil
     }
 
     func nextArticleChunk(for feed: Feed, before date: Date, chunkDays days: Int) -> Date? {
         _ = dataRevision
         let calendar = Calendar.current
-        guard (try? database.earliestArticleDate(forFeedID: feed.id, before: date)) ?? nil != nil else {
-            return nil
+        var cursor = date
+        var iterations = 0
+        let maxIterations = FeedManager.chunkWalkLimit
+        while iterations < maxIterations {
+            iterations += 1
+            guard (try? database.earliestArticleDate(forFeedID: feed.id, before: cursor)) ?? nil != nil else {
+                return nil
+            }
+            guard let newStart = calendar.date(byAdding: .day, value: -days, to: cursor) else { return nil }
+            let windowArticles = ((try? database.articles(forFeedID: feed.id, since: newStart)) ?? [])
+                .filter { ($0.publishedDate ?? .distantPast) < cursor }
+            if !applyRules(windowArticles, feedID: feed.id).isEmpty {
+                return newStart
+            }
+            cursor = newStart
         }
-        guard let newStart = calendar.date(byAdding: .day, value: -days, to: date) else { return nil }
-        let windowArticles = ((try? database.articles(forFeedID: feed.id, since: newStart)) ?? [])
-            .filter { ($0.publishedDate ?? .distantPast) < date }
-        return applyRules(windowArticles, feedID: feed.id).isEmpty ? nil : newStart
+        return nil
     }
 }

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+PendingReads.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+PendingReads.swift
@@ -4,9 +4,12 @@ extension FeedManager {
 
     static let pendingReadsDebounceInterval: DispatchTimeInterval = .milliseconds(250)
 
-    /// True if persisted as read or queued for the next flush.
+    /// True if persisted as read or queued for the next flush. Reads
+    /// `readMaskRevision` so views refresh when the queue flushes, while
+    /// individual scroll-driven inserts stay outside observation.
     func isRead(_ article: Article) -> Bool {
-        article.isRead || pendingReadIDs.contains(article.id)
+        _ = readMaskRevision
+        return article.isRead || pendingReadIDs.contains(article.id)
     }
 
     func markReadOnScroll(_ article: Article) {
@@ -17,7 +20,9 @@ extension FeedManager {
     }
 
     /// IDs stay in `pendingReadIDs` past the flush so `isRead(_:)` keeps masking them
-    /// without bumping `dataRevision`; cleared on the next `loadFromDatabase`.
+    /// without bumping `dataRevision`; cleared on the next `loadFromDatabase`. Bumps
+    /// `readMaskRevision` so views observing `isRead(_:)` update once per debounce
+    /// window instead of once per scroll-driven mark.
     func flushDebouncedReads() {
         pendingReadsFlushWorkItem?.cancel()
         pendingReadsFlushWorkItem = nil
@@ -30,6 +35,7 @@ extension FeedManager {
 
         let idArray = Array(pendingReadIDs)
         try? database.markArticlesRead(ids: idArray, read: true)
+        readMaskRevision += 1
 
         let dbm = database
         Task.detached(priority: .utility) {

--- a/SakuraRSS/Classes/Feed Manager/FeedManager.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager.swift
@@ -29,7 +29,7 @@ final class FeedManager {
     /// Kept out of observation so scroll-driven mutations don't cascade body re-evaluations
     /// across every visible article row; views observe `readMaskRevision` instead.
     @ObservationIgnored var pendingReadIDs: Set<Int64> = []
-    private(set) var readMaskRevision: Int = 0
+    var readMaskRevision: Int = 0
     @ObservationIgnored var pendingReadDecrements: [Int64: Int] = [:]
     @ObservationIgnored var refreshTask: Task<Void, Never>?
 

--- a/SakuraRSS/Classes/Feed Manager/FeedManager.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager.swift
@@ -26,7 +26,10 @@ final class FeedManager {
     private(set) var feedsByID: [Int64: Feed] = [:]
 
     /// Queued mark-read IDs; flushed every 250ms while scrolling, on idle, or on backgrounding.
-    var pendingReadIDs: Set<Int64> = []
+    /// Kept out of observation so scroll-driven mutations don't cascade body re-evaluations
+    /// across every visible article row; views observe `readMaskRevision` instead.
+    @ObservationIgnored var pendingReadIDs: Set<Int64> = []
+    private(set) var readMaskRevision: Int = 0
     @ObservationIgnored var pendingReadDecrements: [Int64: Int] = [:]
     @ObservationIgnored var refreshTask: Task<Void, Never>?
 
@@ -48,6 +51,7 @@ final class FeedManager {
             lists = (try? database.allLists()) ?? []
             pendingReadIDs.removeAll()
             pendingReadDecrements.removeAll()
+            readMaskRevision += 1
             dataRevision += 1
         } catch {
             print("Failed to load from database: \(error)")
@@ -73,6 +77,7 @@ final class FeedManager {
                     self.lists = loadedLists
                     self.pendingReadIDs.removeAll()
                     self.pendingReadDecrements.removeAll()
+                    self.readMaskRevision += 1
                     self.dataRevision += 1
                 }
                 if animated {

--- a/SakuraRSS/Views/Feeds/FeedArticlesView.swift
+++ b/SakuraRSS/Views/Feeds/FeedArticlesView.swift
@@ -32,8 +32,15 @@ struct FeedArticlesView: View {
             return { loadedSinceDate = next }
         }
         if let batch = batchingMode.batchSize {
-            guard feedManager.hasMoreArticles(for: feed, beyond: loadedCount) else { return nil }
-            return { loadedCount += batch }
+            guard let next = feedManager.nextLoadedCount(
+                for: feed,
+                after: loadedCount,
+                batchSize: batch,
+                requireUnread: hideViewedContent
+            ) else {
+                return nil
+            }
+            return { loadedCount = next }
         }
         return nil
     }

--- a/SakuraRSS/Views/Feeds/FeedArticlesView.swift
+++ b/SakuraRSS/Views/Feeds/FeedArticlesView.swift
@@ -21,9 +21,12 @@ struct FeedArticlesView: View {
     private var loadMoreAction: (() -> Void)? {
         if hideViewedContent && visibility.hasReachedEnd { return nil }
         if let days = batchingMode.chunkDays {
-            guard let next = feedManager.nextArticleChunk(for: feed,
-                                                          before: loadedSinceDate,
-                                                          chunkDays: days) else {
+            guard let next = feedManager.nextArticleChunk(
+                for: feed,
+                before: loadedSinceDate,
+                chunkDays: days,
+                requireUnread: hideViewedContent
+            ) else {
                 return nil
             }
             return { loadedSinceDate = next }

--- a/SakuraRSS/Views/Feeds/FeedArticlesView.swift
+++ b/SakuraRSS/Views/Feeds/FeedArticlesView.swift
@@ -12,6 +12,7 @@ struct FeedArticlesView: View {
     @AppStorage("Instagram.HideReels") private var hideReels: Bool = false
     @AppStorage("Articles.HideViewedContent") private var hideViewedContent: Bool = false
     @State private var visibility = ArticleVisibilityTracker()
+    @State private var scrollToTopTick: Int = 0
 
     private var currentFeed: Feed {
         feedManager.feeds.first(where: { $0.id == feed.id }) ?? feed
@@ -62,6 +63,7 @@ struct FeedArticlesView: View {
         withAnimation(.smooth.speed(2.0)) {
             visibility.acceptPendingRefresh()
         }
+        scrollToTopTick &+= 1
     }
 
     var body: some View {
@@ -82,7 +84,8 @@ struct FeedArticlesView: View {
             },
             onMarkAllRead: {
                 feedManager.markAllRead(feed: feed)
-            }
+            },
+            scrollToTopTrigger: scrollToTopTick
         )
         .refreshable {
             await performRefresh()

--- a/SakuraRSS/Views/Home/AllArticlesView.swift
+++ b/SakuraRSS/Views/Home/AllArticlesView.swift
@@ -173,7 +173,11 @@ struct AllArticlesView: View {
     private var loadMoreAction: (() -> Void)? {
         if hideViewedContent && visibility.hasReachedEnd { return nil }
         if let days = batchingMode.chunkDays {
-            guard let next = feedManager.nextArticleChunk(before: loadedSinceDate, chunkDays: days) else {
+            guard let next = feedManager.nextArticleChunk(
+                before: loadedSinceDate,
+                chunkDays: days,
+                requireUnread: hideViewedContent
+            ) else {
                 return nil
             }
             return { loadedSinceDate = next }

--- a/SakuraRSS/Views/Home/AllArticlesView.swift
+++ b/SakuraRSS/Views/Home/AllArticlesView.swift
@@ -109,6 +109,7 @@ struct AllArticlesView: View {
     @AppStorage("Instagram.HideReels") private var hideInstagramReels: Bool = false
     @AppStorage("Articles.HideViewedContent") private var hideViewedContent: Bool = false
     @State private var visibility = ArticleVisibilityTracker()
+    @State private var scrollToTopTick: Int = 0
     @State private var whileYouSleptAvailable = false
     @State private var todaysSummaryAvailable = false
 
@@ -166,6 +167,7 @@ struct AllArticlesView: View {
         withAnimation(.smooth.speed(2.0)) {
             visibility.acceptPendingRefresh()
         }
+        scrollToTopTick &+= 1
     }
 
     private var loadMoreAction: (() -> Void)? {
@@ -328,7 +330,8 @@ struct AllArticlesView: View {
             },
             onMarkAllRead: {
                 feedManager.markAllRead()
-            }
+            },
+            scrollToTopTrigger: scrollToTopTick
         )
         .safeAreaInset(edge: .top, spacing: 0) {
             VStack(spacing: 0) {

--- a/SakuraRSS/Views/Home/AllArticlesView.swift
+++ b/SakuraRSS/Views/Home/AllArticlesView.swift
@@ -183,8 +183,14 @@ struct AllArticlesView: View {
             return { loadedSinceDate = next }
         }
         if let batch = batchingMode.batchSize {
-            guard feedManager.hasMoreArticles(beyond: loadedCount) else { return nil }
-            return { loadedCount += batch }
+            guard let next = feedManager.nextLoadedCount(
+                after: loadedCount,
+                batchSize: batch,
+                requireUnread: hideViewedContent
+            ) else {
+                return nil
+            }
+            return { loadedCount = next }
         }
         return nil
     }

--- a/SakuraRSS/Views/Home/HomeSectionView.swift
+++ b/SakuraRSS/Views/Home/HomeSectionView.swift
@@ -13,6 +13,7 @@ struct HomeSectionView: View {
     @AppStorage("Instagram.HideReels") private var hideInstagramReels: Bool = false
     @AppStorage("Articles.HideViewedContent") private var hideViewedContent: Bool = false
     @State private var visibility = ArticleVisibilityTracker()
+    @State private var scrollToTopTick: Int = 0
 
     private var rawArticles: [Article] {
         var articles: [Article]
@@ -53,6 +54,7 @@ struct HomeSectionView: View {
         withAnimation(.smooth.speed(2.0)) {
             visibility.acceptPendingRefresh()
         }
+        scrollToTopTick &+= 1
     }
 
     private var loadMoreAction: (() -> Void)? {
@@ -86,7 +88,8 @@ struct HomeSectionView: View {
             },
             onMarkAllRead: {
                 feedManager.markAllRead(for: section)
-            }
+            },
+            scrollToTopTrigger: scrollToTopTick
         )
         .refreshable {
             startRefreshWithoutBlocking()

--- a/SakuraRSS/Views/Home/HomeSectionView.swift
+++ b/SakuraRSS/Views/Home/HomeSectionView.swift
@@ -71,8 +71,15 @@ struct HomeSectionView: View {
             return { loadedSinceDate = next }
         }
         if let batch = batchingMode.batchSize {
-            guard feedManager.hasMoreArticles(for: section, beyond: loadedCount) else { return nil }
-            return { loadedCount += batch }
+            guard let next = feedManager.nextLoadedCount(
+                for: section,
+                after: loadedCount,
+                batchSize: batch,
+                requireUnread: hideViewedContent
+            ) else {
+                return nil
+            }
+            return { loadedCount = next }
         }
         return nil
     }

--- a/SakuraRSS/Views/Home/HomeSectionView.swift
+++ b/SakuraRSS/Views/Home/HomeSectionView.swift
@@ -60,9 +60,12 @@ struct HomeSectionView: View {
     private var loadMoreAction: (() -> Void)? {
         if hideViewedContent && visibility.hasReachedEnd { return nil }
         if let days = batchingMode.chunkDays {
-            guard let next = feedManager.nextArticleChunk(for: section,
-                                                          before: loadedSinceDate,
-                                                          chunkDays: days) else {
+            guard let next = feedManager.nextArticleChunk(
+                for: section,
+                before: loadedSinceDate,
+                chunkDays: days,
+                requireUnread: hideViewedContent
+            ) else {
                 return nil
             }
             return { loadedSinceDate = next }

--- a/SakuraRSS/Views/Home/ListSectionView.swift
+++ b/SakuraRSS/Views/Home/ListSectionView.swift
@@ -64,8 +64,15 @@ struct ListSectionView: View {
             return { loadedSinceDate = next }
         }
         if let batch = batchingMode.batchSize {
-            guard feedManager.hasMoreArticles(for: list, beyond: loadedCount) else { return nil }
-            return { loadedCount += batch }
+            guard let next = feedManager.nextLoadedCount(
+                for: list,
+                after: loadedCount,
+                batchSize: batch,
+                requireUnread: hideViewedContent
+            ) else {
+                return nil
+            }
+            return { loadedCount = next }
         }
         return nil
     }

--- a/SakuraRSS/Views/Home/ListSectionView.swift
+++ b/SakuraRSS/Views/Home/ListSectionView.swift
@@ -12,6 +12,7 @@ struct ListSectionView: View {
     @AppStorage("Display.MarkAllReadPosition") private var markAllReadPosition: MarkAllReadPosition = .bottom
     @AppStorage("Articles.HideViewedContent") private var hideViewedContent: Bool = false
     @State private var visibility = ArticleVisibilityTracker()
+    @State private var scrollToTopTick: Int = 0
 
     private var rawArticles: [Article] {
         if batchingMode.isCountBased {
@@ -46,6 +47,7 @@ struct ListSectionView: View {
         withAnimation(.smooth.speed(2.0)) {
             visibility.acceptPendingRefresh()
         }
+        scrollToTopTick &+= 1
     }
 
     private var loadMoreAction: (() -> Void)? {
@@ -76,7 +78,8 @@ struct ListSectionView: View {
             },
             onMarkAllRead: {
                 feedManager.markAllRead(for: list)
-            }
+            },
+            scrollToTopTrigger: scrollToTopTick
         )
         .refreshable {
             startRefreshWithoutBlocking()

--- a/SakuraRSS/Views/Home/ListSectionView.swift
+++ b/SakuraRSS/Views/Home/ListSectionView.swift
@@ -53,9 +53,12 @@ struct ListSectionView: View {
     private var loadMoreAction: (() -> Void)? {
         if hideViewedContent && visibility.hasReachedEnd { return nil }
         if let days = batchingMode.chunkDays {
-            guard let next = feedManager.nextArticleChunk(for: list,
-                                                          before: loadedSinceDate,
-                                                          chunkDays: days) else {
+            guard let next = feedManager.nextArticleChunk(
+                for: list,
+                before: loadedSinceDate,
+                chunkDays: days,
+                requireUnread: hideViewedContent
+            ) else {
                 return nil
             }
             return { loadedSinceDate = next }

--- a/SakuraRSS/Views/Shared/Articles/ArticleVisibilityTracker.swift
+++ b/SakuraRSS/Views/Shared/Articles/ArticleVisibilityTracker.swift
@@ -13,6 +13,10 @@ struct ArticleVisibilityTracker {
     /// the load-more sentinel can be hidden until the next refresh / mode change.
     var hasReachedEnd: Bool = false
     private var preRefreshIDs: Set<Int64> = []
+    /// Highest article ID seen at refresh start. Articles inserted during
+    /// the refresh land with IDs above this (sqlite autoincrement); pre-existing
+    /// articles surfaced by load-more sit at or below it.
+    private var preRefreshMaxID: Int64 = .max
     private var activeRefreshCount: Int = 0
 
     var hasPendingRefresh: Bool { !pendingIDs.isEmpty }
@@ -26,8 +30,10 @@ struct ArticleVisibilityTracker {
             result = result.filter { !pendingIDs.contains($0.id) }
         }
         // Hide arrivals that land before `endRefresh` moves them to `pendingIDs`.
+        // Pre-existing articles (id <= preRefreshMaxID) pass through so load-more
+        // during a refresh still surfaces older content.
         if activeRefreshCount > 0 {
-            result = result.filter { preRefreshIDs.contains($0.id) }
+            result = result.filter { $0.id <= preRefreshMaxID }
         }
         return result
     }
@@ -65,6 +71,7 @@ struct ArticleVisibilityTracker {
         if activeRefreshCount == 0 {
             hasReachedEnd = false
             preRefreshIDs = Set(articles.map(\.id)).union(visibleIDs ?? []).union(pendingIDs)
+            preRefreshMaxID = preRefreshIDs.max() ?? .max
             if isEnabled {
                 visibleIDs = Set(articles.filter { !$0.isRead }.map(\.id))
             } else {
@@ -86,6 +93,7 @@ struct ArticleVisibilityTracker {
         }
         if activeRefreshCount == 0 {
             preRefreshIDs = []
+            preRefreshMaxID = .max
         }
     }
 

--- a/SakuraRSS/Views/Shared/Articles/ArticleVisibilityTracker.swift
+++ b/SakuraRSS/Views/Shared/Articles/ArticleVisibilityTracker.swift
@@ -69,17 +69,20 @@ struct ArticleVisibilityTracker {
     }
 
     /// Computes the set of article IDs that arrived during the refresh and
-    /// stores them as pending until the user taps the refresh prompt.
+    /// stores them as pending until the user taps the refresh prompt. Each
+    /// call processes the diff so a re-mounted `.task` or interleaved
+    /// onChange can't strand the count above zero and miss new content.
     mutating func endRefresh(from articles: [Article], isEnabled: Bool) {
         guard activeRefreshCount > 0 else { return }
         activeRefreshCount -= 1
-        guard activeRefreshCount == 0 else { return }
         let currentIDs = Set(articles.map(\.id))
         let newIDs = currentIDs.subtracting(preRefreshIDs)
         if !newIDs.isEmpty {
             pendingIDs.formUnion(newIDs)
         }
-        preRefreshIDs = []
+        if activeRefreshCount == 0 {
+            preRefreshIDs = []
+        }
     }
 
     /// Releases any pending articles into the visible list.

--- a/SakuraRSS/Views/Shared/Articles/ArticleVisibilityTracker.swift
+++ b/SakuraRSS/Views/Shared/Articles/ArticleVisibilityTracker.swift
@@ -25,6 +25,10 @@ struct ArticleVisibilityTracker {
         if !pendingIDs.isEmpty {
             result = result.filter { !pendingIDs.contains($0.id) }
         }
+        // Hide arrivals that land before `endRefresh` moves them to `pendingIDs`.
+        if activeRefreshCount > 0 {
+            result = result.filter { preRefreshIDs.contains($0.id) }
+        }
         return result
     }
 
@@ -37,9 +41,8 @@ struct ArticleVisibilityTracker {
         visibleIDs = Set(articles.filter { !$0.isRead }.map(\.id))
     }
 
-    /// Returns true if at least one new unread ID was added. Pending refresh
-    /// IDs are excluded so an auto-load that surfaces nothing visible can't
-    /// be masked by content the user hasn't accepted yet.
+    /// Returns true if at least one new unread ID was added. Pending IDs are
+    /// excluded so unaccepted refresh content can't fake growth.
     @discardableResult
     mutating func extend(from articles: [Article], isEnabled: Bool) -> Bool {
         guard isEnabled else {
@@ -71,10 +74,8 @@ struct ArticleVisibilityTracker {
         activeRefreshCount += 1
     }
 
-    /// Computes the set of article IDs that arrived during the refresh and
-    /// stores them as pending until the user taps the refresh prompt. Each
-    /// call processes the diff so a re-mounted `.task` or interleaved
-    /// onChange can't strand the count above zero and miss new content.
+    /// Diffs against `preRefreshIDs` on every call so an imbalanced count
+    /// can't strand new arrivals outside `pendingIDs`.
     mutating func endRefresh(from articles: [Article], isEnabled: Bool) {
         guard activeRefreshCount > 0 else { return }
         activeRefreshCount -= 1

--- a/SakuraRSS/Views/Shared/Articles/ArticleVisibilityTracker.swift
+++ b/SakuraRSS/Views/Shared/Articles/ArticleVisibilityTracker.swift
@@ -37,7 +37,9 @@ struct ArticleVisibilityTracker {
         visibleIDs = Set(articles.filter { !$0.isRead }.map(\.id))
     }
 
-    /// Returns true if at least one new unread ID was added.
+    /// Returns true if at least one new unread ID was added. Pending refresh
+    /// IDs are excluded so an auto-load that surfaces nothing visible can't
+    /// be masked by content the user hasn't accepted yet.
     @discardableResult
     mutating func extend(from articles: [Article], isEnabled: Bool) -> Bool {
         guard isEnabled else {
@@ -45,6 +47,7 @@ struct ArticleVisibilityTracker {
             return false
         }
         let unreadIDs = Set(articles.filter { !$0.isRead }.map(\.id))
+            .subtracting(pendingIDs)
         let previous = visibleIDs ?? []
         let merged = previous.union(unreadIDs)
         let didGrow = merged.count > previous.count

--- a/SakuraRSS/Views/Shared/Articles/ArticlesView.swift
+++ b/SakuraRSS/Views/Shared/Articles/ArticlesView.swift
@@ -31,6 +31,7 @@ struct ArticlesView: View {
     var onLoadMore: (() -> Void)?
     var onRefresh: (() async -> Void)?
     var onMarkAllRead: (() -> Void)?
+    var scrollToTopTrigger: Int
 
     @Environment(\.hidesMarkAllReadToolbar) private var hidesMarkAllReadToolbar
     @State private var displayStyle: FeedDisplayStyle
@@ -56,7 +57,8 @@ struct ArticlesView: View {
          onRestoreSummaries: (() -> Void)? = nil,
          onLoadMore: (() -> Void)? = nil,
          onRefresh: (() async -> Void)? = nil,
-         onMarkAllRead: (() -> Void)? = nil) {
+         onMarkAllRead: (() -> Void)? = nil,
+         scrollToTopTrigger: Int = 0) {
         self.articles = articles
         self.title = title
         self.subtitle = subtitle
@@ -73,6 +75,7 @@ struct ArticlesView: View {
         self.onLoadMore = onLoadMore
         self.onRefresh = onRefresh
         self.onMarkAllRead = onMarkAllRead
+        self.scrollToTopTrigger = scrollToTopTrigger
         let raw = UserDefaults.standard.string(forKey: "Display.Style.\(feedKey)")
         let defaultRaw = UserDefaults.standard.string(forKey: "Display.DefaultStyle") ?? FeedDisplayStyle.inbox.rawValue
         let fallback: FeedDisplayStyle
@@ -96,13 +99,19 @@ struct ArticlesView: View {
 
     var body: some View {
         let effectiveStyle = effectiveDisplayStyle
-        Group {
+        ScrollViewReader { proxy in
             DisplayStyleContentView(
                 style: effectiveStyle,
                 articles: articles,
                 onLoadMore: onLoadMore,
                 onRefresh: onRefresh
             )
+            .onChange(of: scrollToTopTrigger) { _, _ in
+                guard let firstID = articles.first?.id else { return }
+                withAnimation(.smooth.speed(2.0)) {
+                    proxy.scrollTo(firstID, anchor: .top)
+                }
+            }
         }
         .scrollContentBackground(.hidden)
         .sakuraBackground()

--- a/SakuraRSS/Views/Shared/Articles/LoadPreviousArticlesButton.swift
+++ b/SakuraRSS/Views/Shared/Articles/LoadPreviousArticlesButton.swift
@@ -1,17 +1,15 @@
 import SwiftUI
 
 /// Sentinel pinned to the bottom of an article list. Manual mode shows a
-/// tap target; auto mode fires when the user scrolls within range of the
-/// bottom and reveals a progress indicator until the new batch arrives.
+/// tap target; auto mode fires from `.onAppear` so List's lazy rendering
+/// triggers a load whenever the user scrolls the sentinel into view.
 struct LoadPreviousArticlesButton: View {
 
     let action: () -> Void
     var articleCount: Int = 0
 
     @AppStorage("Articles.AutoLoadWhileScrolling") private var autoLoadWhileScrolling: Bool = false
-    @State private var isOnScreen = false
     @State private var isLoading = false
-    @State private var lastFiredAtCount: Int? = nil
 
     var body: some View {
         Group {
@@ -25,10 +23,6 @@ struct LoadPreviousArticlesButton: View {
         }
     }
 
-    /// Fires when the sentinel becomes visible. The trigger row is sized
-    /// taller than the indicator content so it crosses into view a bit
-    /// before the user reaches the absolute bottom of the list, but small
-    /// enough that the empty placeholder isn't a distracting gap.
     private var autoLoadingIndicator: some View {
         HStack(spacing: 8) {
             if isLoading {
@@ -39,21 +33,15 @@ struct LoadPreviousArticlesButton: View {
             }
         }
         .frame(maxWidth: .infinity)
-        .frame(minHeight: 88)
-        .padding(.vertical, 4)
-        .onAppear { isOnScreen = true }
-        .onDisappear { isOnScreen = false }
-        .onScrollVisibilityChange(threshold: 0.05) { visible in
-            isOnScreen = visible
-        }
-        .task(id: AutoLoadKey(isOnScreen: isOnScreen, count: articleCount)) {
-            isLoading = false
-            guard isOnScreen, lastFiredAtCount != articleCount else { return }
-            lastFiredAtCount = articleCount
-            try? await Task.sleep(for: .milliseconds(50))
-            guard !Task.isCancelled else { return }
+        .frame(minHeight: isLoading ? 44 : 1)
+        .onAppear {
+            guard !isLoading else { return }
             isLoading = true
             action()
+        }
+        .onChange(of: articleCount) { _, _ in
+            // The previous load completed; allow the next onAppear to fire.
+            isLoading = false
         }
     }
 
@@ -74,9 +62,4 @@ struct LoadPreviousArticlesButton: View {
         .buttonStyle(.bordered)
         .tint(.secondary)
     }
-}
-
-private struct AutoLoadKey: Equatable {
-    let isOnScreen: Bool
-    let count: Int
 }

--- a/SakuraRSS/Views/Shared/Articles/LoadPreviousArticlesButton.swift
+++ b/SakuraRSS/Views/Shared/Articles/LoadPreviousArticlesButton.swift
@@ -26,8 +26,9 @@ struct LoadPreviousArticlesButton: View {
     }
 
     /// Fires when the sentinel becomes visible. The trigger row is sized
-    /// taller than the indicator content so that it crosses into view well
-    /// before the user reaches the absolute bottom of the list.
+    /// taller than the indicator content so it crosses into view a bit
+    /// before the user reaches the absolute bottom of the list, but small
+    /// enough that the empty placeholder isn't a distracting gap.
     private var autoLoadingIndicator: some View {
         HStack(spacing: 8) {
             if isLoading {
@@ -38,7 +39,8 @@ struct LoadPreviousArticlesButton: View {
             }
         }
         .frame(maxWidth: .infinity)
-        .frame(minHeight: 240)
+        .frame(minHeight: 88)
+        .padding(.vertical, 4)
         .onAppear { isOnScreen = true }
         .onDisappear { isOnScreen = false }
         .onScrollVisibilityChange(threshold: 0.05) { visible in

--- a/SakuraRSS/Views/Shared/Articles/LoadPreviousArticlesButton.swift
+++ b/SakuraRSS/Views/Shared/Articles/LoadPreviousArticlesButton.swift
@@ -1,8 +1,7 @@
 import SwiftUI
 
-/// Sentinel pinned to the bottom of an article list. Manual mode shows a
-/// tap target; auto mode fires from `.onAppear` so List's lazy rendering
-/// triggers a load whenever the user scrolls the sentinel into view.
+/// Sentinel at the end of an article list. Manual mode shows a button;
+/// auto mode loads via `.onAppear` from List's lazy rendering.
 struct LoadPreviousArticlesButton: View {
 
     let action: () -> Void
@@ -40,13 +39,11 @@ struct LoadPreviousArticlesButton: View {
             action()
         }
         .onChange(of: articleCount) { _, _ in
-            // The previous load completed; allow the next onAppear to fire.
             isLoading = false
         }
     }
 
-    /// Fires synchronously without `withAnimation` so the list keeps its
-    /// existing scroll position instead of animating new rows in.
+    /// No `withAnimation`; preserves the list's current scroll offset.
     private var manualButton: some View {
         Button {
             action()

--- a/SakuraRSS/Views/Shared/Articles/LoadPreviousArticlesButton.swift
+++ b/SakuraRSS/Views/Shared/Articles/LoadPreviousArticlesButton.swift
@@ -1,14 +1,20 @@
 import SwiftUI
 
-/// Sentinel pinned to the bottom of an article list.
+/// Sentinel pinned to the bottom of an article list. Manual mode shows a
+/// tap target; auto mode fires when the scroll position approaches the
+/// bottom and reveals a progress indicator until the new batch arrives.
 struct LoadPreviousArticlesButton: View {
 
     let action: () -> Void
     var articleCount: Int = 0
 
     @AppStorage("Articles.AutoLoadWhileScrolling") private var autoLoadWhileScrolling: Bool = false
-    @State private var isOnScreen = false
-    @State private var lastFiredAtCount: Int? = nil
+    @State private var isLoading: Bool = false
+    @State private var isNearBottom: Bool = false
+    @State private var fireToken: Int = 0
+
+    /// Distance (in points) from the bottom at which auto-load fires.
+    private static let nearBottomThreshold: CGFloat = 800
 
     var body: some View {
         Group {
@@ -24,35 +30,41 @@ struct LoadPreviousArticlesButton: View {
 
     private var autoLoadingIndicator: some View {
         HStack(spacing: 8) {
-            ProgressView()
-            Text(String(localized: "LoadPrevious.Loading", table: "Articles"))
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
+            if isLoading {
+                ProgressView()
+                Text(String(localized: "LoadPrevious.Loading", table: "Articles"))
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
         }
         .frame(maxWidth: .infinity)
-        .padding(.vertical, 12)
-        .onAppear { isOnScreen = true }
-        .onDisappear { isOnScreen = false }
-        .onScrollVisibilityChange(threshold: 0.05) { visible in
-            isOnScreen = visible
+        .frame(minHeight: 44)
+        .padding(.vertical, 4)
+        .onScrollGeometryChange(for: Bool.self) { geo in
+            let distance = geo.contentSize.height - geo.contentOffset.y - geo.containerSize.height
+            return distance < Self.nearBottomThreshold
+        } action: { _, near in
+            guard near != isNearBottom else { return }
+            isNearBottom = near
+            fireToken &+= 1
         }
-        .task(id: AutoLoadKey(isOnScreen: isOnScreen, count: articleCount)) {
-            guard isOnScreen,
-                  lastFiredAtCount != articleCount else { return }
-            lastFiredAtCount = articleCount
+        .onChange(of: articleCount) { _, _ in
+            isLoading = false
+            fireToken &+= 1
+        }
+        .task(id: fireToken) {
             try? await Task.sleep(for: .milliseconds(50))
-            guard !Task.isCancelled else { return }
-            withAnimation(.smooth.speed(2.0)) {
-                action()
-            }
+            guard !Task.isCancelled, isNearBottom, !isLoading else { return }
+            isLoading = true
+            action()
         }
     }
 
+    /// Fires synchronously without `withAnimation` so the list keeps its
+    /// existing scroll position instead of animating new rows in.
     private var manualButton: some View {
         Button {
-            withAnimation(.smooth.speed(2.0)) {
-                action()
-            }
+            action()
         } label: {
             HStack {
                 Image(systemName: "clock.arrow.circlepath")
@@ -65,9 +77,4 @@ struct LoadPreviousArticlesButton: View {
         .buttonStyle(.bordered)
         .tint(.secondary)
     }
-}
-
-private struct AutoLoadKey: Equatable {
-    let isOnScreen: Bool
-    let count: Int
 }

--- a/SakuraRSS/Views/Shared/Articles/LoadPreviousArticlesButton.swift
+++ b/SakuraRSS/Views/Shared/Articles/LoadPreviousArticlesButton.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 /// Sentinel pinned to the bottom of an article list. Manual mode shows a
-/// tap target; auto mode fires when the scroll position approaches the
+/// tap target; auto mode fires when the user scrolls within range of the
 /// bottom and reveals a progress indicator until the new batch arrives.
 struct LoadPreviousArticlesButton: View {
 
@@ -9,12 +9,9 @@ struct LoadPreviousArticlesButton: View {
     var articleCount: Int = 0
 
     @AppStorage("Articles.AutoLoadWhileScrolling") private var autoLoadWhileScrolling: Bool = false
-    @State private var isLoading: Bool = false
-    @State private var isNearBottom: Bool = false
-    @State private var fireToken: Int = 0
-
-    /// Distance (in points) from the bottom at which auto-load fires.
-    private static let nearBottomThreshold: CGFloat = 800
+    @State private var isOnScreen = false
+    @State private var isLoading = false
+    @State private var lastFiredAtCount: Int? = nil
 
     var body: some View {
         Group {
@@ -28,6 +25,9 @@ struct LoadPreviousArticlesButton: View {
         }
     }
 
+    /// Fires when the sentinel becomes visible. The trigger row is sized
+    /// taller than the indicator content so that it crosses into view well
+    /// before the user reaches the absolute bottom of the list.
     private var autoLoadingIndicator: some View {
         HStack(spacing: 8) {
             if isLoading {
@@ -38,23 +38,18 @@ struct LoadPreviousArticlesButton: View {
             }
         }
         .frame(maxWidth: .infinity)
-        .frame(minHeight: 44)
-        .padding(.vertical, 4)
-        .onScrollGeometryChange(for: Bool.self) { geo in
-            let distance = geo.contentSize.height - geo.contentOffset.y - geo.containerSize.height
-            return distance < Self.nearBottomThreshold
-        } action: { _, near in
-            guard near != isNearBottom else { return }
-            isNearBottom = near
-            fireToken &+= 1
+        .frame(minHeight: 240)
+        .onAppear { isOnScreen = true }
+        .onDisappear { isOnScreen = false }
+        .onScrollVisibilityChange(threshold: 0.05) { visible in
+            isOnScreen = visible
         }
-        .onChange(of: articleCount) { _, _ in
+        .task(id: AutoLoadKey(isOnScreen: isOnScreen, count: articleCount)) {
             isLoading = false
-            fireToken &+= 1
-        }
-        .task(id: fireToken) {
+            guard isOnScreen, lastFiredAtCount != articleCount else { return }
+            lastFiredAtCount = articleCount
             try? await Task.sleep(for: .milliseconds(50))
-            guard !Task.isCancelled, isNearBottom, !isLoading else { return }
+            guard !Task.isCancelled else { return }
             isLoading = true
             action()
         }
@@ -77,4 +72,9 @@ struct LoadPreviousArticlesButton: View {
         .buttonStyle(.bordered)
         .tint(.secondary)
     }
+}
+
+private struct AutoLoadKey: Equatable {
+    let isOnScreen: Bool
+    let count: Int
 }

--- a/SakuraRSS/Views/Shared/MarkReadOnScrollModifier.swift
+++ b/SakuraRSS/Views/Shared/MarkReadOnScrollModifier.swift
@@ -10,26 +10,26 @@ struct MarkReadOnScrollModifier: ViewModifier {
 
     @State private var hasBeenVisible = false
     @State private var hasQueued = false
-    @State private var lastMinY: CGFloat = .greatestFiniteMagnitude
+    @State private var topAtOrBelowScreenTop = true
 
     func body(content: Content) -> some View {
         content
             .onScrollVisibilityChange(threshold: 0.01) { isVisible in
                 if isVisible { hasBeenVisible = true }
             }
-            .onGeometryChange(for: CGFloat.self) { proxy in
-                proxy.frame(in: .global).minY
+            .onGeometryChange(for: Bool.self) { proxy in
+                proxy.frame(in: .global).minY >= 0
             } action: { newValue in
-                if !hasQueued,
-                   hasBeenVisible,
-                   scrollMarkAsRead,
-                   !article.isRead,
-                   lastMinY >= 0,
-                   newValue < 0 {
+                if hasQueued { return }
+                if topAtOrBelowScreenTop, !newValue,
+                   hasBeenVisible, scrollMarkAsRead, !article.isRead {
                     hasQueued = true
                     feedManager.markReadOnScroll(article)
+                    return
                 }
-                lastMinY = newValue
+                if topAtOrBelowScreenTop != newValue {
+                    topAtOrBelowScreenTop = newValue
+                }
             }
     }
 }

--- a/Shared/Strings/Settings.xcstrings
+++ b/Shared/Strings/Settings.xcstrings
@@ -4019,55 +4019,55 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Beim Scrollen automatisch laden"
+            "value": "Doomscrolling"
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Auto-Load While Scrolling"
+            "value": "Doomscrolling Mode"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Charger automatiquement en faisant défiler"
+            "value": "Mode Doomscrolling"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Carica automaticamente durante lo scorrimento"
+            "value": "Modalità Doomscrolling"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "スクロール中に自動読み込み"
+            "value": "ドゥームスクロール"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "스크롤 시 자동 로드"
+            "value": "둠스크롤"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tự động tải khi cuộn"
+            "value": "Chế độ Doomscrolling"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "滚动时自动加载"
+            "value": "末日刷屏模式"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "滾動時自動載入"
+            "value": "末日刷屏模式"
           }
         }
       }


### PR DESCRIPTION
## Summary

- **Fix #212**: refresh prompt button now shows reliably after a Following-feed refresh, including when no unread content was visible beforehand.
- **Fix #213**: scroll-mark-as-read no longer cascades view re-renders during scroll.
- Plus a stack of follow-on fixes to the load-more sentinel, the chunk walk, the refresh-accept flow, and the rename of the auto-load setting.

## #212 — Refresh prompt button

`ArticleVisibilityTracker.endRefresh` only ran the new-content diff when `activeRefreshCount` returned to exactly zero. A re-mounted `.task` (e.g. a tab switch during a refresh) could leave the count stranded above zero, so newly arrived articles never made it into `pendingIDs` and the floating "New Content" capsule never appeared. The diff now runs on every call (since `formUnion` is idempotent) and `preRefreshIDs` only resets once the count drains.

Two related issues caught while testing:

- **Articles flashed in, then animated back out.** `loadFromDatabaseInBackground` writes new rows into `feedManager.articles` (with an animation) before `endRefresh` moves them into `pendingIDs`, so they appeared briefly and then jumped out again. `filter` now hides anything not in `preRefreshIDs` while `activeRefreshCount > 0`, so arrivals stay invisible until the user accepts them.
- **Tapping the capsule didn't scroll back to the top.** Each parent view (`AllArticlesView`, `FeedArticlesView`, `HomeSectionView`, `ListSectionView`) now bumps a `scrollToTopTick` alongside `acceptPendingRefresh`; `ArticlesView` wraps its content in a `ScrollViewReader` and scrolls to the first article when that tick changes.

## #213 — Scroll-mark jank

Two compounding sources:

1. `pendingReadIDs` was an observed `Set`, so each `markReadOnScroll` cascaded body re-evaluations through every visible row that read `feedManager.isRead(article)`. It is now `@ObservationIgnored`, and observation is funneled through a new `readMaskRevision` counter that bumps once per `flushDebouncedReads` (250ms debounce or scroll-idle).
2. `MarkReadOnScrollModifier` stored the raw `minY` in `@State`, writing on every scroll frame. Switched to a boolean threshold that only flips when the row crosses the screen-top edge, with an early return once the row has been queued.

## Auto-load sentinel

A few rounds of iteration to land the bottom-of-list "load older" UX:

- Manual mode no longer wraps the load in `withAnimation`, so inserting older rows doesn't shift the user's scroll position.
- Auto mode is driven by `.onAppear` on a placeholder row, with `onChange(of: articleCount)` clearing the loading flag. The placeholder is 1pt tall idle and grows to 44pt while a load is outstanding so the spinner can render. The previous `onScrollGeometryChange`/`onScrollVisibilityChange` paths were unreliable on List rows.
- `extend` subtracts `pendingIDs` before computing growth, so `hasReachedEnd` correctly trips when an auto-load surfaces nothing visible (rather than being masked by content the user hasn't accepted yet).

## Chunk walk skips read-only chunks under Hide Viewed Content

`nextArticleChunk(...chunkDays:)` returned the first chunk that had any rule-passing articles, so with Hide Viewed Content on the user could land on a chunk whose only contents were read. `extend` then reported no growth, `hasReachedEnd` flipped to true, and the sentinel hid even though plenty of older unread sat further back in time.

All four variants (`all`, `section`, `list`, `feed`) now take a `requireUnread: Bool = false` parameter that filters out read articles after the rule pipeline before checking the window. The four load-more call sites pass the user's `hideViewedContent` flag so the walk skips read-only chunks and returns the next chunk that will actually surface new visible content.

## Settings rename

The `AutoLoadWhileScrolling` setting is renamed to **Doomscrolling Mode** in all nine localized languages. The xcstrings key, AppStorage key, and call sites are unchanged.

## Build fix

`flushDebouncedReads` lives in `FeedManager+PendingReads.swift`, an extension file, so `readMaskRevision` had to drop `private(set)` for the archive build to succeed.

## Test plan

- [ ] On the Following feed with Hide Viewed Content on and no unread items showing, pull-to-refresh and confirm the "新しいコンテンツ" capsule appears once new articles arrive.
- [ ] Tapping the capsule releases the new content **and** scrolls the list to the top.
- [ ] During a refresh, no items should appear in the list until the user taps the capsule.
- [ ] With Doomscrolling Mode on and Hide Viewed Content on, scroll to the bottom over a feed where the next chunk is read-only — auto-load should walk past it to the next unread chunk rather than dead-ending.
- [ ] With Doomscrolling Mode off, tapping the manual "Load Previous" button inserts older rows in place without animating the scroll position.
- [ ] With Mark as Read on Scroll on, scrolling a long inbox feed is smooth; rows fade to read in batches (per debounce / on idle) rather than per-row.
- [ ] Verify the new "Doomscrolling Mode" label in Browsing settings across languages.

https://claude.ai/code/session_0195aSrq71mcwf6tEzkReLmg

---
_Generated by [Claude Code](https://claude.ai/code/session_0195aSrq71mcwf6tEzkReLmg)_