### PR TITLE
Fix home bar customization, display style padding, scroll lag, refresh text animation

### DIFF
--- a/App/Classes/Feed Manager/FeedManager+Preload.swift
+++ b/App/Classes/Feed Manager/FeedManager+Preload.swift
@@ -80,6 +80,32 @@ extension FeedManager {
         }
     }
 
+    // MARK: - Topic
+
+    /// Preloads articles tagged with the given NLP entity name (a topic).
+    /// Topics span all feeds, but global feed-mute and article-level rules
+    /// still apply.
+    func preloadedArticleEntries(forTopic topic: String, requireUnread: Bool = false) -> [ArticleIDEntry] {
+        _ = dataRevision
+        let muted = mutedFeedIDs
+        let ids = (try? database.articleIDs(
+            forEntity: topic,
+            types: ["organization", "place"]
+        )) ?? []
+        let raw = (try? database.articles(withIDs: ids)) ?? []
+        var pool = applyAllRules(raw)
+        if !muted.isEmpty {
+            pool = pool.filter { !muted.contains($0.feedID) }
+        }
+        if requireUnread {
+            pool = pool.filter { !$0.isRead }
+        }
+        return pool.compactMap { article in
+            guard let date = article.publishedDate else { return nil }
+            return ArticleIDEntry(id: article.id, publishedDate: date)
+        }
+    }
+
     // MARK: - Materialization
 
     /// Materializes articles for the given preloaded IDs, preserving the

--- a/App/Enums/HomeBarItemKind.swift
+++ b/App/Enums/HomeBarItemKind.swift
@@ -21,8 +21,8 @@ enum HomeBarItemKind: String, Codable, CaseIterable, Identifiable, Hashable, Sen
     var systemImage: String {
         switch self {
         case .following: "square.stack"
-        case .feedSections: "rectangle.stack"
-        case .lists: "list.bullet.rectangle"
+        case .feedSections: "dot.radiowaves.up.forward"
+        case .lists: "list.bullet"
         case .topics: "tag"
         }
     }

--- a/App/Enums/HomeBarItemKind.swift
+++ b/App/Enums/HomeBarItemKind.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// The categories of items that can appear in the home section selection bar.
+enum HomeBarItemKind: String, Codable, CaseIterable, Identifiable, Hashable, Sendable {
+    case following
+    case feedSections
+    case lists
+    case topics
+
+    var id: String { rawValue }
+
+    var localizedTitle: String {
+        switch self {
+        case .following: String(localized: "Home.BarItem.Following", table: "Settings")
+        case .feedSections: String(localized: "Home.BarItem.FeedSections", table: "Settings")
+        case .lists: String(localized: "Home.BarItem.Lists", table: "Settings")
+        case .topics: String(localized: "Home.BarItem.Topics", table: "Settings")
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .following: "square.stack"
+        case .feedSections: "rectangle.stack"
+        case .lists: "list.bullet.rectangle"
+        case .topics: "tag"
+        }
+    }
+}
+
+/// Allowed top-N values for the Topics bar item.
+enum HomeBarTopicCount: Int, Codable, CaseIterable, Identifiable, Sendable {
+    case top3 = 3
+    case top5 = 5
+    case top10 = 10
+
+    var id: Int { rawValue }
+
+    var localizedTitle: String {
+        String(localized: "Home.Topics.Top \(rawValue)", table: "Settings")
+    }
+}

--- a/App/Enums/HomeBarItemKind.swift
+++ b/App/Enums/HomeBarItemKind.swift
@@ -2,28 +2,61 @@ import Foundation
 
 /// The categories of items that can appear in the home section selection bar.
 enum HomeBarItemKind: String, Codable, CaseIterable, Identifiable, Hashable, Sendable {
-    case following
-    case feedSections
+    case feeds
+    case podcasts
+    case bluesky
+    case instagram
+    case mastodon
+    case note
+    case pixelfed
+    case reddit
+    case substack
+    case vimeo
+    case x // swiftlint:disable:this identifier_name
+    case youtube
+    case niconico
     case lists
     case topics
 
     var id: String { rawValue }
 
+    var feedSection: FeedSection? {
+        switch self {
+        case .feeds: .feeds
+        case .podcasts: .podcasts
+        case .bluesky: .bluesky
+        case .instagram: .instagram
+        case .mastodon: .mastodon
+        case .note: .note
+        case .pixelfed: .pixelfed
+        case .reddit: .reddit
+        case .substack: .substack
+        case .vimeo: .vimeo
+        case .x: .x
+        case .youtube: .youtube
+        case .niconico: .niconico
+        case .lists, .topics: nil
+        }
+    }
+
     var localizedTitle: String {
         switch self {
-        case .following: String(localized: "Home.BarItem.Following", table: "Settings")
-        case .feedSections: String(localized: "Home.BarItem.FeedSections", table: "Settings")
         case .lists: String(localized: "Home.BarItem.Lists", table: "Settings")
         case .topics: String(localized: "Home.BarItem.Topics", table: "Settings")
+        default: feedSection?.localizedTitle ?? ""
         }
     }
 
     var systemImage: String {
         switch self {
-        case .following: "square.stack"
-        case .feedSections: "dot.radiowaves.up.forward"
         case .lists: "list.bullet"
         case .topics: "tag"
+        case .feeds: "newspaper"
+        case .podcasts: "headphones"
+        case .instagram, .pixelfed: "photo.on.rectangle"
+        case .bluesky, .mastodon, .note, .reddit, .x: "person.2"
+        case .substack: "envelope"
+        case .vimeo, .youtube, .niconico: "play.rectangle"
         }
     }
 }

--- a/App/Enums/HomeSelection.swift
+++ b/App/Enums/HomeSelection.swift
@@ -1,15 +1,17 @@
 import SwiftUI
 
 /// Represents the selected view in the Home tab title menu.
-/// Can be a static section or a user-created list.
+/// Can be a static section, a user-created list, or a top topic.
 enum HomeSelection: Hashable, RawRepresentable {
     case section(HomeSection)
     case list(Int64)
+    case topic(String)
 
     var rawValue: String {
         switch self {
         case .section(let section): "section.\(section.rawValue)"
         case .list(let id): "list.\(id)"
+        case .topic(let name): "topic.\(name)"
         }
     }
 
@@ -26,6 +28,12 @@ enum HomeSelection: Hashable, RawRepresentable {
                 self = .list(id)
                 return
             }
+        } else if rawValue.hasPrefix("topic.") {
+            let name = String(rawValue.dropFirst("topic.".count))
+            if !name.isEmpty {
+                self = .topic(name)
+                return
+            }
         }
         // Legacy: bare section names from before the HomeSelection wrapper.
         if let section = HomeSection(rawValue: rawValue) {
@@ -39,6 +47,7 @@ enum HomeSelection: Hashable, RawRepresentable {
         switch self {
         case .section(let section): section.localizedTitle
         case .list: ""
+        case .topic(let name): name
         }
     }
 
@@ -46,6 +55,7 @@ enum HomeSelection: Hashable, RawRepresentable {
         switch self {
         case .section(let section): section.systemImage
         case .list: nil
+        case .topic: "tag"
         }
     }
 }

--- a/App/Structs/HomeBarConfiguration.swift
+++ b/App/Structs/HomeBarConfiguration.swift
@@ -4,8 +4,10 @@ extension Notification.Name {
     static let homeBarConfigurationDidChange = Notification.Name("HomeBarConfigurationDidChange")
 }
 
