### PR TITLE
Fix background refresh by adding fetch to UIBackgroundModes

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -64,6 +64,7 @@
 	</array>
 	<key>UIBackgroundModes</key>
 	<array>
+		<string>fetch</string>
 		<string>processing</string>
 		<string>audio</string>
 	</array>

--- a/SakuraRSS.xcodeproj/project.pbxproj
+++ b/SakuraRSS.xcodeproj/project.pbxproj
@@ -896,7 +896,6 @@
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = App/Info.plist;
-				INFOPLIST_KEY_BGTaskSchedulerPermittedIdentifiers = "$(PRODUCT_BUNDLE_IDENTIFIER).refresh";
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.news";
 				INFOPLIST_KEY_LSSupportsOpeningDocumentsInPlace = NO;
@@ -904,7 +903,6 @@
 				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "Sakura uses on-device speech recognition to transcribe podcast episodes you download. Audio is processed locally and never leaves your device.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UIBackgroundModes = fetch;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				IPHONEOS_DEPLOYMENT_TARGET = 26.1;
@@ -942,7 +940,6 @@
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = App/Info.plist;
-				INFOPLIST_KEY_BGTaskSchedulerPermittedIdentifiers = "$(PRODUCT_BUNDLE_IDENTIFIER).refresh";
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.news";
 				INFOPLIST_KEY_LSSupportsOpeningDocumentsInPlace = NO;
@@ -950,7 +947,6 @@
 				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "Sakura uses on-device speech recognition to transcribe podcast episodes you download. Audio is processed locally and never leaves your device.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UIBackgroundModes = fetch;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				IPHONEOS_DEPLOYMENT_TARGET = 26.1;


### PR DESCRIPTION
## Summary

Background refresh wasn't working correctly due to conflicting Info.plist configuration:

- `App/Info.plist` declared `UIBackgroundModes` as `["processing", "audio"]` — but `BGAppRefreshTask` (used in `App+BackgroundTasks.swift`) requires `fetch` to be present.
- The project build settings had `INFOPLIST_KEY_UIBackgroundModes = fetch` and `INFOPLIST_KEY_BGTaskSchedulerPermittedIdentifiers = "$(PRODUCT_BUNDLE_IDENTIFIER).refresh"`, which conflicted with the explicit Info.plist file. The build-setting identifier (`com.tsubuzaki.SakuraRSS.refresh`) didn't match either of the identifiers actually registered at runtime (`com.tsubuzaki.SakuraRSS.RefreshFeeds`, `com.tsubuzaki.SakuraRSS.iCloudBackup`).

## Fix

- Add `fetch` to `App/Info.plist` `UIBackgroundModes` so the array now contains all three required modes: `fetch`, `processing`, `audio`.
- Remove the conflicting `INFOPLIST_KEY_UIBackgroundModes` and `INFOPLIST_KEY_BGTaskSchedulerPermittedIdentifiers` from both Debug and Release build configurations, making `App/Info.plist` the single source of truth.

## Test plan

- [ ] Build and run on a device, verify `BGTaskScheduler.shared.submit(...)` no longer throws for the `RefreshFeeds` request.
- [ ] Confirm periodic background refresh fires (use `e -l objc -- (void)[[BGTaskScheduler sharedScheduler] _simulateLaunchForTaskWithIdentifier:@"com.tsubuzaki.SakuraRSS.RefreshFeeds"]` from the debugger to simulate).
- [ ] Confirm the iCloud backup `BGProcessingTask` still schedules and runs.
- [ ] Confirm audio playback (podcast) still works in the background.

https://claude.ai/code/session_017DHQMfkj6V5GBQXZinNUDG

---
_Generated by [Claude Code](https://claude.ai/code/session_017DHQMfkj6V5GBQXZinNUDG)_