### PR TITLE
Preload article IDs per scope before applying batching

### DIFF
--- a/Feeds/ArticleIDBatcher.swift
+++ b/Feeds/ArticleIDBatcher.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// Slices a preloaded list of `ArticleIDEntry` values into the visible window
+/// described by the user's `BatchingMode`. Decoupling the preload (full ID list)
+/// from the presentation (batched slice) keeps "load more" O(1) and avoids
+/// re-querying the database every time the limit grows.
+nonisolated struct ArticleIDBatcher: Sendable {
+    let entries: [ArticleIDEntry]
+
+    /// Count-based slice: first `limit` IDs in published-date order.
+    func ids(limit: Int) -> [Int64] {
+        guard limit > 0 else { return [] }
+        return entries.prefix(limit).map(\.id)
+    }
+
+    /// Date-based slice: every entry whose published date is on or after `date`.
+    /// Undated entries are intentionally excluded; views surface those via a
+    /// dedicated undated query.
+    func ids(since date: Date) -> [Int64] {
+        entries
+            .filter { ($0.publishedDate ?? .distantPast) >= date }
+            .map(\.id)
+    }
+
+    /// Next visible count, or `nil` if there is nothing more to reveal.
+    func nextLoadedCount(after count: Int, batchSize: Int) -> Int? {
+        guard entries.count > count else { return nil }
+        return min(count + batchSize, entries.count)
+    }
+
+    /// Walks backwards in `chunkDays` windows until a window with at least one
+    /// preloaded entry is found, returning that window's start date.
+    func nextChunkStart(before date: Date, chunkDays days: Int) -> Date? {
+        guard days > 0 else { return nil }
+        let calendar = Calendar.current
+        var cursor = date
+        var iterations = 0
+        let maxIterations = 365 * 2
+        while iterations < maxIterations {
+            iterations += 1
+            guard let newStart = calendar.date(byAdding: .day, value: -days, to: cursor) else {
+                return nil
+            }
+            let hasOlder = entries.contains { entry in
+                guard let published = entry.publishedDate else { return false }
+                return published < cursor
+            }
+            guard hasOlder else { return nil }
+            let inWindow = entries.contains { entry in
+                guard let published = entry.publishedDate else { return false }
+                return published >= newStart && published < cursor
+            }
+            if inWindow { return newStart }
+            cursor = newStart
+        }
+        return nil
+    }
+}

--- a/Feeds/ArticleIDEntry.swift
+++ b/Feeds/ArticleIDEntry.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+/// Lightweight (id, publishedDate) pair preloaded for a feed/section/list before
+/// the user's batching settings carve out a visible slice.
+nonisolated struct ArticleIDEntry: Hashable, Sendable {
+    let id: Int64
+    let publishedDate: Date?
+}

