### PR TITLE
Fix zoom transition on Edit Feed sheet from Following tab

### DIFF
--- a/App/Views/Following/FollowingFeedGridCell.swift
+++ b/App/Views/Following/FollowingFeedGridCell.swift
@@ -59,6 +59,7 @@ struct FollowingFeedGridCell: View {
                     }
                 }
                 .frame(width: iconSize, height: iconSize)
+                .zoomSource(id: feed.id, namespace: editTransitionNamespace)
                 .drawingGroup()
                 .contentShape(
                     .hoverEffect,
@@ -67,7 +68,6 @@ struct FollowingFeedGridCell: View {
                         : AnyShape(RoundedRectangle(cornerRadius: iconCornerRadius))
                 )
                 .hoverEffect(.highlight)
-                .zoomSource(id: feed.id, namespace: editTransitionNamespace)
                 .overlay(alignment: .topTrailing) {
                     if !isWiggling, feedManager.unreadCount(for: feed) > 0 {
                         unreadDot


### PR DESCRIPTION
## Summary
- Tapping a feed icon in **Following → (Edit) → cell** failed to play the matched zoom transition into the Edit Feed sheet.
- The cell's `.zoomSource(id:namespace:)` (matched transition source) was the **last** modifier in the icon chain — applied *after* `.drawingGroup()` and `.hoverEffect(.highlight)`. Both wrappers (Metal rasterization + UIKit hover interaction added in `cd2dc7d`) interfere with the snapshot SwiftUI uses as the zoom anchor, so the destination sheet had no usable source to zoom from.
- Move `.zoomSource(...)` directly above `.drawingGroup()` / `.contentShape(.hoverEffect, ...)` / `.hoverEffect(.highlight)` so the matched anchor is captured on the bare icon view. This mirrors the pattern that already works for the edit transition in `FeedHeaderView` (the source is on the inner `Image`, before any styling wrappers).

Add Feed's transition was unaffected because its source is on the bare `+` toolbar button with no `drawingGroup` / `hoverEffect` in the chain.

## Test plan
- [ ] Open the Following tab, tap **Edit**, tap a feed icon → verify the Edit Feed sheet zooms out of the tapped icon, dismiss, repeat on a different feed and verify the transition still plays.
- [ ] Tap the **+** button in Following → confirm the existing Add Feed zoom transition is unchanged.
- [ ] Open a feed, tap the pencil button in the feed header → confirm the Edit Feed sheet zoom from `FeedHeaderView` still works.
- [ ] iPad: confirm the icon's hover highlight still appears when pointing at it.


---
_Generated by [Claude Code](https://claude.ai/code/session_0167xZk8c1JW4Rzk6NdQtXHh)_