### PR TITLE
Run feed refresh as four concurrent queues (regular, slow, X, Instagram)

### DIFF
--- a/App/Classes/Feed Manager/FeedManager+Refresh.swift
+++ b/App/Classes/Feed Manager/FeedManager+Refresh.swift
@@ -17,8 +17,26 @@ extension FeedManager {
     ) async throws {
         // swiftlint:disable:next line_length
         log("FeedRefresh", "refreshFeed begin id=\(feed.id) title=\(feed.title) url=\(feed.url) reloadData=\(reloadData) skipImageFetch=\(skipImageFetch) skipImagePreload=\(skipImagePreload) runNLP=\(runNLP) contentOnly=\(contentOnly)")
+        let started = Date()
+        var didPerformWork = false
+        defer {
+            if didPerformWork {
+                let durationMs = max(0, Int(Date().timeIntervalSince(started) * 1000))
+                let database = self.database
+                let feedID = feed.id
+                Task.detached(priority: .utility) {
+                    do {
+                        try database.recordFeedRefreshMetric(feedID: feedID, durationMs: durationMs)
+                        log("FeedRefresh", "metric recorded id=\(feedID) durationMs=\(durationMs)")
+                    } catch {
+                        log("FeedRefresh", "metric record failed id=\(feedID) error=\(error.localizedDescription)")
+                    }
+                }
+            }
+        }
         if PetalRecipe.isPetalFeedURL(feed.url) {
             log("FeedRefresh", "dispatch -> Petal id=\(feed.id)")
+            didPerformWork = true
             try await refreshPetalFeed(
                 feed,
                 reloadData: reloadData,
@@ -34,6 +52,7 @@ extension FeedManager {
                 return
             }
             log("FeedRefresh", "dispatch -> provider=\(String(describing: provider)) id=\(feed.id)")
+            didPerformWork = true
             try await provider.refresh(
                 feed: feed,
                 on: self,
@@ -47,6 +66,7 @@ extension FeedManager {
 
         log("FeedRefresh", "dispatch -> standard RSS pipeline id=\(feed.id)")
         let database = database
+        didPerformWork = true
         try await Task.detached {
             try await FeedManager.runStandardFeedPipeline(
                 feed: feed,
@@ -391,9 +411,9 @@ extension FeedManager {
             return
         }
 
-        let slowFeeds = feedsToRefresh.filter { $0.isSlowRefreshFeed }
-        let regularFeeds = feedsToRefresh.filter { !$0.isSlowRefreshFeed }
-        log("FeedRefresh.All", "eligible=\(feedsToRefresh.count) slow=\(slowFeeds.count) regular=\(regularFeeds.count)")
+        let queues = partitionRefreshQueues(feedsToRefresh)
+        // swiftlint:disable:next line_length
+        log("FeedRefresh.All", "eligible=\(feedsToRefresh.count) regular=\(queues.regular.count) slow=\(queues.slow.count) x=\(queues.x.count) instagram=\(queues.instagram.count)")
 
         await MainActor.run {
             isLoading = true
@@ -421,21 +441,35 @@ extension FeedManager {
 
         let work = Task { [weak self] in
             guard let self else { return }
-            async let slow: Void = self.runBoundedRefresh(
-                slowFeeds,
-                maxConcurrent: 2,
-                skipImageFetch: skipImageFetch,
-                skipImagePreload: effectiveSkipPreload,
-                runNLP: runNLPAfter
-            )
             async let regular: Void = self.runBoundedRefresh(
-                regularFeeds,
-                maxConcurrent: 8,
+                queues.regular,
+                maxConcurrent: FeedRefreshQueueLimits.maxConcurrentPerQueue,
                 skipImageFetch: skipImageFetch,
                 skipImagePreload: effectiveSkipPreload,
                 runNLP: runNLPAfter
             )
-            _ = await (slow, regular)
+            async let slow: Void = self.runBoundedRefresh(
+                queues.slow,
+                maxConcurrent: FeedRefreshQueueLimits.maxConcurrentPerQueue,
+                skipImageFetch: skipImageFetch,
+                skipImagePreload: effectiveSkipPreload,
+                runNLP: runNLPAfter
+            )
+            async let xRefresh: Void = self.runBoundedRefresh(
+                queues.x,
+                maxConcurrent: FeedRefreshQueueLimits.maxConcurrentPerQueue,
+                skipImageFetch: skipImageFetch,
+                skipImagePreload: effectiveSkipPreload,
+                runNLP: runNLPAfter
+            )
+            async let instagramRefresh: Void = self.runBoundedRefresh(
+                queues.instagram,
+                maxConcurrent: FeedRefreshQueueLimits.maxConcurrentPerQueue,
+                skipImageFetch: skipImageFetch,
+                skipImagePreload: effectiveSkipPreload,
+                runNLP: runNLPAfter
+            )
+            _ = await (regular, slow, xRefresh, instagramRefresh)
         }
         await MainActor.run { self.refreshTask = work }
         _ = await work.value
@@ -453,6 +487,54 @@ extension FeedManager {
             return completed
         }
         log("FeedRefresh.All", "end completed=\(finalCompleted)/\(feedsToRefresh.count)")
+    }
+
+    fileprivate func runTitleSafeBoundedRefresh(
+        _ feeds: [Feed],
+        maxConcurrent: Int
+    ) async {
+        guard !feeds.isEmpty else { return }
+        await withTaskGroup(of: Void.self) { group in
+            var submitted = 0
+            var iterator = feeds.makeIterator()
+            while submitted < maxConcurrent, !Task.isCancelled, let feed = iterator.next() {
+                group.addTask { [weak self] in
+                    guard let self, !Task.isCancelled else { return }
+                    await self.markRefreshStarted(feedID: feed.id)
+                    try? await self.refreshFeed(
+                        feed,
+                        updateTitle: false,
+                        reloadData: false
+                    )
+                    await self.markRefreshFinished(
+                        feedID: feed.id,
+                        cancelled: Task.isCancelled
+                    )
+                }
+                submitted += 1
+            }
+            while await group.next() != nil {
+                if Task.isCancelled {
+                    group.cancelAll()
+                    continue
+                }
+                if let feed = iterator.next() {
+                    group.addTask { [weak self] in
+                        guard let self, !Task.isCancelled else { return }
+                        await self.markRefreshStarted(feedID: feed.id)
+                        try? await self.refreshFeed(
+                            feed,
+                            updateTitle: false,
+                            reloadData: false
+                        )
+                        await self.markRefreshFinished(
+                            feedID: feed.id,
+                            cancelled: Task.isCancelled
+                        )
+                    }
+                }
+            }
+        }
     }
 
     fileprivate func runBoundedRefresh(
@@ -621,54 +703,26 @@ extension FeedManager {
             refreshingFeedIDs = []
         }
 
-        let maxConcurrent = 8
+        let queues = partitionRefreshQueues(currentFeeds)
+        let maxConcurrent = FeedRefreshQueueLimits.maxConcurrentPerQueue
         let work = Task { [weak self] in
             guard let self else { return }
-            async let feedRefresh: Void = withTaskGroup(of: Void.self) { group in
-                var submitted = 0
-                var iterator = currentFeeds.makeIterator()
-                while submitted < maxConcurrent, !Task.isCancelled, let feed = iterator.next() {
-                    group.addTask {
-                        guard !Task.isCancelled else { return }
-                        await self.markRefreshStarted(feedID: feed.id)
-                        try? await self.refreshFeed(
-                            feed,
-                            updateTitle: false,
-                            reloadData: false
-                        )
-                        await self.markRefreshFinished(
-                            feedID: feed.id,
-                            cancelled: Task.isCancelled
-                        )
-                    }
-                    submitted += 1
-                }
-                while await group.next() != nil {
-                    if Task.isCancelled {
-                        group.cancelAll()
-                        continue
-                    }
-                    if let feed = iterator.next() {
-                        group.addTask {
-                            guard !Task.isCancelled else { return }
-                            await self.markRefreshStarted(feedID: feed.id)
-                            try? await self.refreshFeed(
-                                feed,
-                                updateTitle: false,
-                                reloadData: false
-                            )
-                            await self.markRefreshFinished(
-                                feedID: feed.id,
-                                cancelled: Task.isCancelled
-                            )
-                        }
-                    }
-                }
-            }
+            async let regular: Void = self.runTitleSafeBoundedRefresh(
+                queues.regular, maxConcurrent: maxConcurrent
+            )
+            async let slow: Void = self.runTitleSafeBoundedRefresh(
+                queues.slow, maxConcurrent: maxConcurrent
+            )
+            async let xRefresh: Void = self.runTitleSafeBoundedRefresh(
+                queues.x, maxConcurrent: maxConcurrent
+            )
+            async let instagramRefresh: Void = self.runTitleSafeBoundedRefresh(
+                queues.instagram, maxConcurrent: maxConcurrent
+            )
             async let iconRefresh: Void = IconCache.shared.refreshIcons(
                 for: currentFeeds.map { ($0.domain, $0.siteURL as String?) }
             )
-            _ = await (feedRefresh, iconRefresh)
+            _ = await (regular, slow, xRefresh, instagramRefresh, iconRefresh)
         }
         await MainActor.run { self.refreshTask = work }
         _ = await work.value

--- a/App/Classes/Feed Manager/FeedManager+RefreshQueues.swift
+++ b/App/Classes/Feed Manager/FeedManager+RefreshQueues.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// Hard ceiling on concurrent refresh tasks per queue. Each refresh runs four
+/// independent queues (regular RSS, slow RSS, X, Instagram), so the total
+/// concurrent in-flight refresh count tops out at 4 * `maxConcurrentPerQueue`.
+enum FeedRefreshQueueLimits {
+    static let maxConcurrentPerQueue = 4
+}
+
+/// Bucketed feeds for the four-queue refresh pipeline.
+struct FeedRefreshQueues: Sendable {
+    let regular: [Feed]
+    let slow: [Feed]
+    let x: [Feed]
+    let instagram: [Feed]
+}
+
+extension FeedManager {
+
+    /// Splits feeds into the four refresh queues. X and Instagram are routed by
+    /// type; remaining feeds are routed by their last recorded refresh duration
+    /// so feeds that exceeded the slow threshold last time end up on the slow
+    /// queue this time.
+    func partitionRefreshQueues(_ feeds: [Feed]) -> FeedRefreshQueues {
+        let metrics = (try? database.allFeedRefreshMetrics()) ?? [:]
+        let slowThresholdMs = FeedRefreshMetric.slowDurationThresholdMs
+
+        var regular: [Feed] = []
+        var slow: [Feed] = []
+        var x: [Feed] = []
+        var instagram: [Feed] = []
+
+        for feed in feeds {
+            if feed.isXFeed {
+                x.append(feed)
+            } else if feed.isInstagramFeed {
+                instagram.append(feed)
+            } else if let metric = metrics[feed.id] {
+                if metric.lastDurationMs >= slowThresholdMs {
+                    slow.append(feed)
+                } else {
+                    regular.append(feed)
+                }
+            } else if feed.isSlowRefreshFeed {
+                slow.append(feed)
+            } else {
+                regular.append(feed)
+            }
+        }
+
+        return FeedRefreshQueues(regular: regular, slow: slow, x: x, instagram: instagram)
+    }
+}

--- a/App/Classes/Feed Manager/FeedManager+RefreshQueues.swift
+++ b/App/Classes/Feed Manager/FeedManager+RefreshQueues.swift
@@ -11,7 +11,7 @@ enum FeedRefreshQueueLimits {
 struct FeedRefreshQueues: Sendable {
     let regular: [Feed]
     let slow: [Feed]
-    let x: [Feed]
+    let x: [Feed] // swiftlint:disable:this identifier_name
     let instagram: [Feed]
 }
 
@@ -27,7 +27,7 @@ extension FeedManager {
 
         var regular: [Feed] = []
         var slow: [Feed] = []
-        var x: [Feed] = []
+        var x: [Feed] = [] // swiftlint:disable:this identifier_name
         var instagram: [Feed] = []
 
         for feed in feeds {

--- a/App/Classes/Feed Manager/FeedManager+ScopedRefresh.swift
+++ b/App/Classes/Feed Manager/FeedManager+ScopedRefresh.swift
@@ -45,26 +45,39 @@ extension FeedManager {
             }
         }
 
-        let slowFeeds = feeds.filter { $0.isSlowRefreshFeed }
-        let regularFeeds = feeds.filter { !$0.isSlowRefreshFeed }
+        let queues = partitionRefreshQueues(feeds)
 
         let work = Task { [weak self] in
             guard let self else { return }
-            async let slow: Void = self.runScopedBoundedRefresh(
-                slowFeeds,
-                scope: scope,
-                maxConcurrent: 2,
-                skipImagePreload: effectiveSkipPreload,
-                runNLP: runNLP
-            )
             async let regular: Void = self.runScopedBoundedRefresh(
-                regularFeeds,
+                queues.regular,
                 scope: scope,
-                maxConcurrent: 8,
+                maxConcurrent: FeedRefreshQueueLimits.maxConcurrentPerQueue,
                 skipImagePreload: effectiveSkipPreload,
                 runNLP: runNLP
             )
-            _ = await (slow, regular)
+            async let slow: Void = self.runScopedBoundedRefresh(
+                queues.slow,
+                scope: scope,
+                maxConcurrent: FeedRefreshQueueLimits.maxConcurrentPerQueue,
+                skipImagePreload: effectiveSkipPreload,
+                runNLP: runNLP
+            )
+            async let xRefresh: Void = self.runScopedBoundedRefresh(
+                queues.x,
+                scope: scope,
+                maxConcurrent: FeedRefreshQueueLimits.maxConcurrentPerQueue,
+                skipImagePreload: effectiveSkipPreload,
+                runNLP: runNLP
+            )
+            async let instagramRefresh: Void = self.runScopedBoundedRefresh(
+                queues.instagram,
+                scope: scope,
+                maxConcurrent: FeedRefreshQueueLimits.maxConcurrentPerQueue,
+                skipImagePreload: effectiveSkipPreload,
+                runNLP: runNLP
+            )
+            _ = await (regular, slow, xRefresh, instagramRefresh)
         }
         await MainActor.run { self.scopedRefreshTasks[scope] = work }
         _ = await work.value

--- a/Feeds/FeedRefreshMetric.swift
+++ b/Feeds/FeedRefreshMetric.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// Cached refresh-duration sample for a feed. Used to route slow feeds to a
+/// dedicated refresh queue on subsequent refreshes.
+nonisolated struct FeedRefreshMetric: Sendable, Hashable {
+    let feedID: Int64
+    var lastDurationMs: Int
+    var averageDurationMs: Double
+    var sampleCount: Int
+    var lastRecordedAt: Date
+
+    /// Threshold in milliseconds above which a feed is considered slow.
+    static let slowDurationThresholdMs: Int = 3_000
+
+    var isSlow: Bool {
+        lastDurationMs >= Self.slowDurationThresholdMs
+    }
+}

--- a/Shared/Database Manager/DatabaseManager+Feeds.swift
+++ b/Shared/Database Manager/DatabaseManager+Feeds.swift
@@ -96,6 +96,7 @@ nonisolated extension DatabaseManager {
     func deleteFeed(id: Int64) throws {
         try database.run(articles.filter(articleFeedID == id).delete())
         try database.run(feedRules.filter(ruleFeedID == id).delete())
+        try database.run(feedRefreshMetrics.filter(metricFeedID == id).delete())
         try removeDeletedFeedFromLists(feedID: id)
         try database.run(feeds.filter(feedID == id).delete())
     }

--- a/Shared/Database Manager/DatabaseManager+FixUp.swift
+++ b/Shared/Database Manager/DatabaseManager+FixUp.swift
@@ -133,5 +133,14 @@ nonisolated extension DatabaseManager {
         _ = try? database.run(contentOverrides.addColumn(coTitleField, defaultValue: "default"))
         _ = try? database.run(contentOverrides.addColumn(coBodyField, defaultValue: "default"))
         _ = try? database.run(contentOverrides.addColumn(coAuthorField, defaultValue: "default"))
+
+        // feed_refresh_metrics table
+        _ = try? database.run(feedRefreshMetrics.create(ifNotExists: true) { table in
+            table.column(metricFeedID, primaryKey: true, references: feeds, feedID)
+            table.column(metricLastDurationMs, defaultValue: 0)
+            table.column(metricAverageDurationMs, defaultValue: 0.0)
+            table.column(metricSampleCount, defaultValue: 0)
+            table.column(metricLastRecordedAt, defaultValue: 0.0)
+        })
     }
 }

--- a/Shared/Database Manager/DatabaseManager+RefreshMetrics.swift
+++ b/Shared/Database Manager/DatabaseManager+RefreshMetrics.swift
@@ -1,0 +1,63 @@
+import Foundation
+@preconcurrency import SQLite
+
+nonisolated extension DatabaseManager {
+
+    /// Persists a refresh-duration sample for the given feed, blending it into
+    /// a running average so the slow-feed router can react to multiple samples.
+    func recordFeedRefreshMetric(feedID: Int64, durationMs: Int) throws {
+        let now = Date().timeIntervalSince1970
+        if let existing = try database.pluck(feedRefreshMetrics.filter(metricFeedID == feedID)) {
+            let priorCount = existing[metricSampleCount]
+            let priorAverage = existing[metricAverageDurationMs]
+            let nextCount = priorCount + 1
+            let blendedAverage = ((priorAverage * Double(priorCount)) + Double(durationMs))
+                / Double(nextCount)
+            try database.run(feedRefreshMetrics.filter(metricFeedID == feedID).update(
+                metricLastDurationMs <- durationMs,
+                metricAverageDurationMs <- blendedAverage,
+                metricSampleCount <- nextCount,
+                metricLastRecordedAt <- now
+            ))
+        } else {
+            try database.run(feedRefreshMetrics.insert(
+                metricFeedID <- feedID,
+                metricLastDurationMs <- durationMs,
+                metricAverageDurationMs <- Double(durationMs),
+                metricSampleCount <- 1,
+                metricLastRecordedAt <- now
+            ))
+        }
+    }
+
+    func feedRefreshMetric(feedID: Int64) throws -> FeedRefreshMetric? {
+        guard let row = try database.pluck(
+            feedRefreshMetrics.filter(metricFeedID == feedID)
+        ) else { return nil }
+        return rowToFeedRefreshMetric(row)
+    }
+
+    /// Returns every recorded refresh metric, keyed by feed id.
+    func allFeedRefreshMetrics() throws -> [Int64: FeedRefreshMetric] {
+        var results: [Int64: FeedRefreshMetric] = [:]
+        for row in try database.prepare(feedRefreshMetrics) {
+            let metric = rowToFeedRefreshMetric(row)
+            results[metric.feedID] = metric
+        }
+        return results
+    }
+
+    func deleteFeedRefreshMetric(feedID: Int64) throws {
+        try database.run(feedRefreshMetrics.filter(metricFeedID == feedID).delete())
+    }
+
+    private func rowToFeedRefreshMetric(_ row: Row) -> FeedRefreshMetric {
+        FeedRefreshMetric(
+            feedID: row[metricFeedID],
+            lastDurationMs: row[metricLastDurationMs],
+            averageDurationMs: row[metricAverageDurationMs],
+            sampleCount: row[metricSampleCount],
+            lastRecordedAt: Date(timeIntervalSince1970: row[metricLastRecordedAt])
+        )
+    }
+}

--- a/Shared/Database Manager/DatabaseManager.swift
+++ b/Shared/Database Manager/DatabaseManager.swift
@@ -123,6 +123,13 @@ nonisolated final class DatabaseManager: @unchecked Sendable {
     let coBodyField = SQLite.Expression<String>("body_field")
     let coAuthorField = SQLite.Expression<String>("author_field")
 
+    let feedRefreshMetrics = Table("feed_refresh_metrics")
+    let metricFeedID = SQLite.Expression<Int64>("feed_id")
+    let metricLastDurationMs = SQLite.Expression<Int>("last_duration_ms")
+    let metricAverageDurationMs = SQLite.Expression<Double>("avg_duration_ms")
+    let metricSampleCount = SQLite.Expression<Int>("sample_count")
+    let metricLastRecordedAt = SQLite.Expression<Double>("last_recorded_at")
+
     // MARK: - Init
 
     private init() {
@@ -320,6 +327,14 @@ nonisolated final class DatabaseManager: @unchecked Sendable {
             table.column(coTitleField, defaultValue: "default")
             table.column(coBodyField, defaultValue: "default")
             table.column(coAuthorField, defaultValue: "default")
+        })
+
+        try database.run(feedRefreshMetrics.create(ifNotExists: true) { table in
+            table.column(metricFeedID, primaryKey: true, references: feeds, feedID)
+            table.column(metricLastDurationMs, defaultValue: 0)
+            table.column(metricAverageDurationMs, defaultValue: 0.0)
+            table.column(metricSampleCount, defaultValue: 0)
+            table.column(metricLastRecordedAt, defaultValue: 0.0)
         })
     }
 


### PR DESCRIPTION
## Summary

Splits every refresh into four parallel queues, each capped at four in-flight feeds:

1. **Regular RSS** – fast feeds
2. **Slow RSS** – feeds whose last recorded refresh exceeded 3 s
3. **X profiles** – throttled fetcher needs its own lane
4. **Instagram profiles** – throttled fetcher needs its own lane

Each refresh records the elapsed time in a new `feed_refresh_metrics` SQLite table (`last_duration_ms`, running `avg_duration_ms`, `sample_count`, `last_recorded_at`). The slow/regular split for non-X/non-Instagram feeds is driven by the most recent sample, so feeds that crossed the 3 s threshold last time start in the slow queue next time and stop dragging the regular queue.

The same four-queue partitioning is applied to `refreshAllFeeds`, scoped pull-to-refresh (`refreshFeeds(scope:feeds:)`), and `refreshAllFeedsAndIcons`.

### Files

- `Feeds/FeedRefreshMetric.swift` – new model + 3 s slow threshold
- `Shared/Database Manager/DatabaseManager.swift`, `+FixUp.swift`, `+RefreshMetrics.swift`, `+Feeds.swift` – schema, fixup, CRUD, cleanup on feed delete
- `App/Classes/Feed Manager/FeedManager+RefreshQueues.swift` – queue limit constant, `FeedRefreshQueues` struct, `partitionRefreshQueues(_:)` router
- `App/Classes/Feed Manager/FeedManager+Refresh.swift` – defer-based duration capture inside `refreshFeed`, four-queue dispatch in `refreshAllFeeds` and `refreshAllFeedsAndIcons`
- `App/Classes/Feed Manager/FeedManager+ScopedRefresh.swift` – four-queue dispatch for scoped refreshes

## Test plan

- [ ] Cold launch, fresh install: first refresh splits into the four queues; metrics table populates as feeds finish.
- [ ] Add a deliberately slow feed (e.g. via a slow proxy). After the first refresh it appears in the regular queue; on the next refresh it appears in the slow queue.
- [ ] Pull-to-refresh on Home: scoped progress donut still updates correctly.
- [ ] Background refresh budget paths (`refreshFeeds(in:category:…)`) still work; per-category concurrency unchanged.
- [ ] Delete a feed: its row in `feed_refresh_metrics` is removed.
- [ ] App upgrade from previous schema: `fixup()` creates `feed_refresh_metrics` without errors.


---
_Generated by [Claude Code](https://claude.ai/code/session_01V5Em1ML6Gepc96tPpvNCU7)_