### PR TITLE
Resume playback after skipping ad

### DIFF
--- a/App/Classes/Audio Player/AudioPlayer+RemoteCommands.swift
+++ b/App/Classes/Audio Player/AudioPlayer+RemoteCommands.swift
@@ -10,25 +10,37 @@ extension AudioPlayer {
 
         commandCenter.playCommand.addTarget { [weak self] _ in
             Task { @MainActor in
-                self?.player?.play()
-                self?.isPlaying = true
-                self?.postNowPlayingUpdate()
+                if YouTubePlayerSession.shared.isActive {
+                    YouTubePlayerSession.shared.play()
+                } else {
+                    self?.player?.play()
+                    self?.isPlaying = true
+                    self?.postNowPlayingUpdate()
+                }
             }
             return .success
         }
 
         commandCenter.pauseCommand.addTarget { [weak self] _ in
             Task { @MainActor in
-                self?.player?.pause()
-                self?.isPlaying = false
-                self?.postNowPlayingUpdate()
+                if YouTubePlayerSession.shared.isActive {
+                    YouTubePlayerSession.shared.pause()
+                } else {
+                    self?.player?.pause()
+                    self?.isPlaying = false
+                    self?.postNowPlayingUpdate()
+                }
             }
             return .success
         }
 
         commandCenter.togglePlayPauseCommand.addTarget { [weak self] _ in
             Task { @MainActor in
-                self?.togglePlayPause()
+                if YouTubePlayerSession.shared.isActive {
+                    YouTubePlayerSession.shared.togglePlayPause()
+                } else {
+                    self?.togglePlayPause()
+                }
             }
             return .success
         }

--- a/App/Classes/YouTube Player Session/YouTubePlayerSession.swift
+++ b/App/Classes/YouTube Player Session/YouTubePlayerSession.swift
@@ -51,6 +51,8 @@ final class YouTubePlayerSession {
         artworkURL = nil
     }
 
+    var isActive: Bool { webView != nil }
+
     func togglePlayPause() {
         let script = """
         (function() {
@@ -58,11 +60,52 @@ final class YouTubePlayerSession {
             if (!video) { return null; }
             if (video.paused) {
                 window.__ytUserPaused = false;
+                window.__ytAutoplayBlocked = false;
                 video.play();
             } else {
                 window.__ytUserPaused = true;
                 video.pause();
             }
+            return !video.paused;
+        })();
+        """
+        webView?.evaluateJavaScript(script) { result, _ in
+            if let playing = result as? Bool {
+                Task { @MainActor in
+                    YouTubePlayerSession.shared.isPlaying = playing
+                }
+            }
+        }
+    }
+
+    func play() {
+        let script = """
+        (function() {
+            var video = document.querySelector('video');
+            if (!video) { return null; }
+            window.__ytUserPaused = false;
+            window.__ytAutoplayBlocked = false;
+            var p = video.play();
+            if (p && typeof p.catch === 'function') { p.catch(function(){}); }
+            return !video.paused;
+        })();
+        """
+        webView?.evaluateJavaScript(script) { result, _ in
+            if let playing = result as? Bool {
+                Task { @MainActor in
+                    YouTubePlayerSession.shared.isPlaying = playing
+                }
+            }
+        }
+    }
+
+    func pause() {
+        let script = """
+        (function() {
+            var video = document.querySelector('video');
+            if (!video) { return null; }
+            window.__ytUserPaused = true;
+            video.pause();
             return !video.paused;
         })();
         """

--- a/App/Views/Viewers/YouTube Player/YouTubePlayerScripts.swift
+++ b/App/Views/Viewers/YouTube Player/YouTubePlayerScripts.swift
@@ -363,6 +363,23 @@ nonisolated enum YouTubePlayerScripts {
                     dbg('seek fallback skipped');
                 }
             } catch (e) { dbg('seek err: ' + e.message); }
+            if (acted) {
+                window.__ytUserPaused = false;
+                window.__ytAutoplayBlocked = false;
+                var attempts = 0;
+                var resume = function() {
+                    var v = document.querySelector('video');
+                    if (v && v.paused && !v.ended && v.readyState >= 2) {
+                        try {
+                            var p = v.play();
+                            if (p && typeof p.catch === 'function') p.catch(function(){});
+                            dbg('resume play attempt=' + attempts);
+                        } catch (e) { dbg('resume err: ' + e.message); }
+                    }
+                    if (++attempts < 20) { setTimeout(resume, 250); }
+                };
+                setTimeout(resume, 100);
+            }
             dbg('done acted=' + acted);
             return acted;
         })();


### PR DESCRIPTION
## Summary

After tapping Skip Ad, the video element was being left paused — neither the next ad nor the actual content would auto-play.

The skip flow seeks the ad to `duration - 0.05`, which causes the video to end. Once `video.ended` is true, both safeguards step aside: `pauseOverride` allows pauses, and `pauseGuard` returns early on its `pause` listener. When YouTube then loads the next source into the same `<video>` element, it can land in a paused state without firing a fresh `pause` event, so nothing resumes it.

## Fix

After the skip action, the script now:
- Clears `__ytUserPaused` and `__ytAutoplayBlocked` so the safeguards no longer suppress playback.
- Polls briefly (~5s) for a video that is paused, ready, and not ended, calling `play()` when it finds one. This catches the transition to the next ad or to the actual content regardless of whether the skip took effect via the button click or the seek fallback.

## Test plan

- [ ] Play a YouTube video with a skippable pre-roll ad, tap Skip Ad, confirm the video begins playing immediately.
- [ ] Play a video with chained ads; tap Skip Ad on the first ad and confirm the second ad starts playing automatically.
- [ ] Confirm normal play/pause behavior is unaffected (manual pause still pauses, manual play still plays).
- [ ] Confirm ads that complete naturally (not skipped) still transition cleanly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9bDwBnhyxvyZeMByHXkn)_