### PR TITLE
Fix empty Home feed when Hide Read Content is on at launch

### DIFF
--- a/App/Structs/ArticleVisibilityTracker.swift
+++ b/App/Structs/ArticleVisibilityTracker.swift
@@ -54,9 +54,7 @@ struct ArticleVisibilityTracker {
             visibleIDs = nil
             return
         }
-        // Skip when the input is empty so a capture that races with the
-        // initial preload doesn't freeze visibleIDs at an empty set and
-        // hide every article that arrives later.
+        // Don't freeze visibleIDs at an empty set when data isn't loaded yet.
         guard !articles.isEmpty else { return }
         visibleIDs = Set(articles.filter { !$0.isRead }.map(\.id))
     }
@@ -96,9 +94,7 @@ struct ArticleVisibilityTracker {
             preRefreshIDs = Set(articles.map(\.id)).union(visibleIDs ?? []).union(pendingIDs)
             preRefreshMaxID = preRefreshIDs.max() ?? .max
             if isEnabled {
-                // Skip the capture when the input is empty so a refresh
-                // that races with the initial preload doesn't strand
-                // visibleIDs at an empty set.
+                // Don't strand visibleIDs at an empty set when data isn't loaded yet.
                 if (recaptureVisible || visibleIDs == nil), !articles.isEmpty {
                     visibleIDs = Set(articles.filter { !$0.isRead }.map(\.id))
                 }

--- a/App/Structs/ArticleVisibilityTracker.swift
+++ b/App/Structs/ArticleVisibilityTracker.swift
@@ -54,6 +54,10 @@ struct ArticleVisibilityTracker {
             visibleIDs = nil
             return
         }
+        // Skip when the input is empty so a capture that races with the
+        // initial preload doesn't freeze visibleIDs at an empty set and
+        // hide every article that arrives later.
+        guard !articles.isEmpty else { return }
         visibleIDs = Set(articles.filter { !$0.isRead }.map(\.id))
     }
 
@@ -92,7 +96,10 @@ struct ArticleVisibilityTracker {
             preRefreshIDs = Set(articles.map(\.id)).union(visibleIDs ?? []).union(pendingIDs)
             preRefreshMaxID = preRefreshIDs.max() ?? .max
             if isEnabled {
-                if recaptureVisible || visibleIDs == nil {
+                // Skip the capture when the input is empty so a refresh
+                // that races with the initial preload doesn't strand
+                // visibleIDs at an empty set.
+                if (recaptureVisible || visibleIDs == nil), !articles.isEmpty {
                     visibleIDs = Set(articles.filter { !$0.isRead }.map(\.id))
                 }
             } else {

--- a/App/Views/Feed/FeedArticlesView.swift
+++ b/App/Views/Feed/FeedArticlesView.swift
@@ -73,9 +73,6 @@ struct FeedArticlesView: View {
             for: feed,
             requireUnread: hideViewedContent
         )
-        // Capture visibility once data is actually available, so the
-        // freeze-on-read behavior kicks in even when the initial preload
-        // loses the race against the view's `.task` capture.
         if hideViewedContent, visibility.visibleIDs == nil, !preloadedEntries.isEmpty {
             visibility.capture(from: rawArticles, isEnabled: hideViewedContent)
         }

--- a/App/Views/Feed/FeedArticlesView.swift
+++ b/App/Views/Feed/FeedArticlesView.swift
@@ -73,6 +73,12 @@ struct FeedArticlesView: View {
             for: feed,
             requireUnread: hideViewedContent
         )
+        // Capture visibility once data is actually available, so the
+        // freeze-on-read behavior kicks in even when the initial preload
+        // loses the race against the view's `.task` capture.
+        if hideViewedContent, visibility.visibleIDs == nil, !preloadedEntries.isEmpty {
+            visibility.capture(from: rawArticles, isEnabled: hideViewedContent)
+        }
     }
 
     private func performRefresh() async {

--- a/App/Views/Home/All Articles/AllArticlesView+Articles.swift
+++ b/App/Views/Home/All Articles/AllArticlesView+Articles.swift
@@ -78,17 +78,12 @@ extension AllArticlesView {
         preloadedEntries = feedManager.preloadedArticleEntries(
             requireUnread: hideViewedContent
         )
-        // Capture visibility once data is actually available, so the
-        // freeze-on-read behavior kicks in even when the initial preload
-        // loses the race against the view's `.task` capture.
         if hideViewedContent, visibility.visibleIDs == nil, !preloadedEntries.isEmpty {
             visibility.capture(from: rawArticles, isEnabled: hideViewedContent)
         }
     }
 
-    /// Latest published date among the preloaded (already rule and unread
-    /// filtered) entries, so the initial date-based batch is anchored on
-    /// content that will actually appear after filtering.
+    /// Latest preloaded entry date, so the initial batch anchors on visible content.
     func latestArticleDateAcrossFeeds() -> Date? {
         preloadedEntries.compactMap(\.publishedDate).max()
     }

--- a/App/Views/Home/All Articles/AllArticlesView+Articles.swift
+++ b/App/Views/Home/All Articles/AllArticlesView+Articles.swift
@@ -78,12 +78,18 @@ extension AllArticlesView {
         preloadedEntries = feedManager.preloadedArticleEntries(
             requireUnread: hideViewedContent
         )
+        // Capture visibility once data is actually available, so the
+        // freeze-on-read behavior kicks in even when the initial preload
+        // loses the race against the view's `.task` capture.
+        if hideViewedContent, visibility.visibleIDs == nil, !preloadedEntries.isEmpty {
+            visibility.capture(from: rawArticles, isEnabled: hideViewedContent)
+        }
     }
 
-    /// Most recent published date across all feeds, used to anchor the date
-    /// window so the home tab shows the freshest content even when no feed
-    /// has posted within the wall-clock window.
+    /// Latest published date among the preloaded (already rule and unread
+    /// filtered) entries, so the initial date-based batch is anchored on
+    /// content that will actually appear after filtering.
     func latestArticleDateAcrossFeeds() -> Date? {
-        feedManager.latestPublishedDate()
+        preloadedEntries.compactMap(\.publishedDate).max()
     }
 }

--- a/App/Views/Home/All Articles/AllArticlesView.swift
+++ b/App/Views/Home/All Articles/AllArticlesView.swift
@@ -64,6 +64,11 @@ struct AllArticlesView: View {
         }
         .onChange(of: hideViewedContent) { _, _ in
             reloadPreloadedEntries()
+            loadedSinceDate = batchingMode.initialSinceDate(
+                latestArticleDate: latestArticleDateAcrossFeeds()
+            )
+            loadedCount = batchingMode.initialCount()
+            visibility.capture(from: rawArticles, isEnabled: hideViewedContent)
         }
         .onChange(of: batchingMode) { _, newMode in
             loadedSinceDate = newMode.initialSinceDate(

--- a/App/Views/Home/HomeSectionView.swift
+++ b/App/Views/Home/HomeSectionView.swift
@@ -52,9 +52,6 @@ struct HomeSectionView: View {
             for: section,
             requireUnread: hideViewedContent
         )
-        // Capture visibility once data is actually available, so the
-        // freeze-on-read behavior kicks in even when the initial preload
-        // loses the race against the view's `.task` capture.
         if hideViewedContent, visibility.visibleIDs == nil, !preloadedEntries.isEmpty {
             visibility.capture(from: rawArticles, isEnabled: hideViewedContent)
         }
@@ -205,9 +202,7 @@ struct HomeSectionView: View {
         }
     }
 
-    /// Latest published date among the preloaded (already feed-id and
-    /// unread-filtered) entries, so the initial date-based batch is anchored
-    /// on content that will actually appear after filtering.
+    /// Latest preloaded entry date, so the initial batch anchors on visible content.
     private func latestArticleDateForSection() -> Date? {
         preloadedEntries.compactMap(\.publishedDate).max()
     }

--- a/App/Views/Home/HomeSectionView.swift
+++ b/App/Views/Home/HomeSectionView.swift
@@ -52,6 +52,12 @@ struct HomeSectionView: View {
             for: section,
             requireUnread: hideViewedContent
         )
+        // Capture visibility once data is actually available, so the
+        // freeze-on-read behavior kicks in even when the initial preload
+        // loses the race against the view's `.task` capture.
+        if hideViewedContent, visibility.visibleIDs == nil, !preloadedEntries.isEmpty {
+            visibility.capture(from: rawArticles, isEnabled: hideViewedContent)
+        }
     }
 
     private func performRefresh() async {
@@ -181,6 +187,11 @@ struct HomeSectionView: View {
         }
         .onChange(of: hideViewedContent) { _, _ in
             reloadPreloadedEntries()
+            loadedSinceDate = batchingMode.initialSinceDate(
+                latestArticleDate: latestArticleDateForSection()
+            )
+            loadedCount = batchingMode.initialCount()
+            visibility.capture(from: rawArticles, isEnabled: hideViewedContent)
         }
         .onChange(of: batchingMode) { _, newMode in
             loadedSinceDate = newMode.initialSinceDate(
@@ -194,11 +205,10 @@ struct HomeSectionView: View {
         }
     }
 
+    /// Latest published date among the preloaded (already feed-id and
+    /// unread-filtered) entries, so the initial date-based batch is anchored
+    /// on content that will actually appear after filtering.
     private func latestArticleDateForSection() -> Date? {
-        let sectionFeedIDs = Set(
-            feedManager.feeds.filter { $0.feedSection == section }.map(\.id)
-        )
-        guard !sectionFeedIDs.isEmpty else { return nil }
-        return feedManager.latestPublishedDate(forFeedIDs: sectionFeedIDs)
+        preloadedEntries.compactMap(\.publishedDate).max()
     }
 }

--- a/App/Views/Home/ListSectionView.swift
+++ b/App/Views/Home/ListSectionView.swift
@@ -46,6 +46,12 @@ struct ListSectionView: View {
             for: list,
             requireUnread: hideViewedContent
         )
+        // Capture visibility once data is actually available, so the
+        // freeze-on-read behavior kicks in even when the initial preload
+        // loses the race against the view's `.task` capture.
+        if hideViewedContent, visibility.visibleIDs == nil, !preloadedEntries.isEmpty {
+            visibility.capture(from: rawArticles, isEnabled: hideViewedContent)
+        }
     }
 
     private func performRefresh() async {

--- a/App/Views/Home/ListSectionView.swift
+++ b/App/Views/Home/ListSectionView.swift
@@ -46,9 +46,6 @@ struct ListSectionView: View {
             for: list,
             requireUnread: hideViewedContent
         )
-        // Capture visibility once data is actually available, so the
-        // freeze-on-read behavior kicks in even when the initial preload
-        // loses the race against the view's `.task` capture.
         if hideViewedContent, visibility.visibleIDs == nil, !preloadedEntries.isEmpty {
             visibility.capture(from: rawArticles, isEnabled: hideViewedContent)
         }


### PR DESCRIPTION
## Summary

The Home tab could open with the empty state ("何もありません") even when the unread badge was non-zero, as long as Hide Read Content was on. Reproduces with hundreds of unread articles in the badge but a blank feed.

### Root cause

`ArticleVisibilityTracker.capture` is invoked from `TrackArticleVisibilityModifier`'s `.task` modifier on first appearance. That can race the view's `.onAppear`, which is what calls `reloadPreloadedEntries()` to populate `preloadedEntries`. If the task wins, `rawArticles()` returns `[]`, capture sets `visibleIDs = Set([])`, and the subsequent `filter` removes every article that arrives later. The unread badge stays right because it reads `unreadCounts` directly, but the list view shows the empty state.

### Fix

- `ArticleVisibilityTracker.capture` and `beginRefresh` skip the capture when the input array is empty, so a race against the initial preload no longer freezes `visibleIDs` at an empty set.
- Each view's `reloadPreloadedEntries` now captures visibility once data is actually available (when `visibleIDs == nil` and entries are non-empty), so the freeze-on-read behavior still kicks in after the deferred capture.
- Apply PR #232's anchor + reset/capture fix to `AllArticlesView` and `HomeSectionView` so toggling Hide Read Content also re-anchors `loadedSinceDate`/`loadedCount` on the latest preloaded entry. `latestArticleDateAcrossFeeds()` and `latestArticleDateForSection()` now source from `preloadedEntries` (already rule + unread filtered) instead of the raw database, matching the `ListSectionView` behavior.

## Test plan

- [ ] Cold-launch with Hide Read Content on and a non-zero unread badge: Home tab shows the unread articles instead of the empty state.
- [ ] Toggle Hide Read Content off then on while viewing Home or a section: list re-anchors to the freshest unread content instead of going blank.
- [ ] Pull-to-refresh with Hide Read Content on: existing visible content is preserved while new arrivals collect under the refresh prompt.
- [ ] Mark an article as read while scrolling: it stays visible until the next refresh (freeze-on-read still works).
- [ ] Open a per-feed view, a list, and a section view (Instagram, YouTube, etc.) with Hide Read Content on: each shows its unread content rather than the empty state.
- [ ] Switch batching mode (Off / N items / N days) while Hide Read Content is on: initial batch is non-empty for any mode that has unread content.

https://claude.ai/code

---
_Generated by [Claude Code](https://claude.ai/code/session_017jvt9zcVWZxxntaeEXYSLC)_