### PR TITLE
Render table cells with ContentBlockStack

### DIFF
--- a/App/Enums/ContentBlock.swift
+++ b/App/Enums/ContentBlock.swift
@@ -125,8 +125,7 @@ enum ContentBlock: Identifiable {
     }
 
     static func parse(_ text: String) -> [ContentBlock] {
-        // swiftlint:disable:next line_length
-        let pattern = #"\{\{(IMG|CODE|VIDEO|AUDIO|YOUTUBE|XPOST|EMBED|TABLE|MATH)\}\}(.*?)\{\{/(IMG|CODE|VIDEO|AUDIO|YOUTUBE|XPOST|EMBED|TABLE|MATH)\}\}"#
+        let pattern = #"\{\{(IMG|CODE|VIDEO|AUDIO|YOUTUBE|XPOST|EMBED|TABLE|MATH)\}\}(.*?)\{\{/\1\}\}"#
         guard let regex = try? NSRegularExpression(pattern: pattern, options: .dotMatchesLineSeparators)
         else {
             return [.text(ArticleMarker.unescape(text))]

--- a/App/Views/Viewers/Article Detail/Content Blocks/ContentBlockStack.swift
+++ b/App/Views/Viewers/Article Detail/Content Blocks/ContentBlockStack.swift
@@ -10,6 +10,7 @@ struct ContentBlockStack: View {
 
     let text: String
     var textStyle: TextStyle = .primary
+    var font: UIFont = .preferredFont(forTextStyle: .body)
     let imageNamespace: Namespace.ID
     let onImageTap: (URL) -> Void
 
@@ -40,7 +41,13 @@ struct ContentBlockStack: View {
             case .embed(let provider, let url):
                 EmbedBlockView(provider: provider, url: url)
             case .table(let header, let rows):
-                TableBlockView(header: header, rows: rows)
+                TableBlockView(
+                    header: header,
+                    rows: rows,
+                    textStyle: textStyle,
+                    imageNamespace: imageNamespace,
+                    onImageTap: onImageTap
+                )
             case .math(let latex):
                 MathBlockView(latex: latex)
             }
@@ -51,9 +58,9 @@ struct ContentBlockStack: View {
     private func textView(_ content: String) -> some View {
         switch textStyle {
         case .primary:
-            SelectableText(content)
+            SelectableText(content, font: font)
         case .white:
-            SelectableText(content, textColor: .white)
+            SelectableText(content, font: font, textColor: .white)
                 .frame(maxWidth: .infinity, alignment: .leading)
         }
     }

--- a/App/Views/Viewers/Article Detail/Content Blocks/TableBlockView.swift
+++ b/App/Views/Viewers/Article Detail/Content Blocks/TableBlockView.swift
@@ -4,10 +4,22 @@ struct TableBlockView: View {
 
     let header: [String]
     let rows: [[String]]
+    let textStyle: ContentBlockStack.TextStyle
+    let imageNamespace: Namespace.ID
+    let onImageTap: (URL) -> Void
 
     private var columnCount: Int {
         let rowMax = rows.map(\.count).max() ?? 0
         return max(header.count, rowMax)
+    }
+
+    private var headerFont: UIFont {
+        let base = UIFont.preferredFont(forTextStyle: .callout)
+        return base.bold()
+    }
+
+    private var bodyFont: UIFont {
+        UIFont.preferredFont(forTextStyle: .callout)
     }
 
     var body: some View {
@@ -40,13 +52,19 @@ struct TableBlockView: View {
         GridRow {
             ForEach(0..<columnCount, id: \.self) { index in
                 let cell = index < cells.count ? cells[index] : ""
-                Text(cell)
-                    .font(isHeader ? .callout.bold() : .callout)
-                    .foregroundStyle(.primary)
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 8)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-                    .background(background)
+                VStack(alignment: .leading, spacing: 8) {
+                    ContentBlockStack(
+                        text: cell,
+                        textStyle: textStyle,
+                        font: isHeader ? headerFont : bodyFont,
+                        imageNamespace: imageNamespace,
+                        onImageTap: onImageTap
+                    )
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                .background(background)
             }
         }
     }


### PR DESCRIPTION
## Summary

- `TableBlockView` now renders each cell through `ContentBlockStack` instead of plain `Text`, so cells support inline images, code, links, sup/sub, and Markdown formatting like other article content.
- `ContentBlockStack` now plumbs `textStyle`, image namespace, and image-tap callback into `TableBlockView`, plus accepts an optional `font` so headers stay bold-callout and bodies stay regular-callout.
- `ContentBlock.parse` switches the closing-tag alternation to a `\1` backreference (matching the existing translation parser), so nested markers inside `{{TABLE}}` cells no longer cause the outer match to terminate at the wrong closing tag.

## Test plan

- [ ] Open an article whose extracted text contains a `{{TABLE}}` block and verify cells render with Markdown/sup/sub formatting.
- [ ] Verify a table whose cell contains an `{{IMG}}…{{/IMG}}` marker renders the image inside the cell.
- [ ] Verify header row stays visually bold and body rows alternate background.
- [ ] Verify white text style (e.g. scroll display style) still applies inside table cells.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V8ZKaH7Q98oqTu6HV5N5kT)_