### PR TITLE
Show section labels in display style picker menu

### DIFF
--- a/App/Views/Articles/DisplayStylePicker.swift
+++ b/App/Views/Articles/DisplayStylePicker.swift
@@ -11,72 +11,64 @@ struct DisplayStylePicker: View {
 
     var body: some View {
         Group {
-            Section(String(localized: "StyleSection.Classic", table: "Articles")) {
-                Picker(String(localized: "StyleSection.Classic", table: "Articles"), selection: $displayStyle) {
-                    Label(String(localized: "Style.Inbox", table: "Articles"), systemImage: "tray")
-                        .tag(FeedDisplayStyle.inbox)
-                    Label(String(localized: "Style.Compact", table: "Articles"), systemImage: "list.dash")
-                        .tag(FeedDisplayStyle.compact)
-                    if showTimeline {
-                        Label(String(localized: "Style.Timeline", table: "Articles"), systemImage: "clock")
-                            .tag(FeedDisplayStyle.timeline)
-                    }
+            Picker(String(localized: "StyleSection.Classic", table: "Articles"), selection: $displayStyle) {
+                Label(String(localized: "Style.Inbox", table: "Articles"), systemImage: "tray")
+                    .tag(FeedDisplayStyle.inbox)
+                Label(String(localized: "Style.Compact", table: "Articles"), systemImage: "list.dash")
+                    .tag(FeedDisplayStyle.compact)
+                if showTimeline {
+                    Label(String(localized: "Style.Timeline", table: "Articles"), systemImage: "clock")
+                        .tag(FeedDisplayStyle.timeline)
                 }
-                .pickerStyle(.inline)
-                .labelsHidden()
             }
-            Section(String(localized: "StyleSection.MediaFocused", table: "Articles")) {
-                Picker(String(localized: "StyleSection.MediaFocused", table: "Articles"), selection: $displayStyle) {
-                    Label(String(localized: "Style.Feed", table: "Articles"), systemImage: "text.rectangle.page")
-                        .tag(FeedDisplayStyle.feed)
-                    Label(String(localized: "Style.FeedCompact", table: "Articles"), systemImage: "square.text.square")
-                        .tag(FeedDisplayStyle.feedCompact)
-                    if hasImages {
-                        Label(String(localized: "Style.Photos", table: "Articles"), systemImage: "photo.stack")
-                            .tag(FeedDisplayStyle.photos)
-                    }
-                    Label(String(localized: "Style.Video", table: "Articles"), systemImage: "play.rectangle")
-                        .tag(FeedDisplayStyle.video)
-                    if showPodcast {
-                        Label(String(localized: "Style.Podcast", table: "Articles"), systemImage: "headphones")
-                            .tag(FeedDisplayStyle.podcast)
-                    }
+            .pickerStyle(.inline)
+            .labelsVisibility(.visible)
+            Picker(String(localized: "StyleSection.MediaFocused", table: "Articles"), selection: $displayStyle) {
+                Label(String(localized: "Style.Feed", table: "Articles"), systemImage: "text.rectangle.page")
+                    .tag(FeedDisplayStyle.feed)
+                Label(String(localized: "Style.FeedCompact", table: "Articles"), systemImage: "square.text.square")
+                    .tag(FeedDisplayStyle.feedCompact)
+                if hasImages {
+                    Label(String(localized: "Style.Photos", table: "Articles"), systemImage: "photo.stack")
+                        .tag(FeedDisplayStyle.photos)
                 }
-                .pickerStyle(.inline)
-                .labelsHidden()
-            }
-            Section(String(localized: "StyleSection.Grids", table: "Articles")) {
-                Picker(String(localized: "StyleSection.Grids", table: "Articles"), selection: $displayStyle) {
-                    if hasImages {
-                        Label(String(localized: "Style.Magazine", table: "Articles"), systemImage: "rectangle.grid.2x2")
-                            .tag(FeedDisplayStyle.magazine)
-                    }
-                    if hasImages {
-                        Label(String(localized: "Style.Masonry", table: "Articles"), systemImage: "rectangle.3.group")
-                            .tag(FeedDisplayStyle.masonry)
-                    }
-                    if hasImages {
-                        Label(String(localized: "Style.Grid", table: "Articles"), systemImage: "square.grid.3x3")
-                            .tag(FeedDisplayStyle.grid)
-                    }
+                Label(String(localized: "Style.Video", table: "Articles"), systemImage: "play.rectangle")
+                    .tag(FeedDisplayStyle.video)
+                if showPodcast {
+                    Label(String(localized: "Style.Podcast", table: "Articles"), systemImage: "headphones")
+                        .tag(FeedDisplayStyle.podcast)
                 }
-                .pickerStyle(.inline)
-                .labelsHidden()
             }
-            Section(String(localized: "StyleSection.Immersive", table: "Articles")) {
-                Picker(String(localized: "StyleSection.Immersive", table: "Articles"), selection: $displayStyle) {
-                    if hasImages && showCards {
-                        Label(String(localized: "Style.Cards", table: "Articles"), systemImage: "square.stack.3d.up")
-                            .tag(FeedDisplayStyle.cards)
-                    }
-                    if showScroll {
-                        Label(String(localized: "Style.Scroll", table: "Articles"), systemImage: "arrow.up.and.down")
-                            .tag(FeedDisplayStyle.scroll)
-                    }
+            .pickerStyle(.inline)
+            .labelsVisibility(.visible)
+            Picker(String(localized: "StyleSection.Grids", table: "Articles"), selection: $displayStyle) {
+                if hasImages {
+                    Label(String(localized: "Style.Magazine", table: "Articles"), systemImage: "rectangle.grid.2x2")
+                        .tag(FeedDisplayStyle.magazine)
                 }
-                .pickerStyle(.inline)
-                .labelsHidden()
+                if hasImages {
+                    Label(String(localized: "Style.Masonry", table: "Articles"), systemImage: "rectangle.3.group")
+                        .tag(FeedDisplayStyle.masonry)
+                }
+                if hasImages {
+                    Label(String(localized: "Style.Grid", table: "Articles"), systemImage: "square.grid.3x3")
+                        .tag(FeedDisplayStyle.grid)
+                }
             }
+            .pickerStyle(.inline)
+            .labelsVisibility(.visible)
+            Picker(String(localized: "StyleSection.Immersive", table: "Articles"), selection: $displayStyle) {
+                if hasImages && showCards {
+                    Label(String(localized: "Style.Cards", table: "Articles"), systemImage: "square.stack.3d.up")
+                        .tag(FeedDisplayStyle.cards)
+                }
+                if showScroll {
+                    Label(String(localized: "Style.Scroll", table: "Articles"), systemImage: "arrow.up.and.down")
+                        .tag(FeedDisplayStyle.scroll)
+                }
+            }
+            .pickerStyle(.inline)
+            .labelsVisibility(.visible)
         }
         .menuActionDismissBehavior(.disabled)
     }

--- a/App/Views/Articles/DisplayStylePicker.swift
+++ b/App/Views/Articles/DisplayStylePicker.swift
@@ -11,58 +11,73 @@ struct DisplayStylePicker: View {
 
     var body: some View {
         Group {
-            Picker(String(localized: "StyleSection.Classic", table: "Articles"), selection: $displayStyle) {
-                Label(String(localized: "Style.Inbox", table: "Articles"), systemImage: "tray")
-                    .tag(FeedDisplayStyle.inbox)
-                Label(String(localized: "Style.Compact", table: "Articles"), systemImage: "list.dash")
-                    .tag(FeedDisplayStyle.compact)
-                if showTimeline {
-                    Label(String(localized: "Style.Timeline", table: "Articles"), systemImage: "clock")
-                        .tag(FeedDisplayStyle.timeline)
+            Section(String(localized: "StyleSection.Classic", table: "Articles")) {
+                Picker(String(localized: "StyleSection.Classic", table: "Articles"), selection: $displayStyle) {
+                    Label(String(localized: "Style.Inbox", table: "Articles"), systemImage: "tray")
+                        .tag(FeedDisplayStyle.inbox)
+                    Label(String(localized: "Style.Compact", table: "Articles"), systemImage: "list.dash")
+                        .tag(FeedDisplayStyle.compact)
+                    if showTimeline {
+                        Label(String(localized: "Style.Timeline", table: "Articles"), systemImage: "clock")
+                            .tag(FeedDisplayStyle.timeline)
+                    }
                 }
+                .pickerStyle(.inline)
+                .labelsHidden()
             }
-            Picker(String(localized: "StyleSection.MediaFocused", table: "Articles"), selection: $displayStyle) {
-                Label(String(localized: "Style.Feed", table: "Articles"), systemImage: "text.rectangle.page")
-                    .tag(FeedDisplayStyle.feed)
-                Label(String(localized: "Style.FeedCompact", table: "Articles"), systemImage: "square.text.square")
-                    .tag(FeedDisplayStyle.feedCompact)
-                if hasImages {
-                    Label(String(localized: "Style.Photos", table: "Articles"), systemImage: "photo.stack")
-                        .tag(FeedDisplayStyle.photos)
+            Section(String(localized: "StyleSection.MediaFocused", table: "Articles")) {
+                Picker(String(localized: "StyleSection.MediaFocused", table: "Articles"), selection: $displayStyle) {
+                    Label(String(localized: "Style.Feed", table: "Articles"), systemImage: "text.rectangle.page")
+                        .tag(FeedDisplayStyle.feed)
+                    Label(String(localized: "Style.FeedCompact", table: "Articles"), systemImage: "square.text.square")
+                        .tag(FeedDisplayStyle.feedCompact)
+                    if hasImages {
+                        Label(String(localized: "Style.Photos", table: "Articles"), systemImage: "photo.stack")
+                            .tag(FeedDisplayStyle.photos)
+                    }
+                    Label(String(localized: "Style.Video", table: "Articles"), systemImage: "play.rectangle")
+                        .tag(FeedDisplayStyle.video)
+                    if showPodcast {
+                        Label(String(localized: "Style.Podcast", table: "Articles"), systemImage: "headphones")
+                            .tag(FeedDisplayStyle.podcast)
+                    }
                 }
-                Label(String(localized: "Style.Video", table: "Articles"), systemImage: "play.rectangle")
-                    .tag(FeedDisplayStyle.video)
-                if showPodcast {
-                    Label(String(localized: "Style.Podcast", table: "Articles"), systemImage: "headphones")
-                        .tag(FeedDisplayStyle.podcast)
-                }
+                .pickerStyle(.inline)
+                .labelsHidden()
             }
-            Picker(String(localized: "StyleSection.Grids", table: "Articles"), selection: $displayStyle) {
-                if hasImages {
-                    Label(String(localized: "Style.Magazine", table: "Articles"), systemImage: "rectangle.grid.2x2")
-                        .tag(FeedDisplayStyle.magazine)
+            Section(String(localized: "StyleSection.Grids", table: "Articles")) {
+                Picker(String(localized: "StyleSection.Grids", table: "Articles"), selection: $displayStyle) {
+                    if hasImages {
+                        Label(String(localized: "Style.Magazine", table: "Articles"), systemImage: "rectangle.grid.2x2")
+                            .tag(FeedDisplayStyle.magazine)
+                    }
+                    if hasImages {
+                        Label(String(localized: "Style.Masonry", table: "Articles"), systemImage: "rectangle.3.group")
+                            .tag(FeedDisplayStyle.masonry)
+                    }
+                    if hasImages {
+                        Label(String(localized: "Style.Grid", table: "Articles"), systemImage: "square.grid.3x3")
+                            .tag(FeedDisplayStyle.grid)
+                    }
                 }
-                if hasImages {
-                    Label(String(localized: "Style.Masonry", table: "Articles"), systemImage: "rectangle.3.group")
-                        .tag(FeedDisplayStyle.masonry)
-                }
-                if hasImages {
-                    Label(String(localized: "Style.Grid", table: "Articles"), systemImage: "square.grid.3x3")
-                        .tag(FeedDisplayStyle.grid)
-                }
+                .pickerStyle(.inline)
+                .labelsHidden()
             }
-            Picker(String(localized: "StyleSection.Immersive", table: "Articles"), selection: $displayStyle) {
-                if hasImages && showCards {
-                    Label(String(localized: "Style.Cards", table: "Articles"), systemImage: "square.stack.3d.up")
-                        .tag(FeedDisplayStyle.cards)
+            Section(String(localized: "StyleSection.Immersive", table: "Articles")) {
+                Picker(String(localized: "StyleSection.Immersive", table: "Articles"), selection: $displayStyle) {
+                    if hasImages && showCards {
+                        Label(String(localized: "Style.Cards", table: "Articles"), systemImage: "square.stack.3d.up")
+                            .tag(FeedDisplayStyle.cards)
+                    }
+                    if showScroll {
+                        Label(String(localized: "Style.Scroll", table: "Articles"), systemImage: "arrow.up.and.down")
+                            .tag(FeedDisplayStyle.scroll)
+                    }
                 }
-                if showScroll {
-                    Label(String(localized: "Style.Scroll", table: "Articles"), systemImage: "arrow.up.and.down")
-                        .tag(FeedDisplayStyle.scroll)
-                }
+                .pickerStyle(.inline)
+                .labelsHidden()
             }
         }
-        .pickerStyle(.inline)
         .menuActionDismissBehavior(.disabled)
     }
 }


### PR DESCRIPTION
## Summary
- The display style picker menu rendered four sibling inline `Picker` views, but SwiftUI was not surfacing the picker title as a section header in the menu — sections appeared only as dividers without labels.
- Wrap each inline `Picker` in a `Section` with the localized header so the Classic / Media-Focused / Grids / Immersive group titles show up correctly above their items.

## Test plan
- [ ] Open a content list and tap the display style menu — verify all visible sections show their localized header (Classic, Media-Focused, Grids, Immersive).
- [ ] Switch language to Japanese and confirm headers are translated.
- [ ] Verify selection still works and the checkmark moves to the chosen style.
- [ ] Verify conditional items (timeline, photos, podcast, magazine/masonry/grid, cards, scroll) still appear/hide based on context.

https://claude.ai/code/session_01L9F6d2KgPqHcRnFisKxiE2

---
_Generated by [Claude Code](https://claude.ai/code/session_01L9F6d2KgPqHcRnFisKxiE2)_