### PR TITLE
Fan out article viewer toolbar on iPad

### DIFF
--- a/SakuraRSS/Views/Shared/Article Detail/ArticleDetailView+Actions.swift
+++ b/SakuraRSS/Views/Shared/Article Detail/ArticleDetailView+Actions.swift
@@ -169,7 +169,7 @@ extension ArticleDetailView: ArticleActions {
         }
     }
 
-    private func displayHost(_ host: String) -> String {
+    func displayHost(_ host: String) -> String {
         host.hasPrefix("www.") ? String(host.dropFirst(4)) : host
     }
 
@@ -199,7 +199,7 @@ extension ArticleDetailView: ArticleActions {
         arXivPDFReference = ArXivPDFReference(url: pdfURL, title: article.title)
     }
 
-    private var translateLabel: String {
+    var translateLabel: String {
         if showingSummary {
             return String(localized: "Article.TranslateSummary", table: "Articles")
         }
@@ -209,7 +209,7 @@ extension ArticleDetailView: ArticleActions {
         return String(localized: "Article.Translate", table: "Articles")
     }
 
-    private var summarizeLabel: String {
+    var summarizeLabel: String {
         if showingTranslation {
             return String(localized: "Article.SummarizeTranslation", table: "Articles")
         }
@@ -220,7 +220,7 @@ extension ArticleDetailView: ArticleActions {
         return String(localized: "Article.Summarize", table: "Articles")
     }
 
-    private func handleToolbarTranslateTap() {
+    func handleToolbarTranslateTap() {
         if hasTranslationForCurrentMode && !isTranslating {
             withAnimation(.smooth.speed(2.0)) {
                 showingTranslation.toggle()
@@ -230,7 +230,7 @@ extension ArticleDetailView: ArticleActions {
         }
     }
 
-    private func handleToolbarSummarizeTap() {
+    func handleToolbarSummarizeTap() {
         let hasAvailableSummary = (summarizedText != nil || hasCachedSummary) && !isSummarizing
         if hasAvailableSummary && summarizedText != nil {
             withAnimation(.smooth.speed(2.0)) {

--- a/SakuraRSS/Views/Shared/Article Detail/ArticleDetailView+Toolbar.swift
+++ b/SakuraRSS/Views/Shared/Article Detail/ArticleDetailView+Toolbar.swift
@@ -3,18 +3,23 @@ import SwiftUI
 
 extension ArticleDetailView {
 
+    @ToolbarContentBuilder
     var articleToolbar: some ToolbarContent {
-        ToolbarItemGroup(placement: .topBarTrailing) {
-            articleOpenToolbarItems
-            if !article.isEphemeral {
-                Button {
-                    isBookmarked.toggle()
-                    feedManager.toggleBookmark(article)
-                } label: {
-                    Image(systemName: isBookmarked ? "bookmark.fill" : "bookmark")
+        if UIDevice.current.userInterfaceIdiom == .pad {
+            iPadArticleToolbar
+        } else {
+            ToolbarItemGroup(placement: .topBarTrailing) {
+                articleOpenToolbarItems
+                if !article.isEphemeral {
+                    Button {
+                        isBookmarked.toggle()
+                        feedManager.toggleBookmark(article)
+                    } label: {
+                        Image(systemName: isBookmarked ? "bookmark.fill" : "bookmark")
+                    }
                 }
+                articleOverflowMenu
             }
-            articleOverflowMenu
         }
     }
 

--- a/SakuraRSS/Views/Shared/Article Detail/ArticleDetailView+iPadToolbar.swift
+++ b/SakuraRSS/Views/Shared/Article Detail/ArticleDetailView+iPadToolbar.swift
@@ -1,0 +1,152 @@
+import SwiftUI
+
+extension ArticleDetailView {
+
+    @ToolbarContentBuilder
+    var iPadArticleToolbar: some ToolbarContent {
+        if hasIPadIntelligenceActions {
+            ToolbarItemGroup(placement: .topBarTrailing) {
+                iPadIntelligenceActions
+            }
+            ToolbarSpacer(.fixed, placement: .topBarTrailing)
+        }
+        if hasIPadOpenActions {
+            ToolbarItemGroup(placement: .topBarTrailing) {
+                iPadOpenActions
+            }
+            ToolbarSpacer(.fixed, placement: .topBarTrailing)
+        }
+        ToolbarItemGroup(placement: .topBarTrailing) {
+            iPadShareActions
+        }
+    }
+
+    private var hasIPadIntelligenceActions: Bool {
+        !isExtracting && displayText != nil
+    }
+
+    private var hasIPadOpenActions: Bool {
+        includesOpenInAppAction || includesArXivAction || includesOpenLinkAction
+    }
+
+    @ViewBuilder
+    private var iPadIntelligenceActions: some View {
+        if showingTranslation {
+            Button {
+                withAnimation(.smooth.speed(2.0)) {
+                    showingTranslation = false
+                }
+            } label: {
+                Label(showingSummary
+                      ? String(localized: "Article.ShowOriginalTranslation", table: "Articles")
+                      : String(localized: "Article.ShowOriginal", table: "Articles"),
+                      systemImage: "arrow.uturn.backward")
+            }
+        } else {
+            Button {
+                handleToolbarTranslateTap()
+            } label: {
+                Label(translateLabel, systemImage: "translate")
+            }
+            .disabled(isTranslating)
+        }
+
+        if isAppleIntelligenceAvailable {
+            if showingSummary {
+                Button {
+                    withAnimation(.smooth.speed(2.0)) {
+                        showingSummary = false
+                    }
+                } label: {
+                    Label(showingTranslation
+                          ? String(localized: "Article.ShowOriginalSummary", table: "Articles")
+                          : String(localized: "Article.ShowOriginal", table: "Articles"),
+                          systemImage: "arrow.uturn.backward")
+                }
+            } else {
+                Button {
+                    handleToolbarSummarizeTap()
+                } label: {
+                    Label(summarizeLabel, systemImage: "text.line.3.summary")
+                }
+                .disabled(isSummarizing)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var iPadOpenActions: some View {
+        if includesOpenInAppAction {
+            Button {
+                performOpenInApp()
+            } label: {
+                Label(String(localized: "OpenInApp", table: "Articles"),
+                      systemImage: "play.rectangle")
+            }
+        }
+        if includesArXivAction {
+            Button {
+                performOpenArXivPDF()
+            } label: {
+                Label(String(localized: "ArXiv.ViewPDF", table: "Integrations"),
+                      systemImage: "doc.richtext")
+            }
+        }
+        if includesOpenLinkAction {
+            iPadOpenInBrowserItem
+        }
+    }
+
+    @ViewBuilder
+    private var iPadOpenInBrowserItem: some View {
+        if let linkedURL = linkedArticleURL,
+           let articleURL = URL(string: article.url),
+           let articleHost = articleURL.host?.lowercased(),
+           let linkedHost = linkedURL.host?.lowercased(),
+           articleHost != linkedHost {
+            Menu {
+                Button {
+                    openURL(articleURL)
+                } label: {
+                    Label(displayHost(articleHost), systemImage: "safari")
+                }
+                Button {
+                    openURL(linkedURL)
+                } label: {
+                    Label(displayHost(linkedHost), systemImage: "safari")
+                }
+            } label: {
+                Label(String(localized: "Article.OpenInBrowser", table: "Articles"),
+                      systemImage: "safari")
+            }
+        } else {
+            Button {
+                performOpenInBrowser()
+            } label: {
+                Label(String(localized: "Article.OpenInBrowser", table: "Articles"),
+                      systemImage: "safari")
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var iPadShareActions: some View {
+        if !article.isEphemeral {
+            Button {
+                isBookmarked.toggle()
+                feedManager.toggleBookmark(article)
+            } label: {
+                Label(isBookmarked
+                      ? String(localized: "Article.RemoveBookmark", table: "Articles")
+                      : String(localized: "Article.Bookmark", table: "Articles"),
+                      systemImage: isBookmarked ? "bookmark.fill" : "bookmark")
+            }
+        }
+        if let shareURL = URL(string: article.url) {
+            ShareLink(item: shareURL) {
+                Label(String(localized: "Article.Share", table: "Articles"),
+                      systemImage: "square.and.arrow.up")
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

On iPadOS, the article viewer's top trailing toolbar now fans out instead of hiding actions in the ellipsis overflow menu. The iPhone layout is unchanged.

The new iPad layout uses three groups separated by `ToolbarSpacer`:

- **Translate, Summarize** – mirrors the menu's intelligence actions; tapping the active item reverts to the original.
- **Open in App, Open PDF, Open in Browser** – each is conditionally shown when applicable; the browser entry becomes a `Menu` when the article has both an aggregator host and a linked article host.
- **Bookmark, Share** – bookmark is hidden for ephemeral content as before.

Implementation notes:

- `articleToolbar` now dispatches based on `UIDevice.current.userInterfaceIdiom`.
- iPad-specific toolbar content lives in a new `ArticleDetailView+iPadToolbar.swift` so the existing files stay small.
- A few helpers in `ArticleDetailView+Actions.swift` (`translateLabel`, `summarizeLabel`, `handleToolbarTranslateTap`, `handleToolbarSummarizeTap`, `displayHost`) are now non-private so the iPad toolbar can reuse them.
- All labels reuse existing localized strings (`Article.Translate`, `Article.Summarize`, `OpenInApp`, `ArXiv.ViewPDF`, `Article.OpenInBrowser`, `Article.Bookmark` / `Article.RemoveBookmark`, `Article.Share`, plus the `Article.ShowOriginal*` reverts), so no `xcstrings` changes are needed.

## Test plan

- [ ] On iPad, open an article and confirm Translate, Summarize, Open in App (YouTube), Open PDF (arXiv), Open in Browser, Bookmark, and Share fan out across the top trailing toolbar with spacers between the three groups.
- [ ] Tap Translate / Summarize and verify they swap to the revert state and back.
- [ ] Open an article from a Reddit or HN-style aggregator and confirm Open in Browser becomes a menu with both hosts.
- [ ] Open an ephemeral article (`sakura://open` extension) and confirm the bookmark button is hidden.
- [ ] On iPhone, confirm the toolbar still uses the existing ellipsis overflow menu unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J4e2wugqLyR5fkXYFamRye)_