--- a/SakuraRSS/Classes/Feed Manager/FeedManager+Preload.swift
+++ b/SakuraRSS/Classes/Feed Manager/FeedManager+Preload.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+/// Preloads the full ordered list of dated article IDs for a given scope so
+/// views can apply the user's batching mode by slicing instead of repeatedly
+/// re-querying the database with growing limits.
+extension FeedManager {
+
+    // MARK: - All Articles
+
+    func preloadedArticleEntries(requireUnread: Bool = false) -> [ArticleIDEntry] {
+        _ = dataRevision
+        let muted = mutedFeedIDs
+        let raw = (try? database.allArticles(limit: Int.max)) ?? []
+        var pool = applyAllRules(raw)
+        if !muted.isEmpty {
+            pool = pool.filter { !muted.contains($0.feedID) }
+        }
+        if requireUnread {
+            pool = pool.filter { !$0.isRead }
+        }
+        return pool.compactMap { article in
+            guard let date = article.publishedDate else { return nil }
+            return ArticleIDEntry(id: article.id, publishedDate: date)
+        }
+    }
+
+    // MARK: - Feed
+
+    func preloadedArticleEntries(for feed: Feed, requireUnread: Bool = false) -> [ArticleIDEntry] {
+        _ = dataRevision
+        let raw = (try? database.articles(forFeedID: feed.id)) ?? []
+        var pool = applyRules(raw, feedID: feed.id)
+        if requireUnread {
+            pool = pool.filter { !$0.isRead }
+        }
+        return pool.compactMap { article in
+            guard let date = article.publishedDate else { return nil }
+            return ArticleIDEntry(id: article.id, publishedDate: date)
+        }
+    }
+
+    // MARK: - Section
+
+    func preloadedArticleEntries(for section: FeedSection, requireUnread: Bool = false) -> [ArticleIDEntry] {
+        _ = dataRevision
+        let muted = mutedFeedIDs
+        let sectionFeedIDs = feeds
+            .filter { $0.feedSection == section && !muted.contains($0.id) }
+            .map(\.id)
+        guard !sectionFeedIDs.isEmpty else { return [] }
+        let raw = (try? database.articles(
+            forFeedIDs: sectionFeedIDs,
+            limit: Int.max,
+            requireUnread: requireUnread
+        )) ?? []
+        return applyAllRules(raw).compactMap { article in
+            guard let date = article.publishedDate else { return nil }
+            return ArticleIDEntry(id: article.id, publishedDate: date)
+        }
+    }
+
+    // MARK: - List
+
+    func preloadedArticleEntries(for list: FeedList, requireUnread: Bool = false) -> [ArticleIDEntry] {
+        _ = dataRevision
+        let muted = mutedFeedIDs
+        let allowedFeedIDs = feedIDs(for: list).subtracting(muted)
+        guard !allowedFeedIDs.isEmpty else { return [] }
+        let raw = (try? database.articles(
+            forFeedIDs: Array(allowedFeedIDs),
+            limit: Int.max,
+            requireUnread: requireUnread
+        )) ?? []
+        let listed = applyListRules(applyAllRules(raw), listID: list.id)
+        return listed.compactMap { article in
+            guard let date = article.publishedDate else { return nil }
+            return ArticleIDEntry(id: article.id, publishedDate: date)
+        }
+    }
+
+    // MARK: - Materialization
+
+    /// Materializes articles for the given preloaded IDs, preserving the
+    /// preloaded order (which already reflects rule and mute filtering).
+    func articles(withPreloadedIDs ids: [Int64]) -> [Article] {
+        guard !ids.isEmpty else { return [] }
+        _ = dataRevision
+        let fetched = (try? database.articles(withIDs: ids)) ?? []
+        let byID = Dictionary(uniqueKeysWithValues: fetched.map { ($0.id, $0) })
+        return ids.compactMap { byID[$0] }
+    }
+}

