### PR TITLE
Add recent searches to Discover tab

### DIFF
--- a/App/Views/Search/DiscoverView.swift
+++ b/App/Views/Search/DiscoverView.swift
@@ -5,6 +5,9 @@ struct DiscoverView: View {
     @Environment(FeedManager.self) var feedManager
     @AppStorage("Intelligence.ContentInsights.Enabled") private var contentInsightsEnabled: Bool = false
 
+    @Binding var searchText: String
+
+    @State private var recentSearchStore = RecentSearchStore.shared
     @State private var recentArticles: [Article] = []
     @State private var entitySections: [DiscoverEntitySection] = []
     @State private var allTopics: [(name: String, count: Int)] = []
@@ -13,7 +16,8 @@ struct DiscoverView: View {
     @State private var refreshID = 0
 
     private var hasContent: Bool {
-        !recentArticles.isEmpty
+        !recentSearchStore.searches.isEmpty
+            || !recentArticles.isEmpty
             || !entitySections.isEmpty
             || !filteredTopics.isEmpty
             || !filteredPeople.isEmpty
@@ -24,6 +28,14 @@ struct DiscoverView: View {
             if hasContent {
                 ScrollView {
                     VStack(alignment: .leading, spacing: 24) {
+                        if !recentSearchStore.searches.isEmpty {
+                            RecentSearchesSection(
+                                searches: recentSearchStore.searches,
+                                onSelect: { term in searchText = term },
+                                onClear: { recentSearchStore.clear() }
+                            )
+                        }
+
                         if !recentArticles.isEmpty {
                             recentlyAccessedSection
                         }

--- a/App/Views/Search/RecentSearchStore.swift
+++ b/App/Views/Search/RecentSearchStore.swift
@@ -1,0 +1,47 @@
+import Foundation
+import Observation
+
+/// Persistent store of recent search terms used by the Discover tab.
+@Observable
+final class RecentSearchStore {
+
+    static let shared = RecentSearchStore()
+
+    static let defaultsKey = "Search.RecentSearches"
+    static let maximumCount = 10
+
+    private(set) var searches: [String]
+
+    private init() {
+        let stored = UserDefaults.standard.stringArray(forKey: Self.defaultsKey) ?? []
+        searches = stored
+    }
+
+    func add(_ term: String) {
+        let trimmed = term.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        var updated = searches.filter { $0.caseInsensitiveCompare(trimmed) != .orderedSame }
+        updated.insert(trimmed, at: 0)
+        if updated.count > Self.maximumCount {
+            updated = Array(updated.prefix(Self.maximumCount))
+        }
+        searches = updated
+        persist()
+    }
+
+    func remove(_ term: String) {
+        let updated = searches.filter { $0.caseInsensitiveCompare(term) != .orderedSame }
+        guard updated.count != searches.count else { return }
+        searches = updated
+        persist()
+    }
+
+    func clear() {
+        searches = []
+        persist()
+    }
+
+    private func persist() {
+        UserDefaults.standard.set(searches, forKey: Self.defaultsKey)
+    }
+}

--- a/App/Views/Search/RecentSearchesSection.swift
+++ b/App/Views/Search/RecentSearchesSection.swift
@@ -1,0 +1,63 @@
+import SwiftUI
+
+struct RecentSearchesSection: View {
+
+    let searches: [String]
+    let onSelect: (String) -> Void
+    let onClear: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Text(String(localized: "Discover.RecentSearches", table: "Feeds"))
+                    .font(.title3)
+                    .fontWeight(.bold)
+                Spacer()
+                Button(String(localized: "Discover.ClearHistory", table: "Feeds")) {
+                    withAnimation(.smooth.speed(2.0)) {
+                        onClear()
+                    }
+                }
+                .font(.title3)
+            }
+            .padding(.horizontal)
+
+            VStack(spacing: 0) {
+                ForEach(searches, id: \.self) { term in
+                    RecentSearchRow(term: term) {
+                        onSelect(term)
+                    }
+                    if term != searches.last {
+                        Divider()
+                            .padding(.leading, 44)
+                    }
+                }
+            }
+            .padding(.horizontal)
+        }
+    }
+}
+
+private struct RecentSearchRow: View {
+
+    let term: String
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack(spacing: 12) {
+                Image(systemName: "magnifyingglass")
+                    .font(.body)
+                    .frame(width: 20)
+                Text(term)
+                    .font(.body)
+                    .lineLimit(1)
+                Spacer(minLength: 0)
+            }
+            .foregroundStyle(Color.accentColor)
+            .padding(.vertical, 10)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/App/Views/Search/SearchView.swift
+++ b/App/Views/Search/SearchView.swift
@@ -27,7 +27,7 @@ struct SearchView: View {
         NavigationStack(path: $path) {
             Group {
                 if searchText.isEmpty {
-                    DiscoverView()
+                    DiscoverView(searchText: $searchText)
                 } else {
                     searchResultsContent
                 }
@@ -92,6 +92,14 @@ struct SearchView: View {
                 withAnimation(.smooth.speed(2.0)) {
                     searchResults = results
                 }
+            }
+            .task(id: searchText) {
+                let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !query.isEmpty else { return }
+                try? await Task.sleep(for: .seconds(3))
+                guard !Task.isCancelled,
+                      searchText.trimmingCharacters(in: .whitespacesAndNewlines) == query else { return }
+                RecentSearchStore.shared.add(query)
             }
         }
     }

--- a/Shared/Strings/Feeds.xcstrings
+++ b/Shared/Strings/Feeds.xcstrings
@@ -1593,6 +1593,65 @@
         }
       }
     },
+    "Discover.RecentSearches" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Letzte Suchanfragen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recent Searches"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recherches récentes"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ricerche recenti"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最近の検索"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "최근 검색"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tìm kiếm gần đây"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最近搜索"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最近搜尋"
+          }
+        }
+      }
+    },
     "Discover.RecentlyAccessed" : {
       "extractionState" : "manual",
       "localizations" : {


### PR DESCRIPTION
## Summary
- Persist search terms that the user holds for more than 3 seconds via a shared `RecentSearchStore` (UserDefaults backed, capped at 10 entries, deduped case-insensitively).
- Display recent searches at the top of the Discover tab with a magnifying glass icon and `.accentColor` foreground style. Tapping a row populates the search field, immediately starting a search.
- Add a Clear button mirroring Recently Accessed, animated with `.smooth.speed(2.0)`. The whole section disappears when no history exists.
- Localize the new `Discover.RecentSearches` string for de, en, fr, it, ja, ko, vi, zh-Hans, zh-Hant. Reused the existing `Discover.ClearHistory` key for the Clear button label.

## Test plan
- [ ] Type a search term, wait 3+ seconds, then clear the field. Reopen Discover and confirm the term appears at the top with the magnifying glass icon.
- [ ] Tap a recent search and confirm the search field populates and results appear immediately.
- [ ] Tap Clear and confirm the section animates out smoothly.
- [ ] With no recent searches saved, confirm the section is not rendered.
- [ ] Verify duplicate searches are not added twice and that older entries beyond the 10-item cap are dropped.


---
_Generated by [Claude Code](https://claude.ai/code/session_01U7LJh2SbZEEZybBWYAAa66)_