### PR TITLE
Fix empty social and video section feeds

### DIFF
--- a/SakuraRSS/Classes/Feed Manager/FeedManager+Batching.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+Batching.swift
@@ -66,7 +66,20 @@ extension FeedManager {
             .filter { $0.feedSection == section && !muted.contains($0.id) }
             .map(\.id)
         guard !sectionFeedIDs.isEmpty else { return [] }
-        let fetchLimit = max(limit * 4, 100)
+        var fetchLimit = max(limit * 4, 100)
+        let maxIterations = 20
+        for _ in 0..<maxIterations {
+            let raw = (try? database.articles(
+                forFeedIDs: sectionFeedIDs,
+                limit: fetchLimit,
+                requireUnread: requireUnread
+            )) ?? []
+            let pool = applyAllRules(raw)
+            if pool.count >= limit || raw.count < fetchLimit {
+                return Array(pool.prefix(limit))
+            }
+            fetchLimit *= 2
+        }
         let raw = (try? database.articles(
             forFeedIDs: sectionFeedIDs,
             limit: fetchLimit,

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+Batching.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+Batching.swift
@@ -60,30 +60,41 @@ extension FeedManager {
     // MARK: - Count-based Batches (Section)
 
     func articles(for section: FeedSection, limit: Int, requireUnread: Bool = false) -> [Article] {
-        let sectionFeedIDs = Set(feeds.filter { $0.feedSection == section }.map(\.id))
+        _ = dataRevision
+        let muted = mutedFeedIDs
+        let sectionFeedIDs = feeds
+            .filter { $0.feedSection == section && !muted.contains($0.id) }
+            .map(\.id)
         guard !sectionFeedIDs.isEmpty else { return [] }
         if !requireUnread {
-            return Array(articles(limit: limit * 3).filter { sectionFeedIDs.contains($0.feedID) }.prefix(limit))
+            let fetchLimit = max(limit * 4, 100)
+            let raw = (try? database.articles(forFeedIDs: sectionFeedIDs, limit: fetchLimit)) ?? []
+            return Array(applyAllRules(raw).prefix(limit))
         }
-        var multiplier = 3
+        var fetchLimit = max(limit * 4, 100)
         let maxIterations = 20
         for _ in 0..<maxIterations {
-            let pool = articles(limit: limit * multiplier)
-            let filtered = pool.filter { sectionFeedIDs.contains($0.feedID) && !$0.isRead }
-            if filtered.count >= limit || pool.count < limit * multiplier {
-                return Array(filtered.prefix(limit))
+            let raw = (try? database.articles(forFeedIDs: sectionFeedIDs, limit: fetchLimit)) ?? []
+            let pool = applyAllRules(raw)
+            let unread = pool.filter { !$0.isRead }
+            if unread.count >= limit || raw.count < fetchLimit {
+                return Array(unread.prefix(limit))
             }
-            multiplier *= 2
+            fetchLimit *= 2
         }
-        let pool = articles(limit: limit * multiplier)
-        return Array(pool.filter { sectionFeedIDs.contains($0.feedID) && !$0.isRead }.prefix(limit))
+        let raw = (try? database.articles(forFeedIDs: sectionFeedIDs, limit: fetchLimit)) ?? []
+        return Array(applyAllRules(raw).filter { !$0.isRead }.prefix(limit))
     }
 
     func hasMoreArticles(for section: FeedSection, beyond count: Int) -> Bool {
-        let sectionFeedIDs = Set(feeds.filter { $0.feedSection == section }.map(\.id))
+        _ = dataRevision
+        let muted = mutedFeedIDs
+        let sectionFeedIDs = feeds
+            .filter { $0.feedSection == section && !muted.contains($0.id) }
+            .map(\.id)
         guard !sectionFeedIDs.isEmpty else { return false }
-        let filtered = articles(limit: (count + 1) * 3).filter { sectionFeedIDs.contains($0.feedID) }
-        return filtered.count > count
+        let raw = (try? database.articles(forFeedIDs: sectionFeedIDs, limit: count + 1)) ?? []
+        return applyAllRules(raw).count > count
     }
 
     func nextLoadedCount(for section: FeedSection, after count: Int, batchSize: Int, requireUnread: Bool = false) -> Int? {

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+Batching.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+Batching.swift
@@ -66,24 +66,13 @@ extension FeedManager {
             .filter { $0.feedSection == section && !muted.contains($0.id) }
             .map(\.id)
         guard !sectionFeedIDs.isEmpty else { return [] }
-        if !requireUnread {
-            let fetchLimit = max(limit * 4, 100)
-            let raw = (try? database.articles(forFeedIDs: sectionFeedIDs, limit: fetchLimit)) ?? []
-            return Array(applyAllRules(raw).prefix(limit))
-        }
-        var fetchLimit = max(limit * 4, 100)
-        let maxIterations = 20
-        for _ in 0..<maxIterations {
-            let raw = (try? database.articles(forFeedIDs: sectionFeedIDs, limit: fetchLimit)) ?? []
-            let pool = applyAllRules(raw)
-            let unread = pool.filter { !$0.isRead }
-            if unread.count >= limit || raw.count < fetchLimit {
-                return Array(unread.prefix(limit))
-            }
-            fetchLimit *= 2
-        }
-        let raw = (try? database.articles(forFeedIDs: sectionFeedIDs, limit: fetchLimit)) ?? []
-        return Array(applyAllRules(raw).filter { !$0.isRead }.prefix(limit))
+        let fetchLimit = max(limit * 4, 100)
+        let raw = (try? database.articles(
+            forFeedIDs: sectionFeedIDs,
+            limit: fetchLimit,
+            requireUnread: requireUnread
+        )) ?? []
+        return Array(applyAllRules(raw).prefix(limit))
     }
 
     func hasMoreArticles(for section: FeedSection, beyond count: Int) -> Bool {

--- a/Shared/Database Manager/Articles/DatabaseManager+ArticlesQueries.swift
+++ b/Shared/Database Manager/Articles/DatabaseManager+ArticlesQueries.swift
@@ -13,13 +13,15 @@ nonisolated extension DatabaseManager {
     }
 
     /// Returns articles for a set of feed IDs ordered by published date descending.
-    func articles(forFeedIDs feedIDs: [Int64], limit: Int) throws -> [Article] {
+    func articles(forFeedIDs feedIDs: [Int64], limit: Int, requireUnread: Bool = false) throws -> [Article] {
         guard !feedIDs.isEmpty else { return [] }
-        let query = articles
-            .filter(feedIDs.contains(articleFeedID))
-            .order(articlePublishedDate.desc)
-            .limit(limit)
-        return try database.prepare(query).map(rowToArticle)
+        var query = articles.filter(feedIDs.contains(articleFeedID))
+        if requireUnread {
+            query = query.filter(articleIsRead == false)
+        }
+        return try database
+            .prepare(query.order(articlePublishedDate.desc).limit(limit))
+            .map(rowToArticle)
     }
 
     func article(byID id: Int64) throws -> Article? {


### PR DESCRIPTION
## Summary
- Section count-based queries (`articles(for: section, limit:, requireUnread:)`) used to pull the global top-N articles and post-filter by section feed IDs. With high-volume feeds dominating the global recency window, low-volume sections like Instagram, Mastodon, Vimeo, or Niconico could end up empty even though unread articles existed.
- Now query the database directly via `articles(forFeedIDs:limit:)` so the SQL `LIMIT` applies after section filtering. The unread-doubling loop and rule application are preserved, mirroring the all-feeds `articles(limit:requireUnread:)` style. `hasMoreArticles(for: section, beyond:)` updated to match.
- Muted feeds are now excluded at the feed-ID level before querying, removing one source of post-filter loss.

## Test plan
- [ ] Open a section with low article volume (e.g. Instagram) and confirm articles appear instead of the "何もありません" empty state.
- [ ] Toggle Hide Viewed Content on/off and confirm the section feed still loads.
- [ ] Switch between sections (Instagram, Mastodon, YouTube, etc.) and confirm each shows its own articles.
- [ ] Pull-to-refresh and load more in a section feed; verify pagination still progresses.
- [ ] Mute a feed inside a section and confirm its articles are excluded.

https://claude.ai/code/session_01JmgnV53uNXb8dLLnAwLu9h

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmgnV53uNXb8dLLnAwLu9h)_