### PR TITLE
Exclude muted articles from per-feed unread badge

### DIFF
--- a/App/Classes/Feed Manager/FeedManager+Rules.swift
+++ b/App/Classes/Feed Manager/FeedManager+Rules.swift
@@ -52,7 +52,7 @@ extension FeedManager {
         Self.applyRules(articles, feedID: feedID, database: database)
     }
 
-    static func applyRules(_ articles: [Article], feedID: Int64, database: DatabaseManager) -> [Article] {
+    nonisolated static func applyRules(_ articles: [Article], feedID: Int64, database: DatabaseManager) -> [Article] {
         let allowedKeywords = (try? database.rules(forFeedID: feedID, type: "allowed_keyword")) ?? []
         let keywords = (try? database.rules(forFeedID: feedID, type: "muted_keyword")) ?? []
         let authors = Set((try? database.rules(forFeedID: feedID, type: "muted_author")) ?? [])
@@ -79,7 +79,7 @@ extension FeedManager {
 
     /// Adjusts raw per-feed unread counts so muted articles (by keyword or
     /// author rules) are excluded. Only feeds with rules are recomputed.
-    static func applyRulesToUnreadCounts(_ rawCounts: [Int64: Int], database: DatabaseManager) -> [Int64: Int] {
+    nonisolated static func applyRulesToUnreadCounts(_ rawCounts: [Int64: Int], database: DatabaseManager) -> [Int64: Int] {
         let feedsWithRules = (try? database.feedIDsWithRules()) ?? []
         guard !feedsWithRules.isEmpty else { return rawCounts }
         var result = rawCounts
@@ -138,7 +138,7 @@ extension FeedManager {
         Self.articleMatchesKeywords(article, keywords: keywords)
     }
 
-    fileprivate static func articleMatchesKeywords(_ article: Article, keywords: [String]) -> Bool {
+    nonisolated fileprivate static func articleMatchesKeywords(_ article: Article, keywords: [String]) -> Bool {
         for keyword in keywords {
             if article.title.localizedCaseInsensitiveContains(keyword) {
                 return true

--- a/App/Classes/Feed Manager/FeedManager+Rules.swift
+++ b/App/Classes/Feed Manager/FeedManager+Rules.swift
@@ -18,14 +18,20 @@ extension FeedManager {
 
     func saveAllowedKeywords(_ keywords: [String], for feed: Feed) {
         try? database.replaceRules(feedID: feed.id, type: "allowed_keyword", values: keywords)
+        loadFromDatabase()
+        updateBadgeCount()
     }
 
     func saveMutedKeywords(_ keywords: [String], for feed: Feed) {
         try? database.replaceRules(feedID: feed.id, type: "muted_keyword", values: keywords)
+        loadFromDatabase()
+        updateBadgeCount()
     }
 
     func saveMutedAuthors(_ authors: [String], for feed: Feed) {
         try? database.replaceRules(feedID: feed.id, type: "muted_author", values: authors)
+        loadFromDatabase()
+        updateBadgeCount()
     }
 
     func uniqueAuthors(for feed: Feed) -> [String] {
@@ -43,13 +49,17 @@ extension FeedManager {
     // MARK: - Rule Application
 
     func applyRules(_ articles: [Article], feedID: Int64) -> [Article] {
+        Self.applyRules(articles, feedID: feedID, database: database)
+    }
+
+    static func applyRules(_ articles: [Article], feedID: Int64, database: DatabaseManager) -> [Article] {
         let allowedKeywords = (try? database.rules(forFeedID: feedID, type: "allowed_keyword")) ?? []
         let keywords = (try? database.rules(forFeedID: feedID, type: "muted_keyword")) ?? []
         let authors = Set((try? database.rules(forFeedID: feedID, type: "muted_author")) ?? [])
         guard !allowedKeywords.isEmpty || !keywords.isEmpty || !authors.isEmpty else { return articles }
         return articles.filter { article in
             if !allowedKeywords.isEmpty {
-                return articleMatchesKeywords(article, keywords: allowedKeywords)
+                return Self.articleMatchesKeywords(article, keywords: allowedKeywords)
             }
             if let author = article.author, authors.contains(author) {
                 return false
@@ -65,6 +75,19 @@ extension FeedManager {
             }
             return true
         }
+    }
+
+    /// Adjusts raw per-feed unread counts so muted articles (by keyword or
+    /// author rules) are excluded. Only feeds with rules are recomputed.
+    static func applyRulesToUnreadCounts(_ rawCounts: [Int64: Int], database: DatabaseManager) -> [Int64: Int] {
+        let feedsWithRules = (try? database.feedIDsWithRules()) ?? []
+        guard !feedsWithRules.isEmpty else { return rawCounts }
+        var result = rawCounts
+        for feedID in feedsWithRules where (result[feedID] ?? 0) > 0 {
+            let unread = (try? database.unreadArticles(forFeedID: feedID)) ?? []
+            result[feedID] = applyRules(unread, feedID: feedID, database: database).count
+        }
+        return result
     }
 
     func applyAllRules(_ articles: [Article]) -> [Article] {
@@ -112,6 +135,10 @@ extension FeedManager {
     }
 
     private func articleMatchesKeywords(_ article: Article, keywords: [String]) -> Bool {
+        Self.articleMatchesKeywords(article, keywords: keywords)
+    }
+
+    fileprivate static func articleMatchesKeywords(_ article: Article, keywords: [String]) -> Bool {
         for keyword in keywords {
             if article.title.localizedCaseInsensitiveContains(keyword) {
                 return true

--- a/App/Classes/Feed Manager/FeedManager.swift
+++ b/App/Classes/Feed Manager/FeedManager.swift
@@ -47,7 +47,8 @@ final class FeedManager {
             feeds = try database.allFeeds()
             feedsByID = Dictionary(uniqueKeysWithValues: feeds.map { ($0.id, $0) })
             articles = try database.allArticles(limit: 200)
-            unreadCounts = (try? database.allUnreadCounts()) ?? [:]
+            let rawUnreadCounts = (try? database.allUnreadCounts()) ?? [:]
+            unreadCounts = FeedManager.applyRulesToUnreadCounts(rawUnreadCounts, database: database)
             lists = (try? database.allLists()) ?? []
             pendingReadIDs.removeAll()
             pendingReadDecrements.removeAll()
@@ -64,7 +65,8 @@ final class FeedManager {
             let (loadedFeeds, loadedArticles, loadedUnreadCounts, loadedLists) = try await Task.detached {
                 let feeds = try dbm.allFeeds()
                 let articles = try dbm.allArticles(limit: 200)
-                let unreadCounts = (try? dbm.allUnreadCounts()) ?? [:]
+                let rawUnreadCounts = (try? dbm.allUnreadCounts()) ?? [:]
+                let unreadCounts = FeedManager.applyRulesToUnreadCounts(rawUnreadCounts, database: dbm)
                 let lists = (try? dbm.allLists()) ?? []
                 return (feeds, articles, unreadCounts, lists)
             }.value

--- a/Shared/Database Manager/Articles/DatabaseManager+ArticlesQueries.swift
+++ b/Shared/Database Manager/Articles/DatabaseManager+ArticlesQueries.swift
@@ -60,6 +60,13 @@ nonisolated extension DatabaseManager {
         return try database.prepare(query).map(rowToArticle)
     }
 
+    func unreadArticles(forFeedID fid: Int64) throws -> [Article] {
+        let query = articles
+            .filter(articleFeedID == fid && articleIsRead == false)
+            .order(articlePublishedDate.desc)
+        return try database.prepare(query).map(rowToArticle)
+    }
+
     func articleCount(forFeedID fid: Int64) throws -> Int {
         try database.scalar(articles.filter(articleFeedID == fid).count)
     }

--- a/Shared/Database Manager/DatabaseManager+Rules.swift
+++ b/Shared/Database Manager/DatabaseManager+Rules.swift
@@ -13,6 +13,14 @@ nonisolated extension DatabaseManager {
         ).map { $0[ruleValue] }
     }
 
+    func feedIDsWithRules() throws -> Set<Int64> {
+        var result = Set<Int64>()
+        for row in try database.prepare(feedRules.select(distinct: ruleFeedID)) {
+            result.insert(row[ruleFeedID])
+        }
+        return result
+    }
+
     @discardableResult
     func insertRule(feedID: Int64, type: String, value: String) throws -> Int64 {
         try database.run(feedRules.insert(


### PR DESCRIPTION
## Summary

The unread badge shown next to each feed in the Following tab counted every article with `is_read = 0` directly from SQL, so items silenced by a feed's keyword or author mute rules still inflated the badge.

This change applies the feed's rules to the unread set when the cached `unreadCounts` dictionary is built. Only feeds that actually have rules incur the extra work — feeds without rules use the existing fast `allUnreadCounts()` query unchanged.

- New `DatabaseManager.unreadArticles(forFeedID:)` and `DatabaseManager.feedIDsWithRules()` helpers.
- New `FeedManager.applyRulesToUnreadCounts(_:database:)` static helper, callable from the existing detached background load.
- `applyRules` is now also exposed as a static helper so the background loader can apply rules without hopping back to the main actor.
- Saving feed rules via `saveAllowedKeywords` / `saveMutedKeywords` / `saveMutedAuthors` now refreshes the cached counts and the home-screen badge so changes are reflected immediately.

Section and List unread totals are computed by summing `unreadCounts`, so they automatically pick up the corrected per-feed values.

## Test plan

- [ ] Add a `muted_keyword` to a feed and confirm articles matching that keyword no longer count toward the feed's badge in the Following tab.
- [ ] Add a `muted_author` and verify articles by that author drop out of the badge count.
- [ ] Add an `allowed_keyword` (allowlist) and verify the badge reflects only matching unread articles.
- [ ] Remove all rules from a feed and confirm the badge returns to the raw unread count.
- [ ] Mark articles read in a feed with rules and verify the badge decrements correctly.
- [ ] Confirm Section and List badges in the Home tab match the sum of their constituent feeds' (now rule-filtered) badges.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FSFxFE2rEBxEaRTmCihG4j)_