-/// User-configurable layout of the home section selection bar.
-struct HomeBarConfiguration: Codable, Equatable, Hashable, Sendable {
+/// User-configurable layout of the home section selection bar. The Following
+/// tab is always emitted as the first item by `TodayTabItem.items`, so it does
+/// not appear in `orderedItems` or `enabledItems`.
+struct HomeBarConfiguration: Equatable, Hashable, Sendable {
 
     static let storageKey = "Home.BarConfiguration"
 
@@ -13,9 +15,14 @@ struct HomeBarConfiguration: Codable, Equatable, Hashable, Sendable {
     var enabledItems: Set<HomeBarItemKind>
     var topicCount: HomeBarTopicCount
 
+    static let defaultOrderedItems: [HomeBarItemKind] = [
+        .feeds, .podcasts, .bluesky, .instagram, .mastodon, .note,
+        .pixelfed, .reddit, .substack, .vimeo, .x, .youtube, .niconico, .lists, .topics
+    ]
+
     static let `default` = HomeBarConfiguration(
-        orderedItems: [.following, .feedSections, .lists],
-        enabledItems: [.following, .feedSections, .lists],
+        orderedItems: defaultOrderedItems,
+        enabledItems: Set(defaultOrderedItems.filter { $0 != .topics }),
         topicCount: .top3
     )
 
@@ -46,8 +53,77 @@ struct HomeBarConfiguration: Codable, Equatable, Hashable, Sendable {
         }
         return HomeBarConfiguration(
             orderedItems: ordered,
-            enabledItems: enabledItems,
+            enabledItems: enabledItems.intersection(HomeBarItemKind.allCases),
             topicCount: topicCount
         )
+    }
+}
+
+extension HomeBarConfiguration: Codable {
+
+    private enum CodingKeys: String, CodingKey {
+        case orderedItems, enabledItems, topicCount
+    }
+
+    /// Pre-existing rawValue for the legacy aggregate "feed sections" item.
+    private static let legacyFeedSectionsRaw = "feedSections"
+    /// Pre-existing rawValue for the legacy "following" item, now implicit.
+    private static let legacyFollowingRaw = "following"
+    /// Order to insert per-section items when migrating a legacy
+    /// `feedSections` placeholder.
+    private static let legacyFeedSectionExpansion: [HomeBarItemKind] = [
+        .feeds, .podcasts, .bluesky, .instagram, .mastodon, .note,
+        .pixelfed, .reddit, .substack, .vimeo, .x, .youtube, .niconico
+    ]
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let rawOrdered = (try? container.decode([String].self, forKey: .orderedItems)) ?? []
+        let rawEnabled = (try? container.decode([String].self, forKey: .enabledItems)) ?? []
+        let topicCount = (try? container.decode(HomeBarTopicCount.self, forKey: .topicCount)) ?? .top3
+
+        var ordered: [HomeBarItemKind] = []
+        var seenOrdered = Set<HomeBarItemKind>()
+        for raw in rawOrdered {
+            switch raw {
+            case Self.legacyFollowingRaw:
+                continue
+            case Self.legacyFeedSectionsRaw:
+                for kind in Self.legacyFeedSectionExpansion where !seenOrdered.contains(kind) {
+                    ordered.append(kind)
+                    seenOrdered.insert(kind)
+                }
+            default:
+                if let kind = HomeBarItemKind(rawValue: raw), !seenOrdered.contains(kind) {
+                    ordered.append(kind)
+                    seenOrdered.insert(kind)
+                }
+            }
+        }
+
+        var enabled = Set<HomeBarItemKind>()
+        for raw in rawEnabled {
+            switch raw {
+            case Self.legacyFollowingRaw:
+                continue
+            case Self.legacyFeedSectionsRaw:
+                Self.legacyFeedSectionExpansion.forEach { enabled.insert($0) }
+            default:
+                if let kind = HomeBarItemKind(rawValue: raw) {
+                    enabled.insert(kind)
+                }
+            }
+        }
+
+        self.orderedItems = ordered
+        self.enabledItems = enabled
+        self.topicCount = topicCount
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(orderedItems.map(\.rawValue), forKey: .orderedItems)
+        try container.encode(enabledItems.map(\.rawValue), forKey: .enabledItems)
+        try container.encode(topicCount, forKey: .topicCount)
     }
 }

