### PR TITLE
Add Doomscrolling Mode toggle and tighten count-based batching

### DIFF
--- a/Feeds/BatchingMode.swift
+++ b/Feeds/BatchingMode.swift
@@ -45,8 +45,11 @@ nonisolated enum BatchingMode: String, CaseIterable, Identifiable, Sendable {
 
     func initialCount() -> Int { batchSize ?? 0 }
 
-    /// Returns the currently persisted mode.
+    /// Returns the currently persisted mode, with Doomscrolling Mode applied.
     static func current() -> BatchingMode {
+        if UserDefaults.standard.bool(forKey: DoomscrollingMode.storageKey) {
+            return .items25
+        }
         let raw = UserDefaults.standard.string(forKey: "Articles.BatchingMode")
         return raw.flatMap(BatchingMode.init(rawValue:)) ?? .day1
     }

--- a/Feeds/DoomscrollingMode.swift
+++ b/Feeds/DoomscrollingMode.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Bypass values used while Doomscrolling Mode is active. The user's stored
 /// settings are preserved; only the effective values returned here change.
-enum DoomscrollingMode {
+nonisolated enum DoomscrollingMode {
 
     static let storageKey = "Articles.DoomscrollingMode"
 

--- a/Feeds/DoomscrollingMode.swift
+++ b/Feeds/DoomscrollingMode.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// Bypass values used while Doomscrolling Mode is active. The user's stored
+/// settings are preserved; only the effective values returned here change.
+enum DoomscrollingMode {
+
+    static let storageKey = "Articles.DoomscrollingMode"
+
+    static var isEnabled: Bool {
+        UserDefaults.standard.bool(forKey: storageKey)
+    }
+
+    static func effectiveHideViewedContent(_ stored: Bool) -> Bool {
+        isEnabled ? false : stored
+    }
+
+    static func effectiveBatchingMode(_ stored: BatchingMode) -> BatchingMode {
+        isEnabled ? .items25 : stored
+    }
+
+    static func effectiveScrollMarkAsRead(_ stored: Bool) -> Bool {
+        isEnabled ? false : stored
+    }
+}

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+Articles.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+Articles.swift
@@ -59,10 +59,25 @@ extension FeedManager {
         return applyAllRules(all)
     }
 
-    func articles(for feed: Feed, limit: Int? = nil) -> [Article] {
+    func articles(for feed: Feed, limit: Int? = nil, requireUnread: Bool = false) -> [Article] {
         _ = dataRevision
-        let all = (try? database.articles(forFeedID: feed.id, limit: limit)) ?? []
-        return applyRules(all, feedID: feed.id)
+        guard requireUnread, let limit else {
+            let all = (try? database.articles(forFeedID: feed.id, limit: limit)) ?? []
+            return applyRules(all, feedID: feed.id)
+        }
+        var fetchLimit = max(limit * 4, 100)
+        let maxIterations = 20
+        for _ in 0..<maxIterations {
+            let all = (try? database.articles(forFeedID: feed.id, limit: fetchLimit)) ?? []
+            let pool = applyRules(all, feedID: feed.id)
+            let unread = pool.filter { !$0.isRead }
+            if unread.count >= limit || pool.count < fetchLimit {
+                return Array(unread.prefix(limit))
+            }
+            fetchLimit *= 2
+        }
+        let all = (try? database.articles(forFeedID: feed.id, limit: fetchLimit)) ?? []
+        return Array(applyRules(all, feedID: feed.id).filter { !$0.isRead }.prefix(limit))
     }
 
     func articles(for feed: Feed, since date: Date) -> [Article] {

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+Batching.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+Batching.swift
@@ -4,15 +4,37 @@ extension FeedManager {
 
     // MARK: - Count-based Batches (All)
 
-    func articles(limit: Int) -> [Article] {
+    func articles(limit: Int, requireUnread: Bool = false) -> [Article] {
         _ = dataRevision
-        let fetchLimit = max(limit * 4, 100)
-        var all = (try? database.allArticles(limit: fetchLimit)) ?? []
+        if !requireUnread {
+            let fetchLimit = max(limit * 4, 100)
+            var all = (try? database.allArticles(limit: fetchLimit)) ?? []
+            let muted = mutedFeedIDs
+            if !muted.isEmpty {
+                all = all.filter { !muted.contains($0.feedID) }
+            }
+            return Array(applyAllRules(all).prefix(limit))
+        }
+        var fetchLimit = max(limit * 4, 100)
+        let maxIterations = 20
         let muted = mutedFeedIDs
+        for _ in 0..<maxIterations {
+            var all = (try? database.allArticles(limit: fetchLimit)) ?? []
+            if !muted.isEmpty {
+                all = all.filter { !muted.contains($0.feedID) }
+            }
+            let pool = applyAllRules(all)
+            let unread = pool.filter { !$0.isRead }
+            if unread.count >= limit || pool.count < fetchLimit {
+                return Array(unread.prefix(limit))
+            }
+            fetchLimit *= 2
+        }
+        var all = (try? database.allArticles(limit: fetchLimit)) ?? []
         if !muted.isEmpty {
             all = all.filter { !muted.contains($0.feedID) }
         }
-        return Array(applyAllRules(all).prefix(limit))
+        return Array(applyAllRules(all).filter { !$0.isRead }.prefix(limit))
     }
 
     func hasMoreArticles(beyond count: Int) -> Bool {
@@ -26,34 +48,35 @@ extension FeedManager {
         return applyAllRules(all).count > count
     }
 
-    /// Walks forward in `batchSize` increments until the newly-revealed range
-    /// contains at least one unread article. Returns nil when there is no
-    /// further content to surface. With `requireUnread: false` any growth
-    /// suffices, matching the simple `count + batchSize` increment.
+    /// Returns the next loaded count, or nil if there's nothing more to reveal.
     func nextLoadedCount(after count: Int, batchSize: Int, requireUnread: Bool = false) -> Int? {
         _ = dataRevision
-        let maxIterations = 100
-        var newCount = count + batchSize
-        for _ in 0..<maxIterations {
-            let revealedRange = self.articles(limit: newCount)
-            guard revealedRange.count > count else { return nil }
-            if !requireUnread {
-                return newCount
-            }
-            if revealedRange.suffix(revealedRange.count - count).contains(where: { !$0.isRead }) {
-                return newCount
-            }
-            newCount += batchSize
-        }
-        return nil
+        let newCount = count + batchSize
+        let revealedRange = self.articles(limit: newCount, requireUnread: requireUnread)
+        guard revealedRange.count > count else { return nil }
+        return newCount
     }
 
     // MARK: - Count-based Batches (Section)
 
-    func articles(for section: FeedSection, limit: Int) -> [Article] {
+    func articles(for section: FeedSection, limit: Int, requireUnread: Bool = false) -> [Article] {
         let sectionFeedIDs = Set(feeds.filter { $0.feedSection == section }.map(\.id))
         guard !sectionFeedIDs.isEmpty else { return [] }
-        return Array(articles(limit: limit * 3).filter { sectionFeedIDs.contains($0.feedID) }.prefix(limit))
+        if !requireUnread {
+            return Array(articles(limit: limit * 3).filter { sectionFeedIDs.contains($0.feedID) }.prefix(limit))
+        }
+        var multiplier = 3
+        let maxIterations = 20
+        for _ in 0..<maxIterations {
+            let pool = articles(limit: limit * multiplier)
+            let filtered = pool.filter { sectionFeedIDs.contains($0.feedID) && !$0.isRead }
+            if filtered.count >= limit || pool.count < limit * multiplier {
+                return Array(filtered.prefix(limit))
+            }
+            multiplier *= 2
+        }
+        let pool = articles(limit: limit * multiplier)
+        return Array(pool.filter { sectionFeedIDs.contains($0.feedID) && !$0.isRead }.prefix(limit))
     }
 
     func hasMoreArticles(for section: FeedSection, beyond count: Int) -> Bool {
@@ -64,20 +87,10 @@ extension FeedManager {
     }
 
     func nextLoadedCount(for section: FeedSection, after count: Int, batchSize: Int, requireUnread: Bool = false) -> Int? {
-        let maxIterations = 100
-        var newCount = count + batchSize
-        for _ in 0..<maxIterations {
-            let revealedRange = self.articles(for: section, limit: newCount)
-            guard revealedRange.count > count else { return nil }
-            if !requireUnread {
-                return newCount
-            }
-            if revealedRange.suffix(revealedRange.count - count).contains(where: { !$0.isRead }) {
-                return newCount
-            }
-            newCount += batchSize
-        }
-        return nil
+        let newCount = count + batchSize
+        let revealedRange = self.articles(for: section, limit: newCount, requireUnread: requireUnread)
+        guard revealedRange.count > count else { return nil }
+        return newCount
     }
 
     // MARK: - Count-based Batches (Feed)
@@ -90,30 +103,36 @@ extension FeedManager {
 
     func nextLoadedCount(for feed: Feed, after count: Int, batchSize: Int, requireUnread: Bool = false) -> Int? {
         _ = dataRevision
-        let maxIterations = 100
-        var newCount = count + batchSize
-        for _ in 0..<maxIterations {
-            let all = (try? database.articles(forFeedID: feed.id, limit: newCount)) ?? []
-            let revealedRange = applyRules(all, feedID: feed.id)
-            guard revealedRange.count > count else { return nil }
-            if !requireUnread {
-                return newCount
-            }
-            if revealedRange.suffix(revealedRange.count - count).contains(where: { !$0.isRead }) {
-                return newCount
-            }
-            newCount += batchSize
-        }
-        return nil
+        let newCount = count + batchSize
+        let revealedRange = self.articles(for: feed, limit: newCount, requireUnread: requireUnread)
+        guard revealedRange.count > count else { return nil }
+        return newCount
     }
 
     // MARK: - Count-based Batches (List)
 
-    func articles(for list: FeedList, limit: Int) -> [Article] {
+    func articles(for list: FeedList, limit: Int, requireUnread: Bool = false) -> [Article] {
         let listFeedIDs = feedIDs(for: list)
         guard !listFeedIDs.isEmpty else { return [] }
-        let pooled = articles(limit: limit * 3).filter { listFeedIDs.contains($0.feedID) }
-        return Array(applyListRules(pooled, listID: list.id).prefix(limit))
+        if !requireUnread {
+            let pooled = articles(limit: limit * 3).filter { listFeedIDs.contains($0.feedID) }
+            return Array(applyListRules(pooled, listID: list.id).prefix(limit))
+        }
+        var multiplier = 3
+        let maxIterations = 20
+        for _ in 0..<maxIterations {
+            let pool = articles(limit: limit * multiplier)
+            let pooled = pool.filter { listFeedIDs.contains($0.feedID) }
+            let listed = applyListRules(pooled, listID: list.id)
+            let unread = listed.filter { !$0.isRead }
+            if unread.count >= limit || pool.count < limit * multiplier {
+                return Array(unread.prefix(limit))
+            }
+            multiplier *= 2
+        }
+        let pool = articles(limit: limit * multiplier)
+        let pooled = pool.filter { listFeedIDs.contains($0.feedID) }
+        return Array(applyListRules(pooled, listID: list.id).filter { !$0.isRead }.prefix(limit))
     }
 
     func hasMoreArticles(for list: FeedList, beyond count: Int) -> Bool {
@@ -124,20 +143,10 @@ extension FeedManager {
     }
 
     func nextLoadedCount(for list: FeedList, after count: Int, batchSize: Int, requireUnread: Bool = false) -> Int? {
-        let maxIterations = 100
-        var newCount = count + batchSize
-        for _ in 0..<maxIterations {
-            let revealedRange = self.articles(for: list, limit: newCount)
-            guard revealedRange.count > count else { return nil }
-            if !requireUnread {
-                return newCount
-            }
-            if revealedRange.suffix(revealedRange.count - count).contains(where: { !$0.isRead }) {
-                return newCount
-            }
-            newCount += batchSize
-        }
-        return nil
+        let newCount = count + batchSize
+        let revealedRange = self.articles(for: list, limit: newCount, requireUnread: requireUnread)
+        guard revealedRange.count > count else { return nil }
+        return newCount
     }
 
     // MARK: - Date-based Batches (List)

--- a/SakuraRSS/Views/Feeds/FeedArticlesView.swift
+++ b/SakuraRSS/Views/Feeds/FeedArticlesView.swift
@@ -5,14 +5,23 @@ struct FeedArticlesView: View {
     @Environment(FeedManager.self) var feedManager
     let feed: Feed
 
-    @AppStorage("Articles.BatchingMode") private var batchingMode: BatchingMode = .day1
+    @AppStorage("Articles.BatchingMode") private var storedBatchingMode: BatchingMode = .day1
+    @AppStorage(DoomscrollingMode.storageKey) private var doomscrollingMode: Bool = false
     @State private var loadedSinceDate: Date = BatchingMode.current().initialSinceDate()
     @State private var loadedCount: Int = BatchingMode.current().initialCount()
     @AppStorage("Display.MarkAllReadPosition") private var markAllReadPosition: MarkAllReadPosition = .bottom
     @AppStorage("Instagram.HideReels") private var hideReels: Bool = false
-    @AppStorage("Articles.HideViewedContent") private var hideViewedContent: Bool = false
+    @AppStorage("Articles.HideViewedContent") private var storedHideViewedContent: Bool = false
     @State private var visibility = ArticleVisibilityTracker()
     @State private var scrollToTopTick: Int = 0
+
+    private var batchingMode: BatchingMode {
+        DoomscrollingMode.effectiveBatchingMode(storedBatchingMode)
+    }
+
+    private var hideViewedContent: Bool {
+        DoomscrollingMode.effectiveHideViewedContent(storedHideViewedContent)
+    }
 
     private var currentFeed: Feed {
         feedManager.feeds.first(where: { $0.id == feed.id }) ?? feed
@@ -49,7 +58,11 @@ struct FeedArticlesView: View {
         var articles: [Article]
         if batchingMode.isCountBased {
             articles = feedManager.undatedArticles(for: feed)
-                + feedManager.articles(for: feed, limit: loadedCount)
+                + feedManager.articles(
+                    for: feed,
+                    limit: loadedCount,
+                    requireUnread: hideViewedContent
+                )
         } else {
             articles = feedManager.undatedArticles(for: feed)
                 + feedManager.articles(for: feed, since: loadedSinceDate)
@@ -61,8 +74,11 @@ struct FeedArticlesView: View {
     }
 
     private func performRefresh() async {
+        guard !feedManager.isLoading else { return }
         feedManager.flushDebouncedReads()
-        visibility.beginRefresh(from: rawArticles, isEnabled: hideViewedContent)
+        withAnimation(.smooth.speed(2.0)) {
+            visibility.beginRefresh(from: rawArticles, isEnabled: hideViewedContent)
+        }
         try? await feedManager.refreshFeed(feed)
         withAnimation(.smooth.speed(2.0)) {
             visibility.endRefresh(from: rawArticles, isEnabled: hideViewedContent)
@@ -122,6 +138,9 @@ struct FeedArticlesView: View {
         .onChange(of: batchingMode) { _, newMode in
             loadedSinceDate = newMode.initialSinceDate()
             loadedCount = newMode.initialCount()
+            visibility.capture(from: rawArticles, isEnabled: hideViewedContent)
+        }
+        .onChange(of: doomscrollingMode) { _, _ in
             visibility.capture(from: rawArticles, isEnabled: hideViewedContent)
         }
     }

--- a/SakuraRSS/Views/Home/AllArticlesView.swift
+++ b/SakuraRSS/Views/Home/AllArticlesView.swift
@@ -100,18 +100,27 @@ struct AllArticlesView: View {
     @Environment(FeedManager.self) var feedManager
 
     @AppStorage("Home.SelectedSection") private var selectedSelection: HomeSelection = .section(.feed)
-    @AppStorage("Articles.BatchingMode") private var batchingMode: BatchingMode = .day1
+    @AppStorage("Articles.BatchingMode") private var storedBatchingMode: BatchingMode = .day1
+    @AppStorage(DoomscrollingMode.storageKey) private var doomscrollingMode: Bool = false
     @State private var loadedSinceDate: Date = BatchingMode.current().initialSinceDate()
     @State private var loadedCount: Int = BatchingMode.current().initialCount()
     @AppStorage("Display.MarkAllReadPosition") private var markAllReadPosition: MarkAllReadPosition = .bottom
     @AppStorage("WhileYouSlept.DismissedDate") private var whileYouSleptDismissedDate: String = ""
     @AppStorage("TodaysSummary.DismissedDate") private var todaysSummaryDismissedDate: String = ""
     @AppStorage("Instagram.HideReels") private var hideInstagramReels: Bool = false
-    @AppStorage("Articles.HideViewedContent") private var hideViewedContent: Bool = false
+    @AppStorage("Articles.HideViewedContent") private var storedHideViewedContent: Bool = false
     @State private var visibility = ArticleVisibilityTracker()
     @State private var scrollToTopTick: Int = 0
     @State private var whileYouSleptAvailable = false
     @State private var todaysSummaryAvailable = false
+
+    private var batchingMode: BatchingMode {
+        DoomscrollingMode.effectiveBatchingMode(storedBatchingMode)
+    }
+
+    private var hideViewedContent: Bool {
+        DoomscrollingMode.effectiveHideViewedContent(storedHideViewedContent)
+    }
 
     private var todayDateKey: String {
         let formatter = DateFormatter()
@@ -127,7 +136,10 @@ struct AllArticlesView: View {
     private var rawArticles: [Article] {
         var articles: [Article]
         if batchingMode.isCountBased {
-            articles = feedManager.articles(limit: loadedCount)
+            articles = feedManager.articles(
+                limit: loadedCount,
+                requireUnread: hideViewedContent
+            )
         } else {
             articles = feedManager.articles(since: loadedSinceDate)
         }
@@ -142,8 +154,11 @@ struct AllArticlesView: View {
     }
 
     private func performRefresh() async {
+        guard !feedManager.isLoading else { return }
         feedManager.flushDebouncedReads()
-        visibility.beginRefresh(from: rawArticles, isEnabled: hideViewedContent)
+        withAnimation(.smooth.speed(2.0)) {
+            visibility.beginRefresh(from: rawArticles, isEnabled: hideViewedContent)
+        }
         await feedManager.refreshAllFeeds()
         withAnimation(.smooth.speed(2.0)) {
             visibility.endRefresh(from: rawArticles, isEnabled: hideViewedContent)
@@ -153,8 +168,11 @@ struct AllArticlesView: View {
     /// Kicks off a refresh and returns immediately so SwiftUI dismisses the
     /// pull-to-refresh indicator; in-flight progress shows via the toolbar donut.
     private func startRefreshWithoutBlocking() {
+        guard !feedManager.isLoading else { return }
         feedManager.flushDebouncedReads()
-        visibility.beginRefresh(from: rawArticles, isEnabled: hideViewedContent)
+        withAnimation(.smooth.speed(2.0)) {
+            visibility.beginRefresh(from: rawArticles, isEnabled: hideViewedContent)
+        }
         Task { @MainActor in
             await feedManager.refreshAllFeeds()
             withAnimation(.smooth.speed(2.0)) {
@@ -285,6 +303,9 @@ struct AllArticlesView: View {
         .onChange(of: batchingMode) { _, newMode in
             loadedSinceDate = newMode.initialSinceDate()
             loadedCount = newMode.initialCount()
+            visibility.capture(from: rawArticles, isEnabled: hideViewedContent)
+        }
+        .onChange(of: doomscrollingMode) { _, _ in
             visibility.capture(from: rawArticles, isEnabled: hideViewedContent)
         }
         .onAppear {

--- a/SakuraRSS/Views/Home/HomeSectionView.swift
+++ b/SakuraRSS/Views/Home/HomeSectionView.swift
@@ -6,19 +6,32 @@ struct HomeSectionView: View {
 
     let section: FeedSection
 
-    @AppStorage("Articles.BatchingMode") private var batchingMode: BatchingMode = .day1
+    @AppStorage("Articles.BatchingMode") private var storedBatchingMode: BatchingMode = .day1
+    @AppStorage(DoomscrollingMode.storageKey) private var doomscrollingMode: Bool = false
     @State private var loadedSinceDate: Date = BatchingMode.current().initialSinceDate()
     @State private var loadedCount: Int = BatchingMode.current().initialCount()
     @AppStorage("Display.MarkAllReadPosition") private var markAllReadPosition: MarkAllReadPosition = .bottom
     @AppStorage("Instagram.HideReels") private var hideInstagramReels: Bool = false
-    @AppStorage("Articles.HideViewedContent") private var hideViewedContent: Bool = false
+    @AppStorage("Articles.HideViewedContent") private var storedHideViewedContent: Bool = false
     @State private var visibility = ArticleVisibilityTracker()
     @State private var scrollToTopTick: Int = 0
+
+    private var batchingMode: BatchingMode {
+        DoomscrollingMode.effectiveBatchingMode(storedBatchingMode)
+    }
+
+    private var hideViewedContent: Bool {
+        DoomscrollingMode.effectiveHideViewedContent(storedHideViewedContent)
+    }
 
     private var rawArticles: [Article] {
         var articles: [Article]
         if batchingMode.isCountBased {
-            articles = feedManager.articles(for: section, limit: loadedCount)
+            articles = feedManager.articles(
+                for: section,
+                limit: loadedCount,
+                requireUnread: hideViewedContent
+            )
         } else {
             articles = feedManager.articles(for: section, since: loadedSinceDate)
         }
@@ -29,8 +42,11 @@ struct HomeSectionView: View {
     }
 
     private func performRefresh() async {
+        guard !feedManager.isLoading else { return }
         feedManager.flushDebouncedReads()
-        visibility.beginRefresh(from: rawArticles, isEnabled: hideViewedContent)
+        withAnimation(.smooth.speed(2.0)) {
+            visibility.beginRefresh(from: rawArticles, isEnabled: hideViewedContent)
+        }
         await feedManager.refreshAllFeeds()
         withAnimation(.smooth.speed(2.0)) {
             visibility.endRefresh(from: rawArticles, isEnabled: hideViewedContent)
@@ -40,8 +56,11 @@ struct HomeSectionView: View {
     /// Kicks off a refresh and returns immediately so SwiftUI dismisses the
     /// pull-to-refresh indicator; in-flight progress shows via the toolbar donut.
     private func startRefreshWithoutBlocking() {
+        guard !feedManager.isLoading else { return }
         feedManager.flushDebouncedReads()
-        visibility.beginRefresh(from: rawArticles, isEnabled: hideViewedContent)
+        withAnimation(.smooth.speed(2.0)) {
+            visibility.beginRefresh(from: rawArticles, isEnabled: hideViewedContent)
+        }
         Task { @MainActor in
             await feedManager.refreshAllFeeds()
             withAnimation(.smooth.speed(2.0)) {
@@ -126,6 +145,9 @@ struct HomeSectionView: View {
         .onChange(of: batchingMode) { _, newMode in
             loadedSinceDate = newMode.initialSinceDate()
             loadedCount = newMode.initialCount()
+            visibility.capture(from: rawArticles, isEnabled: hideViewedContent)
+        }
+        .onChange(of: doomscrollingMode) { _, _ in
             visibility.capture(from: rawArticles, isEnabled: hideViewedContent)
         }
     }

--- a/SakuraRSS/Views/Home/ListSectionView.swift
+++ b/SakuraRSS/Views/Home/ListSectionView.swift
@@ -6,24 +6,40 @@ struct ListSectionView: View {
 
     let list: FeedList
 
-    @AppStorage("Articles.BatchingMode") private var batchingMode: BatchingMode = .day1
+    @AppStorage("Articles.BatchingMode") private var storedBatchingMode: BatchingMode = .day1
+    @AppStorage(DoomscrollingMode.storageKey) private var doomscrollingMode: Bool = false
     @State private var loadedSinceDate: Date = BatchingMode.current().initialSinceDate()
     @State private var loadedCount: Int = BatchingMode.current().initialCount()
     @AppStorage("Display.MarkAllReadPosition") private var markAllReadPosition: MarkAllReadPosition = .bottom
-    @AppStorage("Articles.HideViewedContent") private var hideViewedContent: Bool = false
+    @AppStorage("Articles.HideViewedContent") private var storedHideViewedContent: Bool = false
     @State private var visibility = ArticleVisibilityTracker()
     @State private var scrollToTopTick: Int = 0
 
+    private var batchingMode: BatchingMode {
+        DoomscrollingMode.effectiveBatchingMode(storedBatchingMode)
+    }
+
+    private var hideViewedContent: Bool {
+        DoomscrollingMode.effectiveHideViewedContent(storedHideViewedContent)
+    }
+
     private var rawArticles: [Article] {
         if batchingMode.isCountBased {
-            return feedManager.articles(for: list, limit: loadedCount)
+            return feedManager.articles(
+                for: list,
+                limit: loadedCount,
+                requireUnread: hideViewedContent
+            )
         }
         return feedManager.articles(for: list, since: loadedSinceDate)
     }
 
     private func performRefresh() async {
+        guard !feedManager.isLoading else { return }
         feedManager.flushDebouncedReads()
-        visibility.beginRefresh(from: rawArticles, isEnabled: hideViewedContent)
+        withAnimation(.smooth.speed(2.0)) {
+            visibility.beginRefresh(from: rawArticles, isEnabled: hideViewedContent)
+        }
         await feedManager.refreshAllFeeds()
         withAnimation(.smooth.speed(2.0)) {
             visibility.endRefresh(from: rawArticles, isEnabled: hideViewedContent)
@@ -33,8 +49,11 @@ struct ListSectionView: View {
     /// Kicks off a refresh and returns immediately so SwiftUI dismisses the
     /// pull-to-refresh indicator; in-flight progress shows via the toolbar donut.
     private func startRefreshWithoutBlocking() {
+        guard !feedManager.isLoading else { return }
         feedManager.flushDebouncedReads()
-        visibility.beginRefresh(from: rawArticles, isEnabled: hideViewedContent)
+        withAnimation(.smooth.speed(2.0)) {
+            visibility.beginRefresh(from: rawArticles, isEnabled: hideViewedContent)
+        }
         Task { @MainActor in
             await feedManager.refreshAllFeeds()
             withAnimation(.smooth.speed(2.0)) {
@@ -116,6 +135,9 @@ struct ListSectionView: View {
         .onChange(of: batchingMode) { _, newMode in
             loadedSinceDate = newMode.initialSinceDate()
             loadedCount = newMode.initialCount()
+            visibility.capture(from: rawArticles, isEnabled: hideViewedContent)
+        }
+        .onChange(of: doomscrollingMode) { _, _ in
             visibility.capture(from: rawArticles, isEnabled: hideViewedContent)
         }
     }

--- a/SakuraRSS/Views/More/Settings/BrowsingSettingsView.swift
+++ b/SakuraRSS/Views/More/Settings/BrowsingSettingsView.swift
@@ -6,13 +6,45 @@ struct BrowsingSettingsView: View {
     @AppStorage("Articles.AutoLoadWhileScrolling") private var autoLoadWhileScrolling: Bool = false
     @AppStorage("Articles.HideViewedContent") private var hideViewedContent: Bool = false
     @AppStorage("Display.ScrollMarkAsRead") private var scrollMarkAsRead: Bool = false
+    @AppStorage(DoomscrollingMode.storageKey) private var doomscrollingMode: Bool = false
+
+    private var hideViewedContentBinding: Binding<Bool> {
+        Binding(
+            get: { doomscrollingMode ? false : hideViewedContent },
+            set: { newValue in
+                guard !doomscrollingMode else { return }
+                hideViewedContent = newValue
+            }
+        )
+    }
+
+    private var scrollMarkAsReadBinding: Binding<Bool> {
+        Binding(
+            get: { doomscrollingMode ? false : scrollMarkAsRead },
+            set: { newValue in
+                guard !doomscrollingMode else { return }
+                scrollMarkAsRead = newValue
+            }
+        )
+    }
+
+    private var batchingModeBinding: Binding<BatchingMode> {
+        Binding(
+            get: { doomscrollingMode ? .items25 : batchingMode },
+            set: { newValue in
+                guard !doomscrollingMode else { return }
+                batchingMode = newValue
+            }
+        )
+    }
 
     var body: some View {
         List {
             Section {
                 Toggle(String(localized: "HideViewedContent", table: "Settings"),
-                       isOn: $hideViewedContent)
-                Picker(selection: $batchingMode) {
+                       isOn: hideViewedContentBinding)
+                    .disabled(doomscrollingMode)
+                Picker(selection: batchingModeBinding) {
                     Section {
                         Text(String(localized: "Batching.Day1", table: "Settings"))
                             .tag(BatchingMode.day1)
@@ -36,6 +68,7 @@ struct BrowsingSettingsView: View {
                 } label: {
                     Text(String(localized: "BatchingMode", table: "Settings"))
                 }
+                .disabled(doomscrollingMode)
             } header: {
                 Text(String(localized: "Section.Feeds", table: "Settings"))
             } footer: {
@@ -45,9 +78,26 @@ struct BrowsingSettingsView: View {
             Section {
                 Toggle(String(localized: "AutoLoadWhileScrolling", table: "Settings"),
                        isOn: $autoLoadWhileScrolling)
-                Toggle(String(localized: "ScrollMarkAsRead", table: "Settings"), isOn: $scrollMarkAsRead)
+                Toggle(String(localized: "ScrollMarkAsRead", table: "Settings"),
+                       isOn: scrollMarkAsReadBinding)
+                    .disabled(doomscrollingMode)
             } header: {
                 Text(String(localized: "Section.Scrolling", table: "Settings"))
+            }
+
+            Section {
+                Toggle(String(localized: "Doomscrolling.Enable", table: "Settings"),
+                       isOn: Binding(
+                            get: { doomscrollingMode },
+                            set: { newValue in
+                                withAnimation(.smooth.speed(2.0)) {
+                                    doomscrollingMode = newValue
+                                }
+                            }
+                       ))
+                    .tint(.red)
+            } header: {
+                Text(String(localized: "Section.Doomscrolling", table: "Settings"))
             }
         }
         .listStyle(.insetGrouped)

--- a/SakuraRSS/Views/More/Settings/BrowsingSettingsView.swift
+++ b/SakuraRSS/Views/More/Settings/BrowsingSettingsView.swift
@@ -3,7 +3,6 @@ import SwiftUI
 struct BrowsingSettingsView: View {
 
     @AppStorage("Articles.BatchingMode") private var batchingMode: BatchingMode = .day1
-    @AppStorage("Articles.AutoLoadWhileScrolling") private var autoLoadWhileScrolling: Bool = false
     @AppStorage("Articles.HideViewedContent") private var hideViewedContent: Bool = false
     @AppStorage("Display.ScrollMarkAsRead") private var scrollMarkAsRead: Bool = false
     @AppStorage(DoomscrollingMode.storageKey) private var doomscrollingMode: Bool = false
@@ -76,8 +75,6 @@ struct BrowsingSettingsView: View {
             }
 
             Section {
-                Toggle(String(localized: "AutoLoadWhileScrolling", table: "Settings"),
-                       isOn: $autoLoadWhileScrolling)
                 Toggle(String(localized: "ScrollMarkAsRead", table: "Settings"),
                        isOn: scrollMarkAsReadBinding)
                     .disabled(doomscrollingMode)

--- a/SakuraRSS/Views/Shared/Articles/LoadPreviousArticlesButton.swift
+++ b/SakuraRSS/Views/Shared/Articles/LoadPreviousArticlesButton.swift
@@ -7,13 +7,13 @@ struct LoadPreviousArticlesButton: View {
     let action: () -> Void
     var articleCount: Int = 0
 
-    @AppStorage("Articles.AutoLoadWhileScrolling") private var autoLoadWhileScrolling: Bool = false
+    @AppStorage(DoomscrollingMode.storageKey) private var doomscrollingMode: Bool = false
     @State private var isLoading = false
 
     var body: some View {
         Group {
             if articleCount > 0 {
-                if autoLoadWhileScrolling {
+                if doomscrollingMode {
                     autoLoadingIndicator
                 } else {
                     manualButton

--- a/SakuraRSS/Views/Shared/MarkReadOnScrollModifier.swift
+++ b/SakuraRSS/Views/Shared/MarkReadOnScrollModifier.swift
@@ -4,7 +4,12 @@ import SwiftUI
 struct MarkReadOnScrollModifier: ViewModifier {
 
     @Environment(FeedManager.self) private var feedManager
-    @AppStorage("Display.ScrollMarkAsRead") private var scrollMarkAsRead: Bool = false
+    @AppStorage("Display.ScrollMarkAsRead") private var storedScrollMarkAsRead: Bool = false
+    @AppStorage(DoomscrollingMode.storageKey) private var doomscrollingMode: Bool = false
+
+    private var scrollMarkAsRead: Bool {
+        DoomscrollingMode.effectiveScrollMarkAsRead(storedScrollMarkAsRead)
+    }
 
     let article: Article
 

--- a/Shared/Strings/Settings.xcstrings
+++ b/Shared/Strings/Settings.xcstrings
@@ -5959,6 +5959,124 @@
           }
         }
       }
+    },
+    "Section.Doomscrolling": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Doomscrolling-Modus"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Doomscrolling Mode"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mode Doomscrolling"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modalità Doomscrolling"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ドゥームスクロールモード"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "둠스크롤링 모드"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chế độ Doomscrolling"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "末日刷屏模式"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "末日刷屏模式"
+          }
+        }
+      }
+    },
+    "Doomscrolling.Enable": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktivieren"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activer"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Attiva"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有効化"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "활성화"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kích hoạt"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "启用"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "啟用"
+          }
+        }
+      }
     }
   },
   "version": "1.1"


### PR DESCRIPTION
## Summary
- Adds a Doomscrolling Mode section at the bottom of the Browsing settings. The toggle is tinted red, animates with `.smooth.speed(2.0)`, and surfaces effective bypass values (Hide Viewed Content off, Items 25 batching, Scroll Mark As Read off) while it is on. The user's stored settings are not overwritten — the bypass kicks in across `FeedArticlesView`, `HomeSectionView`, `ListSectionView`, `AllArticlesView`, and `MarkReadOnScrollModifier`.
- Reworks count-based batching so when Hide Viewed Content is on, the data layer returns unread items first instead of fetching a fixed page and filtering it. `nextLoadedCount` advances by the requested batch size of unread items.
- Pull-to-refresh now wraps the read-content removal in `withAnimation(.smooth.speed(2.0))` and short-circuits when a refresh is already in flight.
- Adds the new `Section.Doomscrolling` and `Doomscrolling.Enable` localization keys with translations for de/en/fr/it/ja/ko/vi/zh-Hans/zh-Hant.

## Test plan
- [ ] Build SakuraRSS and confirm settings list renders the Doomscrolling Mode section at the end.
- [ ] Toggle Doomscrolling Mode on; verify Hide Viewed Content / batching / scroll-to-read controls visually flip to off / Items 25 / off with animation, and remain disabled while Doomscrolling is on.
- [ ] Toggle Doomscrolling Mode off; verify previously stored Hide Read / batching / scroll-to-read settings are restored.
- [ ] With Hide Read on and Items 25 batching, confirm the initial load shows up to 25 unread items and "Load More" advances to the next 25 unread.
- [ ] Pull to refresh while Hide Read is on; verify read content animates out before the refresh starts.
- [ ] Pull to refresh while a refresh is already running; verify the indicator dismisses immediately without launching another refresh.

https://claude.ai/code/session_0144tAM1JddSenDuyNG1qEC3

---
_Generated by [Claude Code](https://claude.ai/code/session_0144tAM1JddSenDuyNG1qEC3)_