### PR TITLE
Add bookmark button to Archive.md and Clear This Page viewers

### DIFF
--- a/SakuraRSS/Views/Shared/ArchivePhView.swift
+++ b/SakuraRSS/Views/Shared/ArchivePhView.swift
@@ -4,9 +4,18 @@ import WebKit
 /// Presents an article URL through archive.today in an embedded WebView.
 struct ArchivePhView: View {
 
+    @Environment(FeedManager.self) private var feedManager
+    let article: Article
     let url: URL
     @State private var isLoading = true
     @State private var reloadTrigger = 0
+    @State private var isBookmarked: Bool
+
+    init(article: Article, url: URL) {
+        self.article = article
+        self.url = url
+        _isBookmarked = State(initialValue: article.isBookmarked)
+    }
 
     var body: some View {
         ZStack {
@@ -24,6 +33,14 @@ struct ArchivePhView: View {
         }
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
+            ToolbarItemGroup(placement: .topBarTrailing) {
+                Button {
+                    isBookmarked.toggle()
+                    feedManager.toggleBookmark(article)
+                } label: {
+                    Image(systemName: isBookmarked ? "bookmark.fill" : "bookmark")
+                }
+            }
             ToolbarItemGroup(placement: .topBarTrailing) {
                 Button {
                     reloadTrigger &+= 1

--- a/SakuraRSS/Views/Shared/ArchivePhView.swift
+++ b/SakuraRSS/Views/Shared/ArchivePhView.swift
@@ -4,7 +4,6 @@ import WebKit
 /// Presents an article URL through archive.today in an embedded WebView.
 struct ArchivePhView: View {
 
-    @Environment(FeedManager.self) private var feedManager
     let article: Article
     let url: URL
     @State private var isLoading = true
@@ -33,26 +32,12 @@ struct ArchivePhView: View {
         }
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
-            ToolbarItemGroup(placement: .topBarTrailing) {
-                Button {
-                    isBookmarked.toggle()
-                    feedManager.toggleBookmark(article)
-                } label: {
-                    Image(systemName: isBookmarked ? "bookmark.fill" : "bookmark")
-                }
-            }
-            ToolbarItemGroup(placement: .topBarTrailing) {
-                Button {
-                    reloadTrigger &+= 1
-                } label: {
-                    Image(systemName: "arrow.clockwise")
-                }
-            }
-            ToolbarItemGroup(placement: .topBarTrailing) {
-                ShareLink(item: url) {
-                    Image(systemName: "square.and.arrow.up")
-                }
-            }
+            WebArticleViewerToolbar(
+                article: article,
+                url: url,
+                isBookmarked: $isBookmarked,
+                onReload: { reloadTrigger &+= 1 }
+            )
         }
     }
 }

--- a/SakuraRSS/Views/Shared/ArticleDestinationView.swift
+++ b/SakuraRSS/Views/Shared/ArticleDestinationView.swift
@@ -22,10 +22,10 @@ struct ArticleDestinationView: View {
             YouTubePlayerView(article: article)
         } else if feedOpenMode == .clearThisPage,
                   let url = URL(string: article.url) {
-            ClearThisPageView(url: url)
+            ClearThisPageView(article: article, url: url)
         } else if feedOpenMode == .archivePh,
                   let url = URL(string: article.url) {
-            ArchivePhView(url: url)
+            ArchivePhView(article: article, url: url)
         } else {
             ArticleDetailView(article: article)
         }

--- a/SakuraRSS/Views/Shared/ClearThisPageView.swift
+++ b/SakuraRSS/Views/Shared/ClearThisPageView.swift
@@ -5,7 +5,6 @@ import WebKit
 struct ClearThisPageView: View {
 
     @Environment(\.colorScheme) private var colorScheme
-    @Environment(FeedManager.self) private var feedManager
     let article: Article
     let url: URL
     @State private var isLoading = true
@@ -35,26 +34,12 @@ struct ClearThisPageView: View {
         }
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
-            ToolbarItemGroup(placement: .topBarTrailing) {
-                Button {
-                    isBookmarked.toggle()
-                    feedManager.toggleBookmark(article)
-                } label: {
-                    Image(systemName: isBookmarked ? "bookmark.fill" : "bookmark")
-                }
-            }
-            ToolbarItemGroup(placement: .topBarTrailing) {
-                Button {
-                    reloadTrigger &+= 1
-                } label: {
-                    Image(systemName: "arrow.clockwise")
-                }
-            }
-            ToolbarItemGroup(placement: .topBarTrailing) {
-                ShareLink(item: url) {
-                    Image(systemName: "square.and.arrow.up")
-                }
-            }
+            WebArticleViewerToolbar(
+                article: article,
+                url: url,
+                isBookmarked: $isBookmarked,
+                onReload: { reloadTrigger &+= 1 }
+            )
         }
     }
 }

--- a/SakuraRSS/Views/Shared/ClearThisPageView.swift
+++ b/SakuraRSS/Views/Shared/ClearThisPageView.swift
@@ -5,9 +5,18 @@ import WebKit
 struct ClearThisPageView: View {
 
     @Environment(\.colorScheme) private var colorScheme
+    @Environment(FeedManager.self) private var feedManager
+    let article: Article
     let url: URL
     @State private var isLoading = true
     @State private var reloadTrigger = 0
+    @State private var isBookmarked: Bool
+
+    init(article: Article, url: URL) {
+        self.article = article
+        self.url = url
+        _isBookmarked = State(initialValue: article.isBookmarked)
+    }
 
     var body: some View {
         ZStack {
@@ -26,6 +35,14 @@ struct ClearThisPageView: View {
         }
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
+            ToolbarItemGroup(placement: .topBarTrailing) {
+                Button {
+                    isBookmarked.toggle()
+                    feedManager.toggleBookmark(article)
+                } label: {
+                    Image(systemName: isBookmarked ? "bookmark.fill" : "bookmark")
+                }
+            }
             ToolbarItemGroup(placement: .topBarTrailing) {
                 Button {
                     reloadTrigger &+= 1

--- a/SakuraRSS/Views/Shared/WebArticleViewerToolbar.swift
+++ b/SakuraRSS/Views/Shared/WebArticleViewerToolbar.swift
@@ -17,8 +17,6 @@ struct WebArticleViewerToolbar: ToolbarContent {
             } label: {
                 Image(systemName: isBookmarked ? "bookmark.fill" : "bookmark")
             }
-        }
-        ToolbarItemGroup(placement: .topBarTrailing) {
             Button(action: onReload) {
                 Image(systemName: "arrow.clockwise")
             }

--- a/SakuraRSS/Views/Shared/WebArticleViewerToolbar.swift
+++ b/SakuraRSS/Views/Shared/WebArticleViewerToolbar.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+/// Shared trailing toolbar used by web-based article viewers.
+struct WebArticleViewerToolbar: ToolbarContent {
+
+    @Environment(FeedManager.self) private var feedManager
+    let article: Article
+    let url: URL
+    @Binding var isBookmarked: Bool
+    let onReload: () -> Void
+
+    var body: some ToolbarContent {
+        ToolbarItemGroup(placement: .topBarTrailing) {
+            Button {
+                isBookmarked.toggle()
+                feedManager.toggleBookmark(article)
+            } label: {
+                Image(systemName: isBookmarked ? "bookmark.fill" : "bookmark")
+            }
+        }
+        ToolbarItemGroup(placement: .topBarTrailing) {
+            Button(action: onReload) {
+                Image(systemName: "arrow.clockwise")
+            }
+        }
+        ToolbarItemGroup(placement: .topBarTrailing) {
+            ShareLink(item: url) {
+                Image(systemName: "square.and.arrow.up")
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add a bookmark toolbar button to `ArchivePhView` and `ClearThisPageView`, placed in its own `ToolbarItemGroup` before the existing refresh and share groups.
- Pass the originating `Article` through `ArticleDestinationView` so the viewers can read and toggle the bookmark state.

## Test plan
- [ ] Open a feed configured to use Archive.md; verify the bookmark icon appears before the refresh and share buttons in the top trailing toolbar and toggles between filled and outline states on tap.
- [ ] Open a feed configured to use Clear This Page; verify the same bookmark behavior.
- [ ] Confirm bookmark state persists by returning to the bookmarks list.

https://claude.ai/code/session_011CnEznhkWXk7ArXN6HqfM9

---
_Generated by [Claude Code](https://claude.ai/code/session_011CnEznhkWXk7ArXN6HqfM9)_