--- a/App/Structs/HomeBarConfiguration.swift
+++ b/App/Structs/HomeBarConfiguration.swift
@@ -29,7 +29,7 @@ struct HomeBarConfiguration: Codable, Equatable, Hashable, Sendable {
 
     func save() {
         guard let data = try? JSONEncoder().encode(self) else { return }
-        UserDefaults.standard.set(data, forKey: storageKey)
+        UserDefaults.standard.set(data, forKey: Self.storageKey)
     }
 
     /// Ensures every kind appears exactly once in the ordered list, appending

--- a/App/Structs/HomeBarConfiguration.swift
+++ b/App/Structs/HomeBarConfiguration.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+extension Notification.Name {
+    static let homeBarConfigurationDidChange = Notification.Name("HomeBarConfigurationDidChange")
+}
+
+/// User-configurable layout of the home section selection bar.
+struct HomeBarConfiguration: Codable, Equatable, Hashable, Sendable {
+
+    static let storageKey = "Home.BarConfiguration"
+
+    var orderedItems: [HomeBarItemKind]
+    var enabledItems: Set<HomeBarItemKind>
+    var topicCount: HomeBarTopicCount
+
+    static let `default` = HomeBarConfiguration(
+        orderedItems: [.following, .feedSections, .lists],
+        enabledItems: [.following, .feedSections, .lists],
+        topicCount: .top3
+    )
+
+    static func load() -> HomeBarConfiguration {
+        guard let data = UserDefaults.standard.data(forKey: storageKey),
+              let decoded = try? JSONDecoder().decode(HomeBarConfiguration.self, from: data) else {
+            return .default
+        }
+        return decoded.normalized()
+    }
+
+    func save() {
+        guard let data = try? JSONEncoder().encode(self) else { return }
+        UserDefaults.standard.set(data, forKey: storageKey)
+    }
+
+    /// Ensures every kind appears exactly once in the ordered list, appending
+    /// any missing kinds at the end so newer item types remain reachable.
+    func normalized() -> HomeBarConfiguration {
+        var seen = Set<HomeBarItemKind>()
+        var ordered: [HomeBarItemKind] = []
+        for kind in orderedItems where !seen.contains(kind) {
+            ordered.append(kind)
+            seen.insert(kind)
+        }
+        for kind in HomeBarItemKind.allCases where !seen.contains(kind) {
+            ordered.append(kind)
+        }
+        return HomeBarConfiguration(
+            orderedItems: ordered,
+            enabledItems: enabledItems,
+            topicCount: topicCount
+        )
+    }
+}

--- a/App/View Modifiers/SakuraBackground.swift
+++ b/App/View Modifiers/SakuraBackground.swift
@@ -4,18 +4,10 @@ private struct FeedBackgroundColorsKey: EnvironmentKey {
     static let defaultValue: [Color] = []
 }
 
-private struct FeedBackgroundScrollOffsetKey: EnvironmentKey {
-    static let defaultValue: CGFloat = 0
-}
-
 extension EnvironmentValues {
     var feedBackgroundColors: [Color] {
         get { self[FeedBackgroundColorsKey.self] }
         set { self[FeedBackgroundColorsKey.self] = newValue }
-    }
-    var feedBackgroundScrollOffset: CGFloat {
-        get { self[FeedBackgroundScrollOffsetKey.self] }
-        set { self[FeedBackgroundScrollOffsetKey.self] = newValue }
     }
 }
 
@@ -23,7 +15,6 @@ struct SakuraBackground: ViewModifier {
 
     @AppStorage("Display.SakuraBackground") private var sakuraBackgroundEnabled: Bool = true
     @Environment(\.feedBackgroundColors) private var feedColors
-    @Environment(\.feedBackgroundScrollOffset) private var feedScrollOffset
 
     @ViewBuilder
     func body(content: Content) -> some View {
@@ -43,7 +34,6 @@ struct SakuraBackground: ViewModifier {
                         if !feedColors.isEmpty {
                             FeedHeaderGradientView(colors: feedColors)
                                 .frame(height: 360)
-                                .offset(y: -max(0, feedScrollOffset))
                         }
                     }
                     .ignoresSafeArea()
@@ -54,7 +44,6 @@ struct SakuraBackground: ViewModifier {
                     if !feedColors.isEmpty {
                         FeedHeaderGradientView(colors: feedColors)
                             .frame(height: 360)
-                            .offset(y: -max(0, feedScrollOffset))
                             .ignoresSafeArea(edges: [.top, .horizontal])
                     }
                 }

--- a/App/Views/Feed/Display Styles/Compact/CompactStyleView.swift
+++ b/App/Views/Feed/Display Styles/Compact/CompactStyleView.swift
@@ -43,6 +43,8 @@ struct CompactStyleView: View {
                 .listRowBackground(Color.clear)
                 .listRowInsets(EdgeInsets(top: 6, leading: 16, bottom: 6, trailing: 16))
                 .listRowSpacing(0.0)
+                .listRowSeparator(.hidden, edges: .top)
+                .listRowSeparator(.visible, edges: .bottom)
                 .contextMenu {
                     Button {
                         feedManager.toggleRead(article)

--- a/App/Views/Feed/Display Styles/Grid/GridStyleView.swift
+++ b/App/Views/Feed/Display Styles/Grid/GridStyleView.swift
@@ -20,44 +20,49 @@ struct GridStyleView: View {
 
     var body: some View {
         ScrollView(.vertical) {
-            if let headerView {
-                headerView
-            }
-            LazyVGrid(columns: columns, spacing: 2) {
-                ForEach(articlesWithImages) { article in
-                    ArticleLink(article: article, label: {
-                        GridArticleCell(article: article)
-                            .zoomSource(id: article.id, namespace: zoomNamespace)
-                            .markReadOnScroll(article: article)
-                    })
-                    .buttonStyle(.plain)
-                    .contextMenu {
-                        Button {
-                            feedManager.toggleRead(article)
-                        } label: {
-                            Label(
-                                feedManager.isRead(article)
-                                    ? String(localized: "Article.MarkUnread", table: "Articles")
-                                    : String(localized: "Article.MarkRead", table: "Articles"),
-                                systemImage: feedManager.isRead(article)
-                                    ? "envelope" : "envelope.open"
-                            )
-                        }
-                        Divider()
-                        if let shareURL = URL(string: article.url) {
-                            ShareLink(item: shareURL) {
-                                Label(String(localized: "Article.Share", table: "Articles"),
-                                      systemImage: "square.and.arrow.up")
+            LazyVStack(spacing: 12) {
+                if let headerView {
+                    headerView
+                }
+                LazyVGrid(columns: columns, spacing: 2) {
+                    ForEach(articlesWithImages) { article in
+                        ArticleLink(article: article, label: {
+                            GridArticleCell(article: article)
+                                .zoomSource(id: article.id, namespace: zoomNamespace)
+                                .markReadOnScroll(article: article)
+                        })
+                        .buttonStyle(.plain)
+                        .contextMenu {
+                            Button {
+                                feedManager.toggleRead(article)
+                            } label: {
+                                Label(
+                                    feedManager.isRead(article)
+                                        ? String(localized: "Article.MarkUnread", table: "Articles")
+                                        : String(localized: "Article.MarkRead", table: "Articles"),
+                                    systemImage: feedManager.isRead(article)
+                                        ? "envelope" : "envelope.open"
+                                )
+                            }
+                            Divider()
+                            if let shareURL = URL(string: article.url) {
+                                ShareLink(item: shareURL) {
+                                    Label(String(localized: "Article.Share", table: "Articles"),
+                                          systemImage: "square.and.arrow.up")
+                                }
                             }
                         }
                     }
                 }
+                .padding(.horizontal, 2)
+                .padding(.top, headerView == nil ? 12 : 0)
+                if let onLoadMore {
+                    LoadPreviousArticlesButton(action: onLoadMore, articleCount: articles.count)
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 12)
+                }
             }
-            if let onLoadMore {
-                LoadPreviousArticlesButton(action: onLoadMore, articleCount: articles.count)
-                    .padding(.horizontal, 16)
-                    .padding(.vertical, 12)
-            }
+            .padding(.bottom)
         }
         .trackScrollActivity()
     }

--- a/App/Views/Feed/Display Styles/Magazine/MagazineArticleCard.swift
+++ b/App/Views/Feed/Display Styles/Magazine/MagazineArticleCard.swift
@@ -26,6 +26,10 @@ struct MagazineArticleCard: View {
                         }
                         .clipped()
                         .clipShape(.rect(cornerRadius: 12))
+                        .overlay {
+                            RoundedRectangle(cornerRadius: 12)
+                                .stroke(.quaternary, lineWidth: 0.5)
+                        }
                 } else {
                     magazineFallbackBackground
                 }

--- a/App/Views/Feed/Display Styles/Magazine/MagazineStyleView.swift
+++ b/App/Views/Feed/Display Styles/Magazine/MagazineStyleView.swift
@@ -54,6 +54,7 @@ struct MagazineStyleView: View {
                     }
                 }
                 .padding(.horizontal, 16)
+                .padding(.top, headerView == nil ? 12 : 0)
                 if let onLoadMore {
                     LoadPreviousArticlesButton(action: onLoadMore, articleCount: articles.count)
                         .padding(.horizontal, 16)

--- a/App/Views/Feed/Display Styles/Masonry/MasonryArticleCard.swift
+++ b/App/Views/Feed/Display Styles/Masonry/MasonryArticleCard.swift
@@ -78,12 +78,6 @@ struct MasonryArticleCard: View {
 
                 Spacer(minLength: 0)
             }
-
-            if let date = article.publishedDate {
-                RelativeTimeText(date: date)
-                    .font(.caption2)
-                    .foregroundStyle(.tertiary)
-            }
         }
         .contentShape(.rect)
         .shadow(color: .black.opacity(0.05), radius: 2, y: 1)

--- a/App/Views/Feed/Display Styles/Masonry/MasonryArticleCard.swift
+++ b/App/Views/Feed/Display Styles/Masonry/MasonryArticleCard.swift
@@ -43,6 +43,10 @@ struct MasonryArticleCard: View {
                         }
                         .clipped()
                         .clipShape(.rect(cornerRadius: 12))
+                        .overlay {
+                            RoundedRectangle(cornerRadius: 12)
+                                .stroke(.quaternary, lineWidth: 0.5)
+                        }
                 } else {
                     masonryFallbackBackground
                 }

--- a/App/Views/Feed/Display Styles/Masonry/MasonryStyleView.swift
+++ b/App/Views/Feed/Display Styles/Masonry/MasonryStyleView.swift
@@ -65,6 +65,7 @@ struct MasonryStyleView: View {
                     }
                 }
                 .padding(.horizontal, 16)
+                .padding(.top, headerView == nil ? 12 : 0)
                 if let onLoadMore {
                     LoadPreviousArticlesButton(action: onLoadMore, articleCount: articles.count)
                         .padding(.horizontal, 16)

--- a/App/Views/Feed/Display Styles/Timeline/TimelineStyleView.swift
+++ b/App/Views/Feed/Display Styles/Timeline/TimelineStyleView.swift
@@ -57,6 +57,8 @@ struct TimelineStyleView: View {
             }
         }
         .listStyle(.plain)
+        .listSectionSpacing(.compact)
+        .environment(\.defaultMinListHeaderHeight, 0)
         .trackScrollActivity()
     }
 

--- a/App/Views/Feed/Display Styles/Video/VideoStyleView.swift
+++ b/App/Views/Feed/Display Styles/Video/VideoStyleView.swift
@@ -16,7 +16,7 @@ struct VideoStyleView: View {
 
     var body: some View {
         ScrollView(.vertical) {
-            LazyVStack(spacing: 24) {
+            LazyVStack(spacing: 12) {
                 if let headerView {
                     headerView
                 }
@@ -39,6 +39,7 @@ struct VideoStyleView: View {
                             .markReadOnScroll(article: article)
                     }
                     .buttonStyle(.plain)
+                    .contentShape(.rect)
                     .contextMenu {
                         Button {
                             feedManager.toggleRead(article)

--- a/App/Views/Feed/Display Styles/Video/VideoStyleView.swift
+++ b/App/Views/Feed/Display Styles/Video/VideoStyleView.swift
@@ -76,13 +76,13 @@ struct VideoStyleView: View {
                         }
                     }
                 }
+                if let onLoadMore {
+                    LoadPreviousArticlesButton(action: onLoadMore, articleCount: articles.count)
+                        .padding(.horizontal, 16)
+                }
             }
+            .padding(.top, headerView == nil ? 12 : 0)
             .padding(.bottom)
-            if let onLoadMore {
-                LoadPreviousArticlesButton(action: onLoadMore, articleCount: articles.count)
-                    .padding(.horizontal, 16)
-                    .padding(.bottom)
-            }
         }
         .trackScrollActivity()
         .sheet(isPresented: $showSafari) {

--- a/App/Views/Feed/FeedArticlesView.swift
+++ b/App/Views/Feed/FeedArticlesView.swift
@@ -18,7 +18,6 @@ struct FeedArticlesView: View {
     @State private var hasScrolledPastTitle: Bool = false
     @State private var effectiveDisplayStyle: FeedDisplayStyle?
     @State private var prominentColors: [Color] = []
-    @State private var scrollOffset: CGFloat = 0
 
     private var batchingMode: BatchingMode {
         DoomscrollingMode.effectiveBatchingMode(storedBatchingMode)
@@ -165,7 +164,6 @@ struct FeedArticlesView: View {
             effectiveStyleBinding: $effectiveDisplayStyle
         )
         .environment(\.feedBackgroundColors, prominentColors)
-        .environment(\.feedBackgroundScrollOffset, scrollOffset)
         .toolbar {
             ToolbarItem(placement: .principal) {
                 VStack(spacing: 0) {
@@ -193,11 +191,9 @@ struct FeedArticlesView: View {
                 .animation(.smooth.speed(2.0), value: showsPrincipalTitle)
             }
         }
-        .onScrollGeometryChange(for: CGFloat.self) { geo in
-            geo.contentOffset.y
-        } action: { _, newValue in
-            scrollOffset = newValue
-            let scrolled = newValue > 90
+        .onScrollGeometryChange(for: Bool.self) { geo in
+            geo.contentOffset.y > 90
+        } action: { _, scrolled in
             guard scrolled != hasScrolledPastTitle else { return }
             withAnimation(.smooth.speed(2.0)) {
                 hasScrolledPastTitle = scrolled

--- a/App/Views/Feed/FeedArticlesView.swift
+++ b/App/Views/Feed/FeedArticlesView.swift
@@ -168,7 +168,8 @@ struct FeedArticlesView: View {
             ToolbarItem(placement: .principal) {
                 VStack(spacing: 0) {
                     Text(currentFeed.title)
-                        .font(.headline)
+                        .font(.subheadline)
+                        .fontWeight(.semibold)
                     if !currentFeed.domain.isEmpty {
                         Text(currentFeed.domain)
                             .font(.caption2)

--- a/App/Views/Following/FeedGridCell.swift
+++ b/App/Views/Following/FeedGridCell.swift
@@ -48,16 +48,18 @@ struct FeedGridCell: View {
                         FaviconProgressBadge(
                             lastFetched: feed.lastFetched,
                             cooldown: FeedManager.xRefreshInterval,
-                            size: 15
+                            size: iconSize,
+                            isCircle: feed.isCircleIcon,
+                            cornerRadius: iconCornerRadius
                         )
-                        .offset(x: 3, y: 3)
                     } else if feed.isInstagramFeed {
                         FaviconProgressBadge(
                             lastFetched: feed.lastFetched,
                             cooldown: FeedManager.instagramRefreshInterval,
-                            size: 15
+                            size: iconSize,
+                            isCircle: feed.isCircleIcon,
+                            cornerRadius: iconCornerRadius
                         )
-                        .offset(x: 3, y: 3)
                     }
                 }
                 .frame(width: iconSize, height: iconSize)

--- a/App/Views/Following/FeedRowView.swift
+++ b/App/Views/Following/FeedRowView.swift
@@ -41,16 +41,18 @@ struct FeedRowView: View {
                     FaviconProgressBadge(
                         lastFetched: feed.lastFetched,
                         cooldown: FeedManager.xRefreshInterval,
-                        size: 13
+                        size: 32,
+                        isCircle: feed.isCircleIcon,
+                        cornerRadius: iconCornerRadius
                     )
-                    .offset(x: 3, y: 3)
                 } else if feed.isInstagramFeed {
                     FaviconProgressBadge(
                         lastFetched: feed.lastFetched,
                         cooldown: FeedManager.instagramRefreshInterval,
-                        size: 13
+                        size: 32,
+                        isCircle: feed.isCircleIcon,
+                        cornerRadius: iconCornerRadius
                     )
-                    .offset(x: 3, y: 3)
                 }
             }
             .frame(width: 32, height: 32)

--- a/App/Views/Home/All Articles/AllArticlesView+Sections.swift
+++ b/App/Views/Home/All Articles/AllArticlesView+Sections.swift
@@ -19,6 +19,9 @@ extension AllArticlesView {
             if !feedManager.lists.contains(where: { $0.id == id }) {
                 selectedSelection = .section(.all)
             }
+        case .topic:
+            // Validated against the dynamic top-N list at the HomeView level.
+            break
         }
     }
 }

--- a/App/Views/Home/All Articles/AllArticlesView.swift
+++ b/App/Views/Home/All Articles/AllArticlesView.swift
@@ -24,6 +24,8 @@ struct AllArticlesView: View {
         case .list(let id):
             return feedManager.lists.first { $0.id == id }?.name
                 ?? String(localized: "Shared.AllArticles")
+        case .topic(let name):
+            return name
         }
     }
 
@@ -36,6 +38,8 @@ struct AllArticlesView: View {
                 return .list(list)
             }
             return .section(nil)
+        case .topic(let name):
+            return .topic(name)
         }
     }
 }

--- a/App/Views/Home/HomeSectionView.swift
+++ b/App/Views/Home/HomeSectionView.swift
@@ -1,11 +1,12 @@
 import SwiftUI
 
-/// Source of articles for `HomeSectionView`. Modeling section and list together
-/// keeps the view type stable across selection changes so safeAreaInset content
-/// (the Today tab bar) doesn't get torn down when switching modes.
+/// Source of articles for `HomeSectionView`. Modeling section, list, and topic
+/// together keeps the view type stable across selection changes so safeAreaInset
+/// content (the Today tab bar) doesn't get torn down when switching modes.
 enum HomeContentSource: Hashable {
     case section(FeedSection?)
     case list(FeedList)
+    case topic(String)
 }
 
 struct HomeSectionView: View {
@@ -24,6 +25,10 @@ struct HomeSectionView: View {
 
     init(list: FeedList) {
         self.source = .list(list)
+    }
+
+    init(topic: String) {
+        self.source = .topic(topic)
     }
 
     @AppStorage("Articles.BatchingMode") private var storedBatchingMode: BatchingMode = .items25
@@ -108,6 +113,11 @@ struct HomeSectionView: View {
         case .list(let list):
             preloadedEntries = feedManager.preloadedArticleEntries(
                 for: list,
+                requireUnread: hideViewedContent
+            )
+        case .topic(let name):
+            preloadedEntries = feedManager.preloadedArticleEntries(
+                forTopic: name,
                 requireUnread: hideViewedContent
             )
         }
@@ -197,6 +207,8 @@ struct HomeSectionView: View {
             return section?.localizedTitle ?? HomeSection.all.localizedTitle
         case .list(let list):
             return list.name
+        case .topic(let name):
+            return name
         }
     }
 
@@ -207,6 +219,8 @@ struct HomeSectionView: View {
             return "all"
         case .list(let list):
             return "list.\(list.id)"
+        case .topic(let name):
+            return "topic.\(name)"
         }
     }
 
@@ -217,6 +231,8 @@ struct HomeSectionView: View {
             return "section.all"
         case .list(let list):
             return "list.\(list.id)"
+        case .topic(let name):
+            return "topic.\(name)"
         }
     }
 
@@ -227,6 +243,8 @@ struct HomeSectionView: View {
             return feedManager.feeds.filter { $0.feedSection == section }
         case .list(let list):
             return feedManager.feeds(for: list)
+        case .topic:
+            return feedManager.feeds
         }
     }
 
@@ -256,6 +274,10 @@ struct HomeSectionView: View {
             }
         case .list(let list):
             feedManager.markAllRead(for: list)
+        case .topic:
+            for article in rawArticles where !feedManager.isRead(article) {
+                feedManager.markRead(article)
+            }
         }
     }
 

--- a/App/Views/Home/HomeView.swift
+++ b/App/Views/Home/HomeView.swift
@@ -17,6 +17,8 @@ struct HomeView: View {
     @State private var pendingYouTubeSafariURL: URL?
     @State private var isShowingMarkAllReadConfirmation = false
     @State private var tabFrames: [String: CGRect] = [:]
+    @State private var topTopics: [String] = []
+    @State private var barConfiguration: HomeBarConfiguration = .load()
     @Namespace private var cardZoom
 
     var body: some View {
@@ -38,8 +40,6 @@ struct HomeView: View {
                         Text(principalText)
                             .font(.caption)
                             .foregroundStyle(.secondary)
-                            .contentTransition(.numericText())
-                            .animation(.smooth, value: principalText)
                     }
                     if markAllReadPosition == .top {
                         ToolbarItemGroup(placement: .topBarLeading) {
@@ -163,6 +163,15 @@ struct HomeView: View {
             // before this view mounts, so `onChange` would never fire.
             handlePendingOpenRequestIfNeeded()
         }
+        .task(id: barConfiguration) {
+            await loadTopTopicsIfNeeded()
+        }
+        .onChange(of: feedManager.dataRevision) {
+            Task { await loadTopTopicsIfNeeded() }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .homeBarConfigurationDidChange)) { _ in
+            reloadBarConfiguration()
+        }
     }
 
     private var principalText: String {
@@ -191,6 +200,8 @@ struct HomeView: View {
             return "section.all"
         case .list(let id):
             return "list.\(id)"
+        case .topic(let name):
+            return "topic.\(name)"
         }
     }
 
@@ -222,6 +233,12 @@ struct HomeView: View {
             if let list = feedManager.lists.first(where: { $0.id == id }) {
                 feedManager.markAllRead(for: list)
             }
+        case .topic(let name):
+            let entries = feedManager.preloadedArticleEntries(forTopic: name)
+            let articles = feedManager.articles(withPreloadedIDs: entries.map(\.id))
+            for article in articles where !feedManager.isRead(article) {
+                feedManager.markRead(article)
+            }
         }
     }
 
@@ -233,7 +250,43 @@ struct HomeView: View {
     }
 
     private var tabItems: [TodayTabItem] {
-        TodayTabItem.items(sections: availableSections, lists: feedManager.lists)
+        TodayTabItem.items(
+            sections: availableSections,
+            lists: feedManager.lists,
+            topics: topTopics,
+            configuration: barConfiguration
+        )
+    }
+
+    private func reloadBarConfiguration() {
+        barConfiguration = .load()
+    }
+
+    private func loadTopTopicsIfNeeded() async {
+        guard barConfiguration.enabledItems.contains(.topics) else {
+            topTopics = []
+            validateTopicSelection()
+            return
+        }
+        let limit = barConfiguration.topicCount.rawValue
+        let database = DatabaseManager.shared
+        let topics: [String] = await Task.detached {
+            let sevenDaysAgo = Date().addingTimeInterval(-7 * 24 * 3600)
+            let results = (try? database.topEntities(
+                types: ["organization", "place"],
+                since: sevenDaysAgo,
+                limit: limit
+            )) ?? []
+            return results.map(\.name)
+        }.value
+        topTopics = topics
+        validateTopicSelection()
+    }
+
+    private func validateTopicSelection() {
+        if case .topic(let name) = selectedSelection, !topTopics.contains(name) {
+            selectedSelection = .section(.all)
+        }
     }
 
     private func handlePendingOpenRequestIfNeeded() {

--- a/App/Views/Home/Today/TodayTabBar.swift
+++ b/App/Views/Home/Today/TodayTabBar.swift
@@ -14,6 +14,7 @@ struct TodayTabBar: View {
         switch selection {
         case .section(let section): section.tabAccentColor
         case .list: .accentColor
+        case .topic: .accentColor
         }
     }
 

--- a/App/Views/Home/Today/TodayTabItem+Builder.swift
+++ b/App/Views/Home/Today/TodayTabItem+Builder.swift
@@ -9,32 +9,25 @@ extension TodayTabItem {
         configuration: HomeBarConfiguration
     ) -> [TodayTabItem] {
         var items: [TodayTabItem] = []
+
+        if sections.contains(.all) {
+            items.append(item(for: .all))
+        }
+
         for kind in configuration.orderedItems where configuration.enabledItems.contains(kind) {
             switch kind {
-            case .following:
-                if sections.contains(.all) {
-                    items.append(item(for: .all))
-                }
-            case .feedSections:
-                items.append(contentsOf: feedSectionItems(from: sections))
             case .lists:
                 items.append(contentsOf: lists.map(item(for:)))
             case .topics:
                 items.append(contentsOf: topics.map(topicItem(name:)))
+            default:
+                if let homeSection = HomeSection(rawValue: kind.rawValue),
+                   sections.contains(homeSection) {
+                    items.append(item(for: homeSection))
+                }
             }
         }
         return items
-    }
-
-    private static func feedSectionItems(from sections: [HomeSection]) -> [TodayTabItem] {
-        let primaryOrder: [HomeSection] = [.feeds, .podcasts]
-        let primary = primaryOrder.filter { sections.contains($0) }
-        let others = sections
-            .filter { $0 != .all && !primaryOrder.contains($0) }
-            .sorted { lhs, rhs in
-                lhs.localizedTitle.localizedCompare(rhs.localizedTitle) == .orderedAscending
-            }
-        return (primary + others).map(item(for:))
     }
 
     private static func item(for section: HomeSection) -> TodayTabItem {

--- a/App/Views/Home/Today/TodayTabItem+Builder.swift
+++ b/App/Views/Home/Today/TodayTabItem+Builder.swift
@@ -4,36 +4,61 @@ extension TodayTabItem {
 
     static func items(
         sections: [HomeSection],
-        lists: [FeedList]
+        lists: [FeedList],
+        topics: [String],
+        configuration: HomeBarConfiguration
     ) -> [TodayTabItem] {
-        let primaryOrder: [HomeSection] = [.all, .feeds, .podcasts]
+        var items: [TodayTabItem] = []
+        for kind in configuration.orderedItems where configuration.enabledItems.contains(kind) {
+            switch kind {
+            case .following:
+                if sections.contains(.all) {
+                    items.append(item(for: .all))
+                }
+            case .feedSections:
+                items.append(contentsOf: feedSectionItems(from: sections))
+            case .lists:
+                items.append(contentsOf: lists.map(item(for:)))
+            case .topics:
+                items.append(contentsOf: topics.map(topicItem(name:)))
+            }
+        }
+        return items
+    }
+
+    private static func feedSectionItems(from sections: [HomeSection]) -> [TodayTabItem] {
+        let primaryOrder: [HomeSection] = [.feeds, .podcasts]
         let primary = primaryOrder.filter { sections.contains($0) }
         let others = sections
-            .filter { !primaryOrder.contains($0) }
+            .filter { $0 != .all && !primaryOrder.contains($0) }
             .sorted { lhs, rhs in
                 lhs.localizedTitle.localizedCompare(rhs.localizedTitle) == .orderedAscending
             }
+        return (primary + others).map(item(for:))
+    }
 
-        var items: [TodayTabItem] = []
-        for section in primary + others {
-            items.append(
-                TodayTabItem(
-                    id: HomeSelection.section(section).rawValue,
-                    title: section.todayTabTitle,
-                    selection: .section(section)
-                )
-            )
-        }
-        for list in lists {
-            items.append(
-                TodayTabItem(
-                    id: HomeSelection.list(list.id).rawValue,
-                    title: list.name,
-                    selection: .list(list.id)
-                )
-            )
-        }
-        return items
+    private static func item(for section: HomeSection) -> TodayTabItem {
+        TodayTabItem(
+            id: HomeSelection.section(section).rawValue,
+            title: section.todayTabTitle,
+            selection: .section(section)
+        )
+    }
+
+    private static func item(for list: FeedList) -> TodayTabItem {
+        TodayTabItem(
+            id: HomeSelection.list(list.id).rawValue,
+            title: list.name,
+            selection: .list(list.id)
+        )
+    }
+
+    private static func topicItem(name: String) -> TodayTabItem {
+        TodayTabItem(
+            id: HomeSelection.topic(name).rawValue,
+            title: name,
+            selection: .topic(name)
+        )
     }
 }
 

--- a/App/Views/Profile/MoreView.swift
+++ b/App/Views/Profile/MoreView.swift
@@ -29,21 +29,21 @@ struct MoreView: View {
 
                 Section {
                     NavigationLink {
-                        HomeSettingsView()
-                    } label: {
-                        SettingsIconLabel(
-                            String(localized: "Section.Home", table: "Settings"),
-                            systemImage: "newspaper",
-                            color: .red
-                        )
-                    }
-                    NavigationLink {
                         AppearanceSettingsView()
                     } label: {
                         SettingsIconLabel(
                             String(localized: "Section.Appearance", table: "Settings"),
                             systemImage: "paintpalette.fill",
                             color: .orange
+                        )
+                    }
+                    NavigationLink {
+                        HomeSettingsView()
+                    } label: {
+                        SettingsIconLabel(
+                            String(localized: "Section.Home", table: "Settings"),
+                            systemImage: "newspaper.fill",
+                            color: .red
                         )
                     }
                     NavigationLink {

--- a/App/Views/Profile/MoreView.swift
+++ b/App/Views/Profile/MoreView.swift
@@ -29,6 +29,15 @@ struct MoreView: View {
 
                 Section {
                     NavigationLink {
+                        HomeSettingsView()
+                    } label: {
+                        SettingsIconLabel(
+                            String(localized: "Section.Home", table: "Settings"),
+                            systemImage: "house.fill",
+                            color: .red
+                        )
+                    }
+                    NavigationLink {
                         AppearanceSettingsView()
                     } label: {
                         SettingsIconLabel(

--- a/App/Views/Profile/MoreView.swift
+++ b/App/Views/Profile/MoreView.swift
@@ -33,7 +33,7 @@ struct MoreView: View {
                     } label: {
                         SettingsIconLabel(
                             String(localized: "Section.Home", table: "Settings"),
-                            systemImage: "house.fill",
+                            systemImage: "newspaper",
                             color: .red
                         )
                     }

--- a/App/Views/Profile/Settings/HomeSettingsView.swift
+++ b/App/Views/Profile/Settings/HomeSettingsView.swift
@@ -2,13 +2,14 @@ import SwiftUI
 
 struct HomeSettingsView: View {
 
+    @Environment(FeedManager.self) var feedManager
     @State private var configuration: HomeBarConfiguration = .load()
     @State private var editMode: EditMode = .active
 
     var body: some View {
         List {
             Section {
-                ForEach(configuration.orderedItems, id: \.self) { kind in
+                ForEach(visibleItems, id: \.self) { kind in
                     HomeBarItemRow(
                         kind: kind,
                         isEnabled: enabledBinding(for: kind)
@@ -47,8 +48,31 @@ struct HomeSettingsView: View {
         }
     }
 
+    /// Filters out per-section items the user has no feeds for, while
+    /// preserving order so hidden items keep their saved positions.
+    private var visibleItems: [HomeBarItemKind] {
+        configuration.orderedItems.filter(isVisible)
+    }
+
+    private func isVisible(_ kind: HomeBarItemKind) -> Bool {
+        guard let feedSection = kind.feedSection else { return true }
+        return feedManager.hasFeeds(for: feedSection)
+    }
+
     private func move(from source: IndexSet, to destination: Int) {
-        configuration.orderedItems.move(fromOffsets: source, toOffset: destination)
+        var newVisible = visibleItems
+        newVisible.move(fromOffsets: source, toOffset: destination)
+
+        var visibleIndices: [Int] = []
+        for (index, kind) in configuration.orderedItems.enumerated() where isVisible(kind) {
+            visibleIndices.append(index)
+        }
+
+        var newOrdered = configuration.orderedItems
+        for (visibleIndex, absoluteIndex) in visibleIndices.enumerated() {
+            newOrdered[absoluteIndex] = newVisible[visibleIndex]
+        }
+        configuration.orderedItems = newOrdered
     }
 
     private func enabledBinding(for kind: HomeBarItemKind) -> Binding<Bool> {
@@ -79,7 +103,7 @@ private struct HomeBarItemRow: View {
 
     var body: some View {
         Toggle(isOn: $isEnabled) {
-            Label(kind.localizedTitle, systemImage: kind.systemImage)
+            Text(kind.localizedTitle)
         }
     }
 }

--- a/App/Views/Profile/Settings/HomeSettingsView.swift
+++ b/App/Views/Profile/Settings/HomeSettingsView.swift
@@ -81,6 +81,5 @@ private struct HomeBarItemRow: View {
         Toggle(isOn: $isEnabled) {
             Label(kind.localizedTitle, systemImage: kind.systemImage)
         }
-        .tint(.accent)
     }
 }

--- a/App/Views/Profile/Settings/HomeSettingsView.swift
+++ b/App/Views/Profile/Settings/HomeSettingsView.swift
@@ -1,0 +1,86 @@
+import SwiftUI
+
+struct HomeSettingsView: View {
+
+    @State private var configuration: HomeBarConfiguration = .load()
+    @State private var editMode: EditMode = .active
+
+    var body: some View {
+        List {
+            Section {
+                ForEach(configuration.orderedItems, id: \.self) { kind in
+                    HomeBarItemRow(
+                        kind: kind,
+                        isEnabled: enabledBinding(for: kind)
+                    )
+                }
+                .onMove(perform: move)
+            } header: {
+                Text(String(localized: "Home.SectionBar.Title", table: "Settings"))
+            } footer: {
+                Text(String(localized: "Home.SectionBar.Footer", table: "Settings"))
+            }
+
+            if configuration.enabledItems.contains(.topics) {
+                Section {
+                    Picker(
+                        String(localized: "Home.Topics.Count", table: "Settings"),
+                        selection: topicCountBinding
+                    ) {
+                        ForEach(HomeBarTopicCount.allCases) { option in
+                            Text(option.localizedTitle).tag(option)
+                        }
+                    }
+                } header: {
+                    Text(String(localized: "Home.BarItem.Topics", table: "Settings"))
+                }
+            }
+        }
+        .listStyle(.insetGrouped)
+        .sakuraBackground()
+        .environment(\.editMode, $editMode)
+        .navigationTitle(String(localized: "Section.Home", table: "Settings"))
+        .toolbarTitleDisplayMode(.inline)
+        .onChange(of: configuration) { _, newValue in
+            newValue.save()
+            NotificationCenter.default.post(name: .homeBarConfigurationDidChange, object: nil)
+        }
+    }
+
+    private func move(from source: IndexSet, to destination: Int) {
+        configuration.orderedItems.move(fromOffsets: source, toOffset: destination)
+    }
+
+    private func enabledBinding(for kind: HomeBarItemKind) -> Binding<Bool> {
+        Binding(
+            get: { configuration.enabledItems.contains(kind) },
+            set: { isOn in
+                if isOn {
+                    configuration.enabledItems.insert(kind)
+                } else {
+                    configuration.enabledItems.remove(kind)
+                }
+            }
+        )
+    }
+
+    private var topicCountBinding: Binding<HomeBarTopicCount> {
+        Binding(
+            get: { configuration.topicCount },
+            set: { configuration.topicCount = $0 }
+        )
+    }
+}
+
+private struct HomeBarItemRow: View {
+
+    let kind: HomeBarItemKind
+    @Binding var isEnabled: Bool
+
+    var body: some View {
+        Toggle(isOn: $isEnabled) {
+            Label(kind.localizedTitle, systemImage: kind.systemImage)
+        }
+        .tint(.accent)
+    }
+}

--- a/App/Views/Shared/CachedAsyncImage.swift
+++ b/App/Views/Shared/CachedAsyncImage.swift
@@ -70,6 +70,7 @@ struct CachedAsyncImage<Placeholder: View>: View {
                     .clipped()
             }
         }
+        .contentShape(.rect)
         .transaction { transaction in
             transaction.animation = nil
             transaction.disablesAnimations = true

--- a/App/Views/Shared/FaviconProgressBadge.swift
+++ b/App/Views/Shared/FaviconProgressBadge.swift
@@ -1,30 +1,39 @@
 import SwiftUI
 
-/// Pie badge overlaid on a favicon to visualise rate-limit cooldown progress.
+/// Full-icon overlay that visualises a feed's rate-limit cooldown.
+/// Dims the underlying favicon and fills clockwise as the cooldown elapses.
 struct FaviconProgressBadge: View {
 
     let lastFetched: Date?
     let cooldown: TimeInterval
 
-    var size: CGFloat = 12
+    var size: CGFloat = 56
+    var isCircle: Bool = true
+    var cornerRadius: CGFloat = 12
 
     var body: some View {
         TimelineView(.periodic(from: .now, by: 1)) { context in
             if let progress = cooldownProgress(now: context.date) {
                 ZStack {
-                    Circle()
-                        .fill(Color.black.opacity(0.6))
-                    Circle()
-                        .strokeBorder(Color.white.opacity(0.9), lineWidth: 0.8)
-                    PieSliceShape(progress: progress)
-                        .fill(Color.white)
-                        .padding(2)
+                    shape
+                        .fill(Color.black.opacity(0.55))
+                    PieSliceShape(progress: 1 - progress)
+                        .fill(Color.white.opacity(0.85))
+                        .clipShape(shape)
                 }
                 .frame(width: size, height: size)
-                .shadow(color: .black.opacity(0.3), radius: 0.5, x: 0, y: 0.5)
+                .allowsHitTesting(false)
             } else {
                 Color.clear.frame(width: size, height: size)
             }
+        }
+    }
+
+    private var shape: AnyShape {
+        if isCircle {
+            AnyShape(Circle())
+        } else {
+            AnyShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
         }
     }
 
@@ -49,7 +58,7 @@ struct PieSliceShape: Shape {
     func path(in rect: CGRect) -> Path {
         var path = Path()
         let center = CGPoint(x: rect.midX, y: rect.midY)
-        let radius = min(rect.width, rect.height) / 2
+        let radius = max(rect.width, rect.height)
         let clamped = min(max(progress, 0), 1)
         guard clamped > 0 else { return path }
         path.move(to: center)

--- a/Scripts/Localization/HomeSettings/Home.BarItem.FeedSections.json
+++ b/Scripts/Localization/HomeSettings/Home.BarItem.FeedSections.json
@@ -1,0 +1,14 @@
+{
+  "key": "Home.BarItem.FeedSections",
+  "localizations": {
+    "de": "Feed-Bereiche",
+    "en": "Feed Sections",
+    "fr": "Sections de flux",
+    "it": "Sezioni feed",
+    "ja": "フィードセクション",
+    "ko": "피드 섹션",
+    "vi": "Phần nguồn",
+    "zh-Hans": "Feed 分区",
+    "zh-Hant": "Feed 分區"
+  }
+}

--- a/Scripts/Localization/HomeSettings/Home.BarItem.Following.json
+++ b/Scripts/Localization/HomeSettings/Home.BarItem.Following.json
@@ -1,0 +1,14 @@
+{
+  "key": "Home.BarItem.Following",
+  "localizations": {
+    "de": "Folge ich",
+    "en": "Following",
+    "fr": "Abonnements",
+    "it": "Seguiti",
+    "ja": "フォロー中",
+    "ko": "팔로잉",
+    "vi": "Đang theo dõi",
+    "zh-Hans": "关注",
+    "zh-Hant": "追蹤"
+  }
+}

--- a/Scripts/Localization/HomeSettings/Home.BarItem.Lists.json
+++ b/Scripts/Localization/HomeSettings/Home.BarItem.Lists.json
@@ -1,0 +1,14 @@
+{
+  "key": "Home.BarItem.Lists",
+  "localizations": {
+    "de": "Listen",
+    "en": "Lists",
+    "fr": "Listes",
+    "it": "Liste",
+    "ja": "リスト",
+    "ko": "목록",
+    "vi": "Danh sách",
+    "zh-Hans": "列表",
+    "zh-Hant": "清單"
+  }
+}

--- a/Scripts/Localization/HomeSettings/Home.BarItem.Topics.json
+++ b/Scripts/Localization/HomeSettings/Home.BarItem.Topics.json
@@ -1,0 +1,14 @@
+{
+  "key": "Home.BarItem.Topics",
+  "localizations": {
+    "de": "Themen",
+    "en": "Topics",
+    "fr": "Sujets",
+    "it": "Argomenti",
+    "ja": "トピック",
+    "ko": "주제",
+    "vi": "Chủ đề",
+    "zh-Hans": "话题",
+    "zh-Hant": "話題"
+  }
+}

--- a/Scripts/Localization/HomeSettings/Home.SectionBar.Footer.json
+++ b/Scripts/Localization/HomeSettings/Home.SectionBar.Footer.json
@@ -1,0 +1,14 @@
+{
+  "key": "Home.SectionBar.Footer",
+  "localizations": {
+    "de": "Ziehe, um die Reihenfolge zu ändern. Tippe, um Einträge ein- oder auszublenden.",
+    "en": "Drag to reorder. Toggle to show or hide each item.",
+    "fr": "Glisser pour réorganiser. Activer pour afficher ou masquer chaque élément.",
+    "it": "Trascina per riordinare. Attiva per mostrare o nascondere ogni voce.",
+    "ja": "ドラッグして並び替え、トグルで各項目を表示/非表示にします。",
+    "ko": "끌어서 순서를 변경하세요. 각 항목을 켜거나 꺼서 표시 여부를 설정할 수 있습니다.",
+    "vi": "Kéo để sắp xếp lại. Bật/tắt để hiện hoặc ẩn từng mục.",
+    "zh-Hans": "拖动以重新排序。开关以显示或隐藏每个项目。",
+    "zh-Hant": "拖動以重新排序。切換以顯示或隱藏每個項目。"
+  }
+}

--- a/Scripts/Localization/HomeSettings/Home.SectionBar.Title.json
+++ b/Scripts/Localization/HomeSettings/Home.SectionBar.Title.json
@@ -1,0 +1,14 @@
+{
+  "key": "Home.SectionBar.Title",
+  "localizations": {
+    "de": "Auswahlleiste",
+    "en": "Section Bar",
+    "fr": "Barre des sections",
+    "it": "Barra delle sezioni",
+    "ja": "セクションバー",
+    "ko": "섹션 바",
+    "vi": "Thanh phần",
+    "zh-Hans": "分区栏",
+    "zh-Hant": "分區欄"
+  }
+}

--- a/Scripts/Localization/HomeSettings/Home.Topics.Count.json
+++ b/Scripts/Localization/HomeSettings/Home.Topics.Count.json
@@ -1,0 +1,14 @@
+{
+  "key": "Home.Topics.Count",
+  "localizations": {
+    "de": "Top-Themen",
+    "en": "Top Topics",
+    "fr": "Sujets principaux",
+    "it": "Argomenti principali",
+    "ja": "トップトピック",
+    "ko": "인기 주제",
+    "vi": "Chủ đề hàng đầu",
+    "zh-Hans": "热门话题",
+    "zh-Hant": "熱門話題"
+  }
+}

--- a/Scripts/Localization/HomeSettings/Home.Topics.Top.json
+++ b/Scripts/Localization/HomeSettings/Home.Topics.Top.json
@@ -1,0 +1,14 @@
+{
+  "key": "Home.Topics.Top %lld",
+  "localizations": {
+    "de": "Top %lld",
+    "en": "Top %lld",
+    "fr": "Top %lld",
+    "it": "Top %lld",
+    "ja": "上位%lld件",
+    "ko": "상위 %lld개",
+    "vi": "Top %lld",
+    "zh-Hans": "前 %lld",
+    "zh-Hant": "前 %lld"
+  }
+}

--- a/Scripts/Localization/HomeSettings/Section.Home.json
+++ b/Scripts/Localization/HomeSettings/Section.Home.json
@@ -1,0 +1,14 @@
+{
+  "key": "Section.Home",
+  "localizations": {
+    "de": "Startseite",
+    "en": "Home",
+    "fr": "Accueil",
+    "it": "Home",
+    "ja": "ホーム",
+    "ko": "홈",
+    "vi": "Trang chủ",
+    "zh-Hans": "首页",
+    "zh-Hant": "首頁"
+  }
+}

--- a/Scripts/Localization/merge_home_settings_strings.py
+++ b/Scripts/Localization/merge_home_settings_strings.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Merge per-key localization JSON files into Settings.xcstrings.
+
+Reads every *.json file under ./HomeSettings/, each shaped like:
+
+    {
+      "key": "Home.Foo",
+      "localizations": {"en": "Foo", "ja": "...", ...}
+    }
+
+For each entry, writes/updates the corresponding key in Settings.xcstrings
+with `extractionState = manual` and the localized stringUnits per language.
+
+Strings themselves live in the JSON files; this script only structures them.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+XCSTRINGS_PATH = ROOT / "Shared" / "Strings" / "Settings.xcstrings"
+DATA_DIR = Path(__file__).resolve().parent / "HomeSettings"
+
+
+def load_json(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def write_json(path: Path, payload: dict) -> None:
+    # Preserve insertion order so existing keys keep their hand-curated layout;
+    # only newly-upserted keys are appended at the end.
+    serialized = json.dumps(
+        payload,
+        ensure_ascii=False,
+        indent=2,
+        sort_keys=False,
+        separators=(",", " : "),
+    )
+    with path.open("w", encoding="utf-8") as fh:
+        fh.write(serialized)
+        fh.write("\n")
+
+
+def upsert_key(xcstrings: dict, key: str, language_values: dict) -> None:
+    strings = xcstrings.setdefault("strings", {})
+    entry = strings.setdefault(key, {})
+    entry["extractionState"] = "manual"
+    localizations = entry.setdefault("localizations", {})
+    for language, value in language_values.items():
+        localizations[language] = {
+            "stringUnit": {
+                "state": "translated",
+                "value": value,
+            }
+        }
+
+
+def main() -> int:
+    if not XCSTRINGS_PATH.exists():
+        print(f"Missing xcstrings file: {XCSTRINGS_PATH}", file=sys.stderr)
+        return 1
+    if not DATA_DIR.exists():
+        print(f"Missing data dir: {DATA_DIR}", file=sys.stderr)
+        return 1
+
+    xcstrings = load_json(XCSTRINGS_PATH)
+
+    for json_path in sorted(DATA_DIR.glob("*.json")):
+        payload = load_json(json_path)
+        key = payload["key"]
+        language_values = payload["localizations"]
+        upsert_key(xcstrings, key, language_values)
+        print(f"  • {key}")
+
+    write_json(XCSTRINGS_PATH, xcstrings)
+    print(f"Updated {XCSTRINGS_PATH}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Shared/Strings/Settings.xcstrings
+++ b/Shared/Strings/Settings.xcstrings
@@ -6726,6 +6726,537 @@
           }
         }
       }
+    },
+    "Home.BarItem.FeedSections" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Feed-Bereiche"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Feed Sections"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sections de flux"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sezioni feed"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "フィードセクション"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "피드 섹션"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Phần nguồn"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Feed 分区"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Feed 分區"
+          }
+        }
+      }
+    },
+    "Home.BarItem.Following" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Folge ich"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Following"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abonnements"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seguiti"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "フォロー中"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "팔로잉"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đang theo dõi"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关注"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "追蹤"
+          }
+        }
+      }
+    },
+    "Home.BarItem.Lists" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Listen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lists"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Listes"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Liste"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リスト"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "목록"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Danh sách"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "列表"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清單"
+          }
+        }
+      }
+    },
+    "Home.BarItem.Topics" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Themen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Topics"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sujets"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Argomenti"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "トピック"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "주제"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chủ đề"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "话题"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "話題"
+          }
+        }
+      }
+    },
+    "Home.SectionBar.Footer" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ziehe, um die Reihenfolge zu ändern. Tippe, um Einträge ein- oder auszublenden."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Drag to reorder. Toggle to show or hide each item."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Glisser pour réorganiser. Activer pour afficher ou masquer chaque élément."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trascina per riordinare. Attiva per mostrare o nascondere ogni voce."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ドラッグして並び替え、トグルで各項目を表示/非表示にします。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "끌어서 순서를 변경하세요. 각 항목을 켜거나 꺼서 표시 여부를 설정할 수 있습니다."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kéo để sắp xếp lại. Bật/tắt để hiện hoặc ẩn từng mục."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "拖动以重新排序。开关以显示或隐藏每个项目。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "拖動以重新排序。切換以顯示或隱藏每個項目。"
+          }
+        }
+      }
+    },
+    "Home.SectionBar.Title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Auswahlleiste"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Section Bar"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Barre des sections"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Barra delle sezioni"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "セクションバー"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "섹션 바"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thanh phần"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分区栏"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分區欄"
+          }
+        }
+      }
+    },
+    "Home.Topics.Count" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Top-Themen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Top Topics"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sujets principaux"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Argomenti principali"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "トップトピック"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "인기 주제"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chủ đề hàng đầu"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "热门话题"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "熱門話題"
+          }
+        }
+      }
+    },
+    "Home.Topics.Top %lld" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Top %lld"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Top %lld"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Top %lld"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Top %lld"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上位%lld件"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "상위 %lld개"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Top %lld"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "前 %lld"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "前 %lld"
+          }
+        }
+      }
+    },
+    "Section.Home" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Startseite"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Home"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Accueil"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Home"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ホーム"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "홈"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trang chủ"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "首页"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "首頁"
+          }
+        }
+      }
     }
   },
   "version" : "1.1"

