### PR TITLE
Move zoom transition toggle to its own Navigation section

### DIFF
--- a/SakuraRSS/Views/More/Settings/AppearanceSettingsView.swift
+++ b/SakuraRSS/Views/More/Settings/AppearanceSettingsView.swift
@@ -29,6 +29,11 @@ struct AppearanceSettingsView: View {
             Section {
                 Toggle(String(localized: "ZoomTransition", table: "Settings"),
                        isOn: $zoomTransitionEnabled)
+            } header: {
+                Text(String(localized: "Section.Navigation", table: "Settings"))
+            }
+
+            Section {
                 Picker(selection: $markAllReadPosition) {
                     Text(String(localized: "MarkAllReadPosition.Bottom", table: "Settings"))
                         .tag(MarkAllReadPosition.bottom)

--- a/Shared/Strings/Settings.xcstrings
+++ b/Shared/Strings/Settings.xcstrings
@@ -6136,6 +6136,65 @@
           }
         }
       }
+    },
+    "Section.Navigation": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Navigation"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Navigation"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Navigation"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Navigazione"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ナビゲーション"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "내비게이션"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Điều hướng"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "导航"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "導覽"
+          }
+        }
+      }
     }
   },
   "version": "1.1"


### PR DESCRIPTION
## Summary
- Splits the Customization section in Appearance settings so the zoom transition toggle now lives under a dedicated Navigation header
- Adds the new `Section.Navigation` localization key for all supported languages (de, en, fr, it, ja, ko, vi, zh-Hans, zh-Hant)

## Test plan
- [ ] Open Settings → Appearance and confirm the Zoom Transition toggle appears under a "Navigation" section heading, separate from "Customization"
- [ ] Toggle still drives `Display.ZoomTransition` correctly
- [ ] Spot-check at least one non-English locale to confirm the new section header is localized

---
_Generated by [Claude Code](https://claude.ai/code/session_011x7BTxK1gJFJTe2UqPcnyP)_