### PR TITLE
Improve feed icon borders to match Feed display style

### DIFF
--- a/App/Views/Feed/Display Styles/Inbox/InboxArticleRow.swift
+++ b/App/Views/Feed/Display Styles/Inbox/InboxArticleRow.swift
@@ -28,6 +28,10 @@ struct InboxArticleRow: View {
                 }
                 .frame(width: 48, height: 48)
                 .clipShape(.rect(cornerRadius: 8))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 8)
+                        .strokeBorder(.primary.opacity(0.2), lineWidth: 0.5)
+                }
             } else {
                 FeedIconPlaceholder(
                     icon: icon,
@@ -38,6 +42,10 @@ struct InboxArticleRow: View {
                     cornerRadius: 8
                 )
                 .frame(width: 48, height: 48)
+                .overlay {
+                    RoundedRectangle(cornerRadius: 8)
+                        .strokeBorder(.primary.opacity(0.2), lineWidth: 0.5)
+                }
             }
 
             VStack(alignment: .leading, spacing: 4) {

--- a/App/Views/Shared/IconImage.swift
+++ b/App/Views/Shared/IconImage.swift
@@ -51,7 +51,15 @@ struct IconImage: View {
             .frame(width: size, height: size)
             .background(image.nearWhiteAverageGradient)
             .clipShape(shape)
-            .overlay(shape.stroke(.secondary, lineWidth: 0.5))
+            .overlay {
+                if isCircle {
+                    Circle()
+                        .strokeBorder(.primary.opacity(0.2), lineWidth: 0.5)
+                } else {
+                    RoundedRectangle(cornerRadius: cornerRadius)
+                        .strokeBorder(.primary.opacity(0.2), lineWidth: 0.5)
+                }
+            }
     }
 }
 

--- a/App/Views/Shared/IconImage.swift
+++ b/App/Views/Shared/IconImage.swift
@@ -41,25 +41,28 @@ struct IconImage: View {
     }
 
     var body: some View {
-        let shape: AnyShape = isCircle
-            ? AnyShape(Circle())
-            : AnyShape(RoundedRectangle(cornerRadius: cornerRadius))
-        Image(uiImage: image)
+        let baseImage = Image(uiImage: image)
             .resizable()
             .aspectRatio(contentMode: isNonSquare ? .fit : .fill)
             .frame(width: iconSize, height: iconSize)
             .frame(width: size, height: size)
             .background(image.nearWhiteAverageGradient)
-            .clipShape(shape)
-            .overlay {
-                if isCircle {
+
+        if isCircle {
+            baseImage
+                .clipShape(Circle())
+                .overlay {
                     Circle()
                         .strokeBorder(.primary.opacity(0.2), lineWidth: 0.5)
-                } else {
+                }
+        } else {
+            baseImage
+                .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
+                .overlay {
                     RoundedRectangle(cornerRadius: cornerRadius)
                         .strokeBorder(.primary.opacity(0.2), lineWidth: 0.5)
                 }
-            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- Replace the white-leaning `.secondary` stroke on feed icons in `IconImage` with a subtle `.primary.opacity(0.2)` `strokeBorder`, matching the outline already used on Feed display style images.
- Add the same subtle outline to the Inbox display style image/placeholder, which previously had none.

## Test plan

- [ ] Feed icons across the app no longer show an ugly white border in light mode
- [ ] Feed icons render with a subtle outline matching the Feed display style images
- [ ] Inbox display style rows now show the same subtle outline around their image/placeholder
- [ ] Verify the outline reads correctly in both light and dark mode

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ax7xFetJJjBgjMWYM7PFfn)_