--- a/Shared/Strings/Settings.xcstrings
+++ b/Shared/Strings/Settings.xcstrings
@@ -6727,124 +6727,6 @@
         }
       }
     },
-    "Home.BarItem.FeedSections" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Feed-Bereiche"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Feed Sections"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sections de flux"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sezioni feed"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "フィードセクション"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "피드 섹션"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Phần nguồn"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Feed 分区"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Feed 分區"
-          }
-        }
-      }
-    },
-    "Home.BarItem.Following" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Folge ich"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Following"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abonnements"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seguiti"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "フォロー中"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "팔로잉"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Đang theo dõi"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "关注"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "追蹤"
-          }
-        }
-      }
-    },
     "Home.BarItem.Lists" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -7028,55 +6910,55 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Auswahlleiste"
+            "value" : "Anordnung"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Section Bar"
+            "value" : "Reorder"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Barre des sections"
+            "value" : "Réorganiser"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Barra delle sezioni"
+            "value" : "Riordina"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "セクションバー"
+            "value" : "並べ替え"
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "섹션 바"
+            "value" : "정렬"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Thanh phần"
+            "value" : "Sắp xếp"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "分区栏"
+            "value" : "重新排序"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "分區欄"
+            "value" : "重新排序"
           }
         }
       }
@@ -7087,55 +6969,55 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Top-Themen"
+            "value" : "Angezeigte Themen"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Top Topics"
+            "value" : "Displayed Topics"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sujets principaux"
+            "value" : "Sujets affichés"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Argomenti principali"
+            "value" : "Argomenti mostrati"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "トップトピック"
+            "value" : "表示されるトピック"
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "인기 주제"
+            "value" : "표시되는 주제"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Chủ đề hàng đầu"
+            "value" : "Chủ đề hiển thị"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "热门话题"
+            "value" : "显示的话题"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "熱門話題"
+            "value" : "顯示的話題"
           }
         }
       }