--- a/SakuraRSS/Views/Feeds/FeedArticlesView.swift
+++ b/SakuraRSS/Views/Feeds/FeedArticlesView.swift
@@ -10,6 +10,7 @@ struct FeedArticlesView: View {
     @State private var loadedSinceDate: Date = Date(timeIntervalSince1970: 0)
     @State private var loadedCount: Int = BatchingMode.current().initialCount()
     @State private var hasInitializedSinceDate = false
+    @State private var preloadedEntries: [ArticleIDEntry] = []
     @AppStorage("Instagram.HideReels") private var hideReels: Bool = false
     @AppStorage("Articles.HideViewedContent") private var storedHideViewedContent: Bool = false
     @State private var visibility = ArticleVisibilityTracker()
@@ -27,26 +28,21 @@ struct FeedArticlesView: View {
         feedManager.feeds.first(where: { $0.id == feed.id }) ?? feed
     }
 
+    private var batcher: ArticleIDBatcher {
+        ArticleIDBatcher(entries: preloadedEntries)
+    }
+
     private var loadMoreAction: (() -> Void)? {
         if hideViewedContent && visibility.hasReachedEnd { return nil }
+        let batcher = self.batcher
         if let days = batchingMode.chunkDays {
-            guard let next = feedManager.nextArticleChunk(
-                for: feed,
-                before: loadedSinceDate,
-                chunkDays: days,
-                requireUnread: hideViewedContent
-            ) else {
+            guard let next = batcher.nextChunkStart(before: loadedSinceDate, chunkDays: days) else {
                 return nil
             }
             return { loadedSinceDate = next }
         }
         if let batch = batchingMode.batchSize {
-            guard let next = feedManager.nextLoadedCount(
-                for: feed,
-                after: loadedCount,
-                batchSize: batch,
-                requireUnread: hideViewedContent
-            ) else {
+            guard let next = batcher.nextLoadedCount(after: loadedCount, batchSize: batch) else {
                 return nil
             }
             return { loadedCount = next }
@@ -55,22 +51,28 @@ struct FeedArticlesView: View {
     }
 
     private var rawArticles: [Article] {
-        var articles: [Article]
+        let batcher = self.batcher
+        let slicedIDs: [Int64]
         if batchingMode.isCountBased {
-            articles = feedManager.undatedArticles(for: feed)
-                + feedManager.articles(
-                    for: feed,
-                    limit: loadedCount,
-                    requireUnread: hideViewedContent
-                )
+            slicedIDs = batcher.ids(limit: loadedCount)
+        } else if batchingMode.isDateBased {
+            slicedIDs = batcher.ids(since: loadedSinceDate)
         } else {
-            articles = feedManager.undatedArticles(for: feed)
-                + feedManager.articles(for: feed, since: loadedSinceDate)
+            slicedIDs = preloadedEntries.map(\.id)
         }
+        var articles = feedManager.undatedArticles(for: feed)
+            + feedManager.articles(withPreloadedIDs: slicedIDs)
         if hideReels && feed.isInstagramFeed {
             articles = articles.filter { !$0.url.contains("/reel/") }
         }
         return articles
+    }
+
+    private func reloadPreloadedEntries() {
+        preloadedEntries = feedManager.preloadedArticleEntries(
+            for: feed,
+            requireUnread: hideViewedContent
+        )
     }
 
     private func performRefresh() async {
@@ -147,12 +149,19 @@ struct FeedArticlesView: View {
             print("[FeedArticlesView] onAppear id=\(feed.id) title=\(feed.title) "
                   + "hasInitializedSinceDate=\(hasInitializedSinceDate)")
             #endif
+            reloadPreloadedEntries()
             if !hasInitializedSinceDate {
                 loadedSinceDate = batchingMode.initialSinceDate(
                     latestArticleDate: latestArticleDateForFeed()
                 )
                 hasInitializedSinceDate = true
             }
+        }
+        .onChange(of: feedManager.dataRevision) { _, _ in
+            reloadPreloadedEntries()
+        }
+        .onChange(of: hideViewedContent) { _, _ in
+            reloadPreloadedEntries()
         }
         .onChange(of: batchingMode) { _, newMode in
             loadedSinceDate = newMode.initialSinceDate(

--- a/SakuraRSS/Views/Feeds/FeedArticlesView.swift
+++ b/SakuraRSS/Views/Feeds/FeedArticlesView.swift
@@ -157,6 +157,14 @@ struct FeedArticlesView: View {
                 hasInitializedSinceDate = true
             }
         }
+        .onChange(of: feed.id) { _, _ in
+            reloadPreloadedEntries()
+            loadedSinceDate = batchingMode.initialSinceDate(
+                latestArticleDate: latestArticleDateForFeed()
+            )
+            loadedCount = batchingMode.initialCount()
+            visibility.capture(from: rawArticles, isEnabled: hideViewedContent)
+        }
         .onChange(of: feedManager.dataRevision) { _, _ in
             reloadPreloadedEntries()
         }

--- a/SakuraRSS/Views/Home/AllArticlesView.swift
+++ b/SakuraRSS/Views/Home/AllArticlesView.swift
@@ -126,6 +126,7 @@ struct AllArticlesView: View {
     @State private var loadedSinceDate: Date = Date(timeIntervalSince1970: 0)
     @State private var loadedCount: Int = BatchingMode.current().initialCount()
     @State private var hasInitializedSinceDate = false
+    @State private var preloadedEntries: [ArticleIDEntry] = []
     @AppStorage("WhileYouSlept.DismissedDate") private var whileYouSleptDismissedDate: String = ""
     @AppStorage("TodaysSummary.DismissedDate") private var todaysSummaryDismissedDate: String = ""
     @AppStorage("Instagram.HideReels") private var hideInstagramReels: Bool = false
@@ -154,20 +155,31 @@ struct AllArticlesView: View {
         || (todaysSummaryDismissedDate == todayDateKey && todaysSummaryAvailable)
     }
 
+    private var batcher: ArticleIDBatcher {
+        ArticleIDBatcher(entries: preloadedEntries)
+    }
+
     private var rawArticles: [Article] {
-        var articles: [Article]
+        let batcher = self.batcher
+        let slicedIDs: [Int64]
         if batchingMode.isCountBased {
-            articles = feedManager.articles(
-                limit: loadedCount,
-                requireUnread: hideViewedContent
-            )
+            slicedIDs = batcher.ids(limit: loadedCount)
+        } else if batchingMode.isDateBased {
+            slicedIDs = batcher.ids(since: loadedSinceDate)
         } else {
-            articles = feedManager.articles(since: loadedSinceDate)
+            slicedIDs = preloadedEntries.map(\.id)
         }
+        var articles = feedManager.articles(withPreloadedIDs: slicedIDs)
         if hideInstagramReels {
             articles = articles.filter { !$0.url.contains("/reel/") }
         }
         return articles
+    }
+
+    private func reloadPreloadedEntries() {
+        preloadedEntries = feedManager.preloadedArticleEntries(
+            requireUnread: hideViewedContent
+        )
     }
 
     private var displayedArticles: [Article] {
@@ -224,22 +236,15 @@ struct AllArticlesView: View {
 
     private var loadMoreAction: (() -> Void)? {
         if hideViewedContent && visibility.hasReachedEnd { return nil }
+        let batcher = self.batcher
         if let days = batchingMode.chunkDays {
-            guard let next = feedManager.nextArticleChunk(
-                before: loadedSinceDate,
-                chunkDays: days,
-                requireUnread: hideViewedContent
-            ) else {
+            guard let next = batcher.nextChunkStart(before: loadedSinceDate, chunkDays: days) else {
                 return nil
             }
             return { loadedSinceDate = next }
         }
         if let batch = batchingMode.batchSize {
-            guard let next = feedManager.nextLoadedCount(
-                after: loadedCount,
-                batchSize: batch,
-                requireUnread: hideViewedContent
-            ) else {
+            guard let next = batcher.nextLoadedCount(after: loadedCount, batchSize: batch) else {
                 return nil
             }
             return { loadedCount = next }
@@ -339,12 +344,19 @@ struct AllArticlesView: View {
             print("[AllArticlesView] onAppear selection=\(selectedSelection.rawValue) "
                   + "hasInitializedSinceDate=\(hasInitializedSinceDate)")
             #endif
+            reloadPreloadedEntries()
             if !hasInitializedSinceDate {
                 loadedSinceDate = batchingMode.initialSinceDate(
                     latestArticleDate: latestArticleDateAcrossFeeds()
                 )
                 hasInitializedSinceDate = true
             }
+        }
+        .onChange(of: feedManager.dataRevision) { _, _ in
+            reloadPreloadedEntries()
+        }
+        .onChange(of: hideViewedContent) { _, _ in
+            reloadPreloadedEntries()
         }
         .onChange(of: batchingMode) { _, newMode in
             loadedSinceDate = newMode.initialSinceDate(

--- a/SakuraRSS/Views/Home/HomeSectionView.swift
+++ b/SakuraRSS/Views/Home/HomeSectionView.swift
@@ -11,6 +11,7 @@ struct HomeSectionView: View {
     @State private var loadedSinceDate: Date = Date(timeIntervalSince1970: 0)
     @State private var loadedCount: Int = BatchingMode.current().initialCount()
     @State private var hasInitializedSinceDate = false
+    @State private var preloadedEntries: [ArticleIDEntry] = []
     @AppStorage("Instagram.HideReels") private var hideInstagramReels: Bool = false
     @AppStorage("Articles.HideViewedContent") private var storedHideViewedContent: Bool = false
     @State private var visibility = ArticleVisibilityTracker()
@@ -24,23 +25,33 @@ struct HomeSectionView: View {
         DoomscrollingMode.effectiveHideViewedContent(storedHideViewedContent)
     }
 
+    private var batcher: ArticleIDBatcher {
+        ArticleIDBatcher(entries: preloadedEntries)
+    }
+
     private var rawArticles: [Article] {
-        var articles: [Article]
+        let batcher = self.batcher
+        let slicedIDs: [Int64]
         if batchingMode.isCountBased {
-            articles = feedManager.undatedArticles(for: section)
-                + feedManager.articles(
-                    for: section,
-                    limit: loadedCount,
-                    requireUnread: hideViewedContent
-                )
+            slicedIDs = batcher.ids(limit: loadedCount)
+        } else if batchingMode.isDateBased {
+            slicedIDs = batcher.ids(since: loadedSinceDate)
         } else {
-            articles = feedManager.undatedArticles(for: section)
-                + feedManager.articles(for: section, since: loadedSinceDate)
+            slicedIDs = preloadedEntries.map(\.id)
         }
+        var articles = feedManager.undatedArticles(for: section)
+            + feedManager.articles(withPreloadedIDs: slicedIDs)
         if hideInstagramReels {
             articles = articles.filter { !$0.url.contains("/reel/") }
         }
         return articles
+    }
+
+    private func reloadPreloadedEntries() {
+        preloadedEntries = feedManager.preloadedArticleEntries(
+            for: section,
+            requireUnread: hideViewedContent
+        )
     }
 
     private func performRefresh() async {
@@ -80,24 +91,15 @@ struct HomeSectionView: View {
 
     private var loadMoreAction: (() -> Void)? {
         if hideViewedContent && visibility.hasReachedEnd { return nil }
+        let batcher = self.batcher
         if let days = batchingMode.chunkDays {
-            guard let next = feedManager.nextArticleChunk(
-                for: section,
-                before: loadedSinceDate,
-                chunkDays: days,
-                requireUnread: hideViewedContent
-            ) else {
+            guard let next = batcher.nextChunkStart(before: loadedSinceDate, chunkDays: days) else {
                 return nil
             }
             return { loadedSinceDate = next }
         }
         if let batch = batchingMode.batchSize {
-            guard let next = feedManager.nextLoadedCount(
-                for: section,
-                after: loadedCount,
-                batchSize: batch,
-                requireUnread: hideViewedContent
-            ) else {
+            guard let next = batcher.nextLoadedCount(after: loadedCount, batchSize: batch) else {
                 return nil
             }
             return { loadedCount = next }
@@ -150,12 +152,19 @@ struct HomeSectionView: View {
             acceptPendingRefresh()
         }
         .onAppear {
+            reloadPreloadedEntries()
             if !hasInitializedSinceDate {
                 loadedSinceDate = batchingMode.initialSinceDate(
                     latestArticleDate: latestArticleDateForSection()
                 )
                 hasInitializedSinceDate = true
             }
+        }
+        .onChange(of: feedManager.dataRevision) { _, _ in
+            reloadPreloadedEntries()
+        }
+        .onChange(of: hideViewedContent) { _, _ in
+            reloadPreloadedEntries()
         }
         .onChange(of: batchingMode) { _, newMode in
             loadedSinceDate = newMode.initialSinceDate(

--- a/SakuraRSS/Views/Home/HomeSectionView.swift
+++ b/SakuraRSS/Views/Home/HomeSectionView.swift
@@ -160,6 +160,14 @@ struct HomeSectionView: View {
                 hasInitializedSinceDate = true
             }
         }
+        .onChange(of: section) { _, _ in
+            reloadPreloadedEntries()
+            loadedSinceDate = batchingMode.initialSinceDate(
+                latestArticleDate: latestArticleDateForSection()
+            )
+            loadedCount = batchingMode.initialCount()
+            visibility.capture(from: rawArticles, isEnabled: hideViewedContent)
+        }
         .onChange(of: feedManager.dataRevision) { _, _ in
             reloadPreloadedEntries()
         }

--- a/SakuraRSS/Views/Home/ListSectionView.swift
+++ b/SakuraRSS/Views/Home/ListSectionView.swift
@@ -11,6 +11,7 @@ struct ListSectionView: View {
     @State private var loadedSinceDate: Date = Date(timeIntervalSince1970: 0)
     @State private var loadedCount: Int = BatchingMode.current().initialCount()
     @State private var hasInitializedSinceDate = false
+    @State private var preloadedEntries: [ArticleIDEntry] = []
     @AppStorage("Articles.HideViewedContent") private var storedHideViewedContent: Bool = false
     @State private var visibility = ArticleVisibilityTracker()
     @State private var scrollToTopTick: Int = 0
@@ -23,15 +24,28 @@ struct ListSectionView: View {
         DoomscrollingMode.effectiveHideViewedContent(storedHideViewedContent)
     }
 
+    private var batcher: ArticleIDBatcher {
+        ArticleIDBatcher(entries: preloadedEntries)
+    }
+
     private var rawArticles: [Article] {
+        let batcher = self.batcher
+        let slicedIDs: [Int64]
         if batchingMode.isCountBased {
-            return feedManager.articles(
-                for: list,
-                limit: loadedCount,
-                requireUnread: hideViewedContent
-            )
+            slicedIDs = batcher.ids(limit: loadedCount)
+        } else if batchingMode.isDateBased {
+            slicedIDs = batcher.ids(since: loadedSinceDate)
+        } else {
+            slicedIDs = preloadedEntries.map(\.id)
         }
-        return feedManager.articles(for: list, since: loadedSinceDate)
+        return feedManager.articles(withPreloadedIDs: slicedIDs)
+    }
+
+    private func reloadPreloadedEntries() {
+        preloadedEntries = feedManager.preloadedArticleEntries(
+            for: list,
+            requireUnread: hideViewedContent
+        )
     }
 
     private func performRefresh() async {
@@ -71,24 +85,15 @@ struct ListSectionView: View {
 
     private var loadMoreAction: (() -> Void)? {
         if hideViewedContent && visibility.hasReachedEnd { return nil }
+        let batcher = self.batcher
         if let days = batchingMode.chunkDays {
-            guard let next = feedManager.nextArticleChunk(
-                for: list,
-                before: loadedSinceDate,
-                chunkDays: days,
-                requireUnread: hideViewedContent
-            ) else {
+            guard let next = batcher.nextChunkStart(before: loadedSinceDate, chunkDays: days) else {
                 return nil
             }
             return { loadedSinceDate = next }
         }
         if let batch = batchingMode.batchSize {
-            guard let next = feedManager.nextLoadedCount(
-                for: list,
-                after: loadedCount,
-                batchSize: batch,
-                requireUnread: hideViewedContent
-            ) else {
+            guard let next = batcher.nextLoadedCount(after: loadedCount, batchSize: batch) else {
                 return nil
             }
             return { loadedCount = next }
@@ -130,12 +135,19 @@ struct ListSectionView: View {
             acceptPendingRefresh()
         }
         .onAppear {
+            reloadPreloadedEntries()
             if !hasInitializedSinceDate {
                 loadedSinceDate = batchingMode.initialSinceDate(
                     latestArticleDate: latestArticleDateForList()
                 )
                 hasInitializedSinceDate = true
             }
+        }
+        .onChange(of: feedManager.dataRevision) { _, _ in
+            reloadPreloadedEntries()
+        }
+        .onChange(of: hideViewedContent) { _, _ in
+            reloadPreloadedEntries()
         }
         .onChange(of: batchingMode) { _, newMode in
             loadedSinceDate = newMode.initialSinceDate(

--- a/SakuraRSS/Views/Home/ListSectionView.swift
+++ b/SakuraRSS/Views/Home/ListSectionView.swift
@@ -143,6 +143,14 @@ struct ListSectionView: View {
                 hasInitializedSinceDate = true
             }
         }
+        .onChange(of: list.id) { _, _ in
+            reloadPreloadedEntries()
+            loadedSinceDate = batchingMode.initialSinceDate(
+                latestArticleDate: latestArticleDateForList()
+            )
+            loadedCount = batchingMode.initialCount()
+            visibility.capture(from: rawArticles, isEnabled: hideViewedContent)
+        }
         .onChange(of: feedManager.dataRevision) { _, _ in
             reloadPreloadedEntries()
         }


### PR DESCRIPTION
## Summary

- Each feed/home section/list view now preloads the full ordered list of `(id, publishedDate)` pairs for its scope once, then applies the user's batching mode by slicing that snapshot.
- "Load Previous" advances the slice window in-memory instead of re-querying the database with a growing limit, and rule/mute filtering happens once per data revision rather than per render.

## Changes

- **New `ArticleIDEntry`** (`Feeds/ArticleIDEntry.swift`): lightweight `(id, publishedDate)` pair stored in view state.
- **New `ArticleIDBatcher`** (`Feeds/ArticleIDBatcher.swift`): slices preloaded entries by count or date window, and walks chunk dates entirely in memory.
- **New `FeedManager+Preload.swift`**: `preloadedArticleEntries(...)` for the all/feed/section/list scopes, plus `articles(withPreloadedIDs:)` to materialize a slice in the preloaded order.
- **`FeedArticlesView`, `AllArticlesView`, `HomeSectionView`, `ListSectionView`**: hold preloaded entries in `@State`, refresh on `dataRevision` and `hideViewedContent` changes, slice via `ArticleIDBatcher`, and materialize via `articles(withPreloadedIDs:)`.

## Test plan

- [ ] All Articles, section, list, and per-feed views render the same content as before for each batching mode (Off, 1 day, 3 days, 1 week, 25, 50, 100 items).
- [ ] "Load Previous" still reveals older content in count- and date-based modes, and disappears when nothing more is available.
- [ ] Pull-to-refresh, mark-all-read, and mark-as-read-on-scroll continue to update the visible list (preloaded entries reload when `dataRevision` bumps).
- [ ] Toggling Hide Viewed Content reloads the preloaded set with `requireUnread`.
- [ ] Switching batching mode resets the slice anchor and the visibility tracker re-captures.
- [ ] Doomscrolling Mode override still forces `.items25` and reloads correctly.

https://claude.ai/code/session_01EdbvU8L9ezauFpuFaBV1j3

---
_Generated by [Claude Code](https://claude.ai/code/session_01EdbvU8L9ezauFpuFaBV1j3)_