### PR TITLE
Fix Topic view article list not reflecting read state changes

### DIFF
--- a/App/Views/Search/EntityArticlesView.swift
+++ b/App/Views/Search/EntityArticlesView.swift
@@ -70,6 +70,9 @@ struct EntityArticlesView: View {
         .task {
             await loadArticles()
         }
+        .onChange(of: feedManager.dataRevision) { _, _ in
+            Task { await loadArticles() }
+        }
     }
 
     private func loadArticles() async {


### PR DESCRIPTION
## Summary

`EntityArticlesView` (the article list shown when drilling into a topic) loaded articles into a local `@State` array via a one-shot `.task`. Swiping to mark read/unread persisted to the database correctly, but the rendered rows kept their stale `Article.isRead` value once `pendingReadIDs` flushed, so the unread dot and bold weight never updated.

## Fix

Observe `feedManager.dataRevision` (bumped by `FeedManager.loadFromDatabase()` after every toggle/mark-all action) and re-run `loadArticles()` so the in-memory copies pick up the fresh `isRead` / `isBookmarked` values. Mirrors the existing pattern in `FeedArticlesView.swift:268`.

## Test plan

- [ ] Open Topic view, swipe an article to mark read — row fades to read style without leaving the view
- [ ] Swipe again to mark unread — row returns to unread style
- [ ] Toggle bookmark from Topic view — bookmark indicator updates
- [ ] Drill from Topic into article, mark read inside, return — list reflects new state


---
_Generated by [Claude Code](https://claude.ai/code/session_01JrKURg2n2jtqxFBjgt8fTT)_