### PR TITLE
Match Home settings icon to Home tab bar icon

### DIFF
--- a/App/Views/Profile/MoreView.swift
+++ b/App/Views/Profile/MoreView.swift
@@ -33,7 +33,7 @@ struct MoreView: View {
                     } label: {
                         SettingsIconLabel(
                             String(localized: "Section.Home", table: "Settings"),
-                            systemImage: "house.fill",
+                            systemImage: "newspaper",
                             color: .red
                         )
                     }


### PR DESCRIPTION
## Summary

- The new **Settings → Home** entry introduced in #244 used `house.fill`, while the Home tab bar item uses `newspaper`. Switched the settings icon to `newspaper` so the two match.

## Test plan

- [ ] Open Profile → Settings and verify the Home row's icon matches the Home tab bar icon.

https://claude.ai/code


---
_Generated by [Claude Code](https://claude.ai/code/session_015jXCK2YzXjTWLRadU1k6Wy)_