### PR TITLE
Fix excessive image height in X embed blocks

### DIFF
--- a/SakuraRSS/Views/Shared/Article Detail/XEmbedBlockView.swift
+++ b/SakuraRSS/Views/Shared/Article Detail/XEmbedBlockView.swift
@@ -8,6 +8,8 @@ struct XEmbedBlockView: View {
     @State private var tweet: ParsedTweet?
     @State private var isLoading = false
     @State private var loadFailed = false
+    @State private var imageAspectRatio: CGFloat?
+    @State private var imageSize: CGSize?
 
     private var tweetID: String? {
         XProfileScraper.extractTweetID(from: url)
@@ -42,13 +44,17 @@ struct XEmbedBlockView: View {
                     .textSelection(.enabled)
 
                 if let imageURL = tweet.imageURL, let url = URL(string: imageURL) {
-                    CachedAsyncImage(url: url) {
+                    CachedAsyncImage(url: url, onImageLoaded: { image in
+                        imageAspectRatio = image.size.width / image.size.height
+                        imageSize = image.size
+                    }, placeholder: {
                         Rectangle()
                             .fill(.secondary.opacity(0.1))
-                            .frame(height: 160)
-                    }
-                    .aspectRatio(contentMode: .fit)
+                    })
+                    .aspectRatio(imageAspectRatio ?? (16.0 / 9.0), contentMode: .fit)
+                    .frame(maxWidth: imageSize?.width)
                     .clipShape(RoundedRectangle(cornerRadius: 8))
+                    .frame(maxWidth: .infinity, alignment: .center)
                 }
             } else if isLoading {
                 HStack(spacing: 8) {


### PR DESCRIPTION
## Summary

Fixes the bug where images inside X (Twitter) embed blocks render with excessive height — the image area stretches and fills most of the screen with empty black space (see screenshot in the linked issue).

## Root cause

`XEmbedBlockView` rendered the tweet image with:

```swift
CachedAsyncImage(url: url) { ... }
    .aspectRatio(contentMode: .fit)
```

`CachedAsyncImage` internally uses a greedy `Color.clear` to host the image, so it has no intrinsic aspect ratio. Calling `.aspectRatio(contentMode: .fit)` without a numeric value therefore does not constrain the view, and it expands to fill all available height in the surrounding card.

## Fix

Mirror the existing `FitWidthImage` pattern used in `ArticleDetailView`:

- Capture the loaded image's actual size via the `onImageLoaded` callback.
- Apply the captured ratio numerically with `.aspectRatio(imageAspectRatio ?? (16.0 / 9.0), contentMode: .fit)`.
- Constrain `maxWidth` to the image's natural width so small images don't get scaled up.

While the image is loading, the placeholder now uses a 16:9 ratio rather than the previous fixed 160pt height, matching the loaded-image behavior.

## Test plan

- [ ] Open an article that contains an X embed (with the `Labs.XProfileFeeds` toggle enabled and an active X session).
- [ ] Confirm the embedded tweet's image renders at its natural aspect ratio with no excessive empty space.
- [ ] Confirm the placeholder during loading sits at a reasonable 16:9 height instead of expanding.
- [ ] Verify embeds without an image still render correctly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NYeV2y1moa78dWoYwmJmuS)_