### PR DESCRIPTION
## Summary

Closes #240, #241, #242, #243.

- **#240** — New **Settings → Home** view that lets users reorder and toggle the items in the home section selection bar (Following, Feed Sections, Lists, Topics) and choose how many top topics (3 / 5 / 10) to surface as tabs. Topics resolve from the existing NLP entity index and refresh on data changes.
- **#241** — Display style padding cleanup:
  - Magazine, Masonry, Grid, Video: add top padding when no rich header is present and tighten content insets.
  - Timeline: collapse extra section spacing and zero out the default header inset that produced the large top gap.
  - Compact: hide the leading row separator that was bleeding above the first row.
- **#242** — Drop the `numericText` content transition on the Home principal text so the "Refreshing N of M / Updated…" label no longer animates on every tick.
- **#243** — Stop tracking per-frame scroll offset for the feed background. The `feedBackgroundScrollOffset` environment value was forcing the entire `FeedArticlesView` body (including `rawArticles`) to re-evaluate on every scroll geometry change just to parallax the gradient. The gradient now stays anchored, and the scroll-past-title check uses a `Bool` so action only fires when the threshold is crossed.

Localized all new strings (de, en, fr, it, ja, ko, vi, zh-Hans, zh-Hant) via per-key JSON files under `Scripts/Localization/HomeSettings/` and a matching merge script.

## Test plan

- [ ] Settings → Home: toggle each item, reorder them, switch the top topic count, and verify the home tab bar updates immediately.
- [ ] Disable Topics in settings while a topic tab is selected — selection should fall back to "Following".
- [ ] Open feeds in Magazine, Masonry, Grid, Video, Timeline, and Compact styles and verify the new padding/separator behavior matches the issue.
- [ ] Trigger a refresh on Home — the principal text should swap without the digit-tumbling animation.
- [ ] Scroll a feed with the Sakura background enabled and confirm scrolling is smooth (no hitching from background work).

https://claude.ai/code/session_014RvyZghA613kcpYhYoRD1R

---
_Generated by [Claude Code](https://claude.ai/code/session_014RvyZghA613kcpYhYoRD1R)_