### PR TITLE
Stop YouTube article embeds from autoplaying

### DIFF
--- a/App/Views/Viewers/YouTube Player/YouTubePlayerScripts.swift
+++ b/App/Views/Viewers/YouTube Player/YouTubePlayerScripts.swift
@@ -121,19 +121,25 @@ nonisolated enum YouTubePlayerScripts {
     """
 
     /// Blocks autoplay until `window.__ytAutoplayBlocked` is cleared by a native play action.
+    /// Sets `__ytUserPaused = true` before pausing so the pause survives `pauseOverride`
+    /// and is not re-played by `pauseGuard`.
     static let autoplayBlocker = """
     (function() {
         window.__ytAutoplayBlocked = true;
+        function block(video) {
+            window.__ytUserPaused = true;
+            video.pause();
+        }
         function attach(video) {
             if (!video || video.__ytAutoplayAttached) return;
             video.__ytAutoplayAttached = true;
             video.addEventListener('play', function() {
                 if (window.__ytAutoplayBlocked) {
-                    video.pause();
+                    block(video);
                 }
             });
             if (!video.paused && window.__ytAutoplayBlocked) {
-                video.pause();
+                block(video);
             }
         }
         function tryAttach() {


### PR DESCRIPTION
## Summary
- YouTube embeds inside articles were autoplaying despite `YouTubeEmbedBlockView` passing `autoplay: false` and the `autoplayBlocker` script being injected.
- The blocker called `video.pause()`, but the unconditionally-injected `pauseOverride` only forwards pauses when `window.__ytUserPaused === true`, so the blocker's pause was a no-op and playback continued.
- Fix: in `autoplayBlocker`, set `__ytUserPaused = true` before pausing. This lets the pause pass through `pauseOverride`, and prevents `pauseGuard` from auto-resuming. When the user taps play in the embed controls, `togglePlayPause` already resets both flags, so manual playback works as before.

## Test plan
- [ ] Open an article that contains a YouTube embed and confirm the video does not autoplay; a black placeholder with a spinner is shown until the user taps play.
- [ ] Tap the embed's play button and confirm playback starts.
- [ ] Tap pause and confirm the video stays paused (no auto-resume from `pauseGuard`).
- [ ] Open a full YouTube video via the standalone player and confirm autoplay still works there (the blocker is only injected when `autoplay == false`).
- [ ] Background the app while the standalone player is playing and confirm audio continues (i.e., `pauseOverride` / `pauseGuard` still function).

https://claude.ai/code/session_01R3y8ksUSfJ2tEGA2znWu26

---
_Generated by [Claude Code](https://claude.ai/code/session_01R3y8ksUSfJ2tEGA2znWu26)_