### PR TITLE
Fix home section going empty during refresh in Doomscroll Mode

### DIFF
--- a/SakuraRSS/Views/Shared/Articles/ArticleVisibilityTracker.swift
+++ b/SakuraRSS/Views/Shared/Articles/ArticleVisibilityTracker.swift
@@ -17,23 +17,33 @@ struct ArticleVisibilityTracker {
     /// the refresh land with IDs above this (sqlite autoincrement); pre-existing
     /// articles surfaced by load-more sit at or below it.
     private var preRefreshMaxID: Int64 = .max
+    /// Pre-refresh article snapshot, kept so count-based queries don't go empty
+    /// when newly inserted articles push the originals out of the top-N window.
+    private var preRefreshSnapshot: [Article] = []
     private var activeRefreshCount: Int = 0
 
     var hasPendingRefresh: Bool { !pendingIDs.isEmpty }
 
     func filter(_ articles: [Article], isEnabled: Bool) -> [Article] {
         var result = articles
+        // Hide arrivals that land before `endRefresh` moves them to `pendingIDs`.
+        // Pre-existing articles (id <= preRefreshMaxID) pass through so load-more
+        // during a refresh still surfaces older content. The snapshot is unioned
+        // back in so count-based queries (e.g. Doomscroll's items25) don't go
+        // empty when new arrivals take over the top-N.
+        if activeRefreshCount > 0 {
+            let liveIDs = Set(result.map(\.id))
+            for snapshot in preRefreshSnapshot where !liveIDs.contains(snapshot.id) {
+                result.append(snapshot)
+            }
+            result = result.filter { $0.id <= preRefreshMaxID }
+            result.sort { ($0.publishedDate ?? .distantPast) > ($1.publishedDate ?? .distantPast) }
+        }
         if isEnabled, let visibleIDs {
             result = result.filter { visibleIDs.contains($0.id) }
         }
         if !pendingIDs.isEmpty {
             result = result.filter { !pendingIDs.contains($0.id) }
-        }
-        // Hide arrivals that land before `endRefresh` moves them to `pendingIDs`.
-        // Pre-existing articles (id <= preRefreshMaxID) pass through so load-more
-        // during a refresh still surfaces older content.
-        if activeRefreshCount > 0 {
-            result = result.filter { $0.id <= preRefreshMaxID }
         }
         return result
     }
@@ -70,6 +80,7 @@ struct ArticleVisibilityTracker {
     mutating func beginRefresh(from articles: [Article], isEnabled: Bool) {
         if activeRefreshCount == 0 {
             hasReachedEnd = false
+            preRefreshSnapshot = articles
             preRefreshIDs = Set(articles.map(\.id)).union(visibleIDs ?? []).union(pendingIDs)
             preRefreshMaxID = preRefreshIDs.max() ?? .max
             if isEnabled {
@@ -94,6 +105,7 @@ struct ArticleVisibilityTracker {
         if activeRefreshCount == 0 {
             preRefreshIDs = []
             preRefreshMaxID = .max
+            preRefreshSnapshot = []
         }
     }
 


### PR DESCRIPTION
## Summary

- The home/list/feed/all-articles views were going empty whenever a refresh ran while a count-based batching mode was active (Doomscroll Mode forces `items25`). The list reappeared after the refresh finished.
- Root cause: `ArticleVisibilityTracker.filter` hid in-flight arrivals via `id <= preRefreshMaxID`. That works while `rawArticles` still contains the originals, but a count-based DB query (`articles(for: section, limit: 25)`) returns the top-N by `publishedDate`. New inserts with newer dates and higher autoincrement IDs take over the top-N, every survivor fails the `id <= preRefreshMaxID` predicate, and the list goes empty mid-refresh. Date-based modes weren't affected because their query has no count cap, so the originals always stayed in the result set.
- Fix: snapshot the pre-refresh articles inside the tracker at `beginRefresh`, then in `filter` union them back into the live results during an active refresh before applying the existing predicate. New arrivals are still hidden until the user accepts the refresh prompt; the originals stay on screen even when a count-limited query loses them. Snapshot is cleared in `endRefresh` once `activeRefreshCount` reaches zero.

## Test plan

- [ ] Enable Doomscroll Mode, reopen the app, confirm the home list does not flicker empty during the initial refresh.
- [ ] Toggle Doomscroll off and pick `items25`/`items50`/`items100` manually; pull-to-refresh — list stays populated, refresh prompt appears with the new count.
- [ ] Pick `day1`/`day3`/`week1` (date-based); pull-to-refresh — behavior unchanged.
- [ ] Use load-more during an in-flight refresh; older content surfaces as before, new arrivals stay hidden until the prompt is tapped.
- [ ] Tap the refresh prompt; new articles slot in at the top.
- [ ] Same checks on `AllArticlesView`, `ListSectionView`, and `FeedArticlesView`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sm4obvzARN1E4Xmo9ZwUjf)_