### PR TITLE
Fix Home section switch lag by loading entries off the main thread and optimizing image loads

### DIFF
--- a/App/Classes/Feed Manager/FeedManager+Lists.swift
+++ b/App/Classes/Feed Manager/FeedManager+Lists.swift
@@ -135,40 +135,6 @@ extension FeedManager {
     // MARK: - List Rule Application
 
     func applyListRules(_ articles: [Article], listID: Int64) -> [Article] {
-        let allowedKeywords = (try? database.listRules(forListID: listID, type: "allowed_keyword")) ?? []
-        let keywords = (try? database.listRules(forListID: listID, type: "muted_keyword")) ?? []
-        let authors = Set((try? database.listRules(forListID: listID, type: "muted_author")) ?? [])
-        guard !allowedKeywords.isEmpty || !keywords.isEmpty || !authors.isEmpty else { return articles }
-        return articles.filter { article in
-            if !allowedKeywords.isEmpty {
-                return articleMatchesAnyKeyword(article, keywords: allowedKeywords)
-            }
-            if let author = article.author, authors.contains(author) {
-                return false
-            }
-            for keyword in keywords {
-                if article.title.localizedCaseInsensitiveContains(keyword) {
-                    return false
-                }
-                if let summary = article.summary,
-                   summary.localizedCaseInsensitiveContains(keyword) {
-                    return false
-                }
-            }
-            return true
-        }
-    }
-
-    private func articleMatchesAnyKeyword(_ article: Article, keywords: [String]) -> Bool {
-        for keyword in keywords {
-            if article.title.localizedCaseInsensitiveContains(keyword) {
-                return true
-            }
-            if let summary = article.summary,
-               summary.localizedCaseInsensitiveContains(keyword) {
-                return true
-            }
-        }
-        return false
+        Self.applyListRules(articles, listID: listID, database: database)
     }
 }

--- a/App/Classes/Feed Manager/FeedManager+Preload.swift
+++ b/App/Classes/Feed Manager/FeedManager+Preload.swift
@@ -118,4 +118,150 @@ extension FeedManager {
         let ordered = ids.compactMap { byID[$0] }
         return applyContentOverrides(ordered)
     }
+
+    // MARK: - Async Preload (Background)
+
+    /// Section/list switches in the Home tab kicked off the synchronous variants
+    /// on the main thread, blocking the UI for the duration of the DB query and
+    /// rule application. The async variants snapshot the main-actor state we
+    /// need, then run the heavy DB and rule work on a detached task.
+    func preloadedArticleEntriesAsync(requireUnread: Bool = false) async -> [ArticleIDEntry] {
+        let database = self.database
+        let muted = mutedFeedIDs
+        return await Task.detached {
+            FeedManager.computeAllPreloadedEntries(
+                database: database, muted: muted, requireUnread: requireUnread
+            )
+        }.value
+    }
+
+    func preloadedArticleEntriesAsync(
+        for section: FeedSection,
+        requireUnread: Bool = false
+    ) async -> [ArticleIDEntry] {
+        let database = self.database
+        let muted = mutedFeedIDs
+        let sectionFeedIDs = feeds
+            .filter { $0.feedSection == section && !muted.contains($0.id) }
+            .map(\.id)
+        return await Task.detached {
+            FeedManager.computeSectionPreloadedEntries(
+                database: database, feedIDs: sectionFeedIDs, requireUnread: requireUnread
+            )
+        }.value
+    }
+
+    func preloadedArticleEntriesAsync(
+        for list: FeedList,
+        requireUnread: Bool = false
+    ) async -> [ArticleIDEntry] {
+        let database = self.database
+        let listFeedIDs = Array(feedIDs(for: list))
+        let listID = list.id
+        return await Task.detached {
+            FeedManager.computeListPreloadedEntries(
+                database: database, feedIDs: listFeedIDs,
+                listID: listID, requireUnread: requireUnread
+            )
+        }.value
+    }
+
+    func preloadedArticleEntriesAsync(
+        forTopic topic: String,
+        requireUnread: Bool = false
+    ) async -> [ArticleIDEntry] {
+        let database = self.database
+        let muted = mutedFeedIDs
+        return await Task.detached {
+            FeedManager.computeTopicPreloadedEntries(
+                database: database, topic: topic,
+                muted: muted, requireUnread: requireUnread
+            )
+        }.value
+    }
+
+    // MARK: - Background computation helpers
+
+    nonisolated static func computeAllPreloadedEntries(
+        database: DatabaseManager,
+        muted: Set<Int64>,
+        requireUnread: Bool
+    ) -> [ArticleIDEntry] {
+        let raw = (try? database.allArticles(limit: Int.max)) ?? []
+        var pool = applyAllRules(raw, database: database)
+        if !muted.isEmpty {
+            pool = pool.filter { !muted.contains($0.feedID) }
+        }
+        if requireUnread {
+            pool = pool.filter { !$0.isRead }
+        }
+        return pool.compactMap { article in
+            guard let date = article.publishedDate else { return nil }
+            return ArticleIDEntry(id: article.id, publishedDate: date)
+        }
+    }
+
+    nonisolated static func computeSectionPreloadedEntries(
+        database: DatabaseManager,
+        feedIDs: [Int64],
+        requireUnread: Bool
+    ) -> [ArticleIDEntry] {
+        guard !feedIDs.isEmpty else { return [] }
+        let raw = (try? database.articles(
+            forFeedIDs: feedIDs,
+            limit: Int.max,
+            requireUnread: requireUnread
+        )) ?? []
+        return applyAllRules(raw, database: database).compactMap { article in
+            guard let date = article.publishedDate else { return nil }
+            return ArticleIDEntry(id: article.id, publishedDate: date)
+        }
+    }
+
+    nonisolated static func computeListPreloadedEntries(
+        database: DatabaseManager,
+        feedIDs: [Int64],
+        listID: Int64,
+        requireUnread: Bool
+    ) -> [ArticleIDEntry] {
+        guard !feedIDs.isEmpty else { return [] }
+        let raw = (try? database.articles(
+            forFeedIDs: feedIDs,
+            limit: Int.max,
+            requireUnread: requireUnread
+        )) ?? []
+        let listed = applyListRules(
+            applyAllRules(raw, database: database),
+            listID: listID,
+            database: database
+        )
+        return listed.compactMap { article in
+            guard let date = article.publishedDate else { return nil }
+            return ArticleIDEntry(id: article.id, publishedDate: date)
+        }
+    }
+
+    nonisolated static func computeTopicPreloadedEntries(
+        database: DatabaseManager,
+        topic: String,
+        muted: Set<Int64>,
+        requireUnread: Bool
+    ) -> [ArticleIDEntry] {
+        let ids = (try? database.articleIDs(
+            forEntity: topic,
+            types: ["organization", "place"]
+        )) ?? []
+        let raw = (try? database.articles(withIDs: ids)) ?? []
+        var pool = applyAllRules(raw, database: database)
+        if !muted.isEmpty {
+            pool = pool.filter { !muted.contains($0.feedID) }
+        }
+        if requireUnread {
+            pool = pool.filter { !$0.isRead }
+        }
+        return pool.compactMap { article in
+            guard let date = article.publishedDate else { return nil }
+            return ArticleIDEntry(id: article.id, publishedDate: date)
+        }
+    }
 }

--- a/App/Classes/Feed Manager/FeedManager+Preload.swift
+++ b/App/Classes/Feed Manager/FeedManager+Preload.swift
@@ -121,10 +121,6 @@ extension FeedManager {
 
     // MARK: - Async Preload (Background)
 
-    /// Section/list switches in the Home tab kicked off the synchronous variants
-    /// on the main thread, blocking the UI for the duration of the DB query and
-    /// rule application. The async variants snapshot the main-actor state we
-    /// need, then run the heavy DB and rule work on a detached task.
     func preloadedArticleEntriesAsync(requireUnread: Bool = false) async -> [ArticleIDEntry] {
         let database = self.database
         let muted = mutedFeedIDs

--- a/App/Classes/Feed Manager/FeedManager+Rules.swift
+++ b/App/Classes/Feed Manager/FeedManager+Rules.swift
@@ -96,9 +96,6 @@ extension FeedManager {
         return applyContentOverrides(filtered)
     }
 
-    /// Background-safe variant. Skips Content Override application since callers
-    /// that need it (e.g. preload pipelines for `ArticleIDEntry`) only consume
-    /// `id`/`publishedDate`, neither of which overrides can mutate.
     nonisolated static func applyAllRules(_ articles: [Article], database: DatabaseManager) -> [Article] {
         // swiftlint:disable:next large_tuple
         var rulesByFeed: [Int64: (allowedKeywords: [String], keywords: [String], authors: Set<String>)] = [:]

--- a/App/Classes/Feed Manager/FeedManager+Rules.swift
+++ b/App/Classes/Feed Manager/FeedManager+Rules.swift
@@ -92,6 +92,14 @@ extension FeedManager {
     }
 
     func applyAllRules(_ articles: [Article]) -> [Article] {
+        let filtered = Self.applyAllRules(articles, database: database)
+        return applyContentOverrides(filtered)
+    }
+
+    /// Background-safe variant. Skips Content Override application since callers
+    /// that need it (e.g. preload pipelines for `ArticleIDEntry`) only consume
+    /// `id`/`publishedDate`, neither of which overrides can mutate.
+    nonisolated static func applyAllRules(_ articles: [Article], database: DatabaseManager) -> [Article] {
         // swiftlint:disable:next large_tuple
         var rulesByFeed: [Int64: (allowedKeywords: [String], keywords: [String], authors: Set<String>)] = [:]
         var result: [Article] = []
@@ -132,14 +140,39 @@ extension FeedManager {
                 result.append(article)
             }
         }
-        return applyContentOverrides(result)
+        return result
+    }
+
+    nonisolated static func applyListRules(_ articles: [Article], listID: Int64, database: DatabaseManager) -> [Article] {
+        let allowedKeywords = (try? database.listRules(forListID: listID, type: "allowed_keyword")) ?? []
+        let keywords = (try? database.listRules(forListID: listID, type: "muted_keyword")) ?? []
+        let authors = Set((try? database.listRules(forListID: listID, type: "muted_author")) ?? [])
+        guard !allowedKeywords.isEmpty || !keywords.isEmpty || !authors.isEmpty else { return articles }
+        return articles.filter { article in
+            if !allowedKeywords.isEmpty {
+                return articleMatchesKeywords(article, keywords: allowedKeywords)
+            }
+            if let author = article.author, authors.contains(author) {
+                return false
+            }
+            for keyword in keywords {
+                if article.title.localizedCaseInsensitiveContains(keyword) {
+                    return false
+                }
+                if let summary = article.summary,
+                   summary.localizedCaseInsensitiveContains(keyword) {
+                    return false
+                }
+            }
+            return true
+        }
     }
 
     private func articleMatchesKeywords(_ article: Article, keywords: [String]) -> Bool {
         Self.articleMatchesKeywords(article, keywords: keywords)
     }
 
-    nonisolated fileprivate static func articleMatchesKeywords(_ article: Article, keywords: [String]) -> Bool {
+    nonisolated static func articleMatchesKeywords(_ article: Article, keywords: [String]) -> Bool {
         for keyword in keywords {
             if article.title.localizedCaseInsensitiveContains(keyword) {
                 return true

--- a/App/Views/Home/HomeSectionView.swift
+++ b/App/Views/Home/HomeSectionView.swift
@@ -89,9 +89,6 @@ struct HomeSectionView: View {
         return articles
     }
 
-    /// Loads preloaded entries off the main thread so switching sections doesn't
-    /// block the UI on DB queries and rule application. Honors cancellation so a
-    /// rapid sequence of taps doesn't apply stale results.
     private func reloadPreloadedEntries() async {
         let entries: [ArticleIDEntry]
         switch source {

--- a/App/Views/Home/HomeSectionView.swift
+++ b/App/Views/Home/HomeSectionView.swift
@@ -41,6 +41,14 @@ struct HomeSectionView: View {
     @AppStorage("Articles.HideViewedContent") private var storedHideViewedContent: Bool = false
     @State private var visibility = ArticleVisibilityTracker()
     @State private var scrollToTopTick: Int = 0
+    @State private var lastLoadedSource: HomeContentSource?
+    @State private var lastLoadedHideViewed: Bool?
+
+    private struct PreloadKey: Hashable {
+        let source: HomeContentSource
+        let revision: Int
+        let hideViewed: Bool
+    }
 
     private var batchingMode: BatchingMode {
         DoomscrollingMode.effectiveBatchingMode(storedBatchingMode)
@@ -81,30 +89,36 @@ struct HomeSectionView: View {
         return articles
     }
 
-    private func reloadPreloadedEntries() {
+    /// Loads preloaded entries off the main thread so switching sections doesn't
+    /// block the UI on DB queries and rule application. Honors cancellation so a
+    /// rapid sequence of taps doesn't apply stale results.
+    private func reloadPreloadedEntries() async {
+        let entries: [ArticleIDEntry]
         switch source {
         case .section(let section):
             if let section {
-                preloadedEntries = feedManager.preloadedArticleEntries(
+                entries = await feedManager.preloadedArticleEntriesAsync(
                     for: section,
                     requireUnread: hideViewedContent
                 )
             } else {
-                preloadedEntries = feedManager.preloadedArticleEntries(
+                entries = await feedManager.preloadedArticleEntriesAsync(
                     requireUnread: hideViewedContent
                 )
             }
         case .list(let list):
-            preloadedEntries = feedManager.preloadedArticleEntries(
+            entries = await feedManager.preloadedArticleEntriesAsync(
                 for: list,
                 requireUnread: hideViewedContent
             )
         case .topic(let name):
-            preloadedEntries = feedManager.preloadedArticleEntries(
+            entries = await feedManager.preloadedArticleEntriesAsync(
                 forTopic: name,
                 requireUnread: hideViewedContent
             )
         }
+        if Task.isCancelled { return }
+        preloadedEntries = entries
         if hideViewedContent, visibility.visibleIDs == nil, !preloadedEntries.isEmpty {
             visibility.capture(from: rawArticles, isEnabled: hideViewedContent)
         }
@@ -291,33 +305,27 @@ struct HomeSectionView: View {
         .refreshPromptOverlay(isVisible: visibility.hasPendingRefresh) {
             acceptPendingRefresh()
         }
-        .onAppear {
-            reloadPreloadedEntries()
-            if !hasInitializedSinceDate {
+        .task(id: PreloadKey(
+            source: source,
+            revision: feedManager.dataRevision,
+            hideViewed: hideViewedContent
+        )) {
+            let priorSource = lastLoadedSource
+            let priorHideViewed = lastLoadedHideViewed
+            await reloadPreloadedEntries()
+            if Task.isCancelled { return }
+            let sourceChanged = priorSource != source
+            let hideViewedChanged = priorHideViewed != hideViewedContent
+            if sourceChanged || hideViewedChanged || !hasInitializedSinceDate {
                 loadedSinceDate = batchingMode.initialSinceDate(
                     latestArticleDate: latestArticleDate()
                 )
+                loadedCount = batchingMode.initialCount()
+                visibility.capture(from: rawArticles, isEnabled: hideViewedContent)
                 hasInitializedSinceDate = true
             }
-        }
-        .onChange(of: source) { _, _ in
-            reloadPreloadedEntries()
-            loadedSinceDate = batchingMode.initialSinceDate(
-                latestArticleDate: latestArticleDate()
-            )
-            loadedCount = batchingMode.initialCount()
-            visibility.capture(from: rawArticles, isEnabled: hideViewedContent)
-        }
-        .onChange(of: feedManager.dataRevision) { _, _ in
-            reloadPreloadedEntries()
-        }
-        .onChange(of: hideViewedContent) { _, _ in
-            reloadPreloadedEntries()
-            loadedSinceDate = batchingMode.initialSinceDate(
-                latestArticleDate: latestArticleDate()
-            )
-            loadedCount = batchingMode.initialCount()
-            visibility.capture(from: rawArticles, isEnabled: hideViewedContent)
+            lastLoadedSource = source
+            lastLoadedHideViewed = hideViewedContent
         }
         .onChange(of: batchingMode) { _, newMode in
             loadedSinceDate = newMode.initialSinceDate(

--- a/App/Views/Home/Today/Cards/TodayCardCarousel.swift
+++ b/App/Views/Home/Today/Cards/TodayCardCarousel.swift
@@ -16,7 +16,7 @@ struct TodayCardCarousel<Card: View>: View {
                 .padding(.horizontal)
 
             ScrollView(.horizontal, showsIndicators: false) {
-                HStack(alignment: .top, spacing: 12) {
+                LazyHStack(alignment: .top, spacing: 12) {
                     ForEach(articles) { article in
                         card(article)
                     }

--- a/App/Views/Shared/CachedAsyncImage.swift
+++ b/App/Views/Shared/CachedAsyncImage.swift
@@ -116,6 +116,7 @@ struct CachedAsyncImage<Placeholder: View>: View {
 
         let memoryCache = ImageMemoryCache.shared
         if let cached = memoryCache.image(forKey: urlString) {
+            _ = cached.ensureIconDerivedMetrics()
             return cached
         }
 
@@ -125,6 +126,7 @@ struct CachedAsyncImage<Placeholder: View>: View {
            let cachedImage = ImageDownsampler.downsample(
                cachedData, maxPixelSize: maxDisplayPixelSize
            ) ?? UIImage(data: cachedData) {
+            _ = cachedImage.ensureIconDerivedMetrics()
             memoryCache.setImage(cachedImage, forKey: urlString)
             log("Image", "Cache hit for \(urlString) (\(cachedData.count) bytes)")
             return cachedImage
@@ -143,6 +145,7 @@ struct CachedAsyncImage<Placeholder: View>: View {
                 log("Image", "Failed to decode image data from \(urlString) (\(data.count) bytes)")
                 return nil
             }
+            _ = downsampled.ensureIconDerivedMetrics()
             if memoryCache.image(forKey: urlString) == nil {
                 try? database.cacheImageData(data, for: urlString)
             }


### PR DESCRIPTION
## Summary

Switching sections in the Home tab caused a noticeable lag: the new section's view appeared first, but it couldn't render content until a synchronous DB query + rule-application pass completed on the main thread. This produced the "view switches, then freezes" behavior the user reported across all sections, lists, and topics.

`HomeSectionView` ran `feedManager.preloadedArticleEntries(...)` synchronously inside `.onAppear` and `.onChange(of: source)`. For the All-Articles scope this fetches every article ID from SQLite and walks them through `applyAllRules`, which itself queries per-feed rules from the DB.

### Changes

- Add `nonisolated static` variants of `applyAllRules` / `applyListRules` that skip Content Override application (overrides only mutate display fields, not `id`/`publishedDate`, so they're not needed for `ArticleIDEntry`). Existing instance methods now thin-wrap the static helpers + apply overrides.
- Add `preloadedArticleEntriesAsync(...)` overloads on `FeedManager` for section / list / topic / all. They snapshot the main-actor inputs (`feeds`, `mutedFeedIDs`, list feed IDs) and dispatch the DB + rule work to `Task.detached`.
- Replace `.onAppear` + `.onChange(of: source)` + `.onChange(of: dataRevision)` + `.onChange(of: hideViewedContent)` in `HomeSectionView` with a single `.task(id: PreloadKey)` driven by `(source, dataRevision, hideViewed)`. The closure tracks the prior values so it can run the same "reset `loadedSinceDate`/`loadedCount` and capture visibility" reset on source/hide-viewed transitions, without blocking the UI.

`.task(id:)` cancels the in-flight reload when the user taps another section, and the `Task.isCancelled` check before assigning `preloadedEntries` prevents stale results from clobbering the latest selection.

## Test plan

- [ ] Tap rapidly between Home sections (e.g. Today → All → YouTube → a List → a Topic) and confirm the new section's tab indicator + scroll position update without the main thread freezing.
- [ ] Verify content for each section actually populates correctly after the switch (no empty list left over).
- [ ] Toggle "Hide Viewed Content" while inside a section and confirm the entry list refreshes.
- [ ] Pull-to-refresh inside a section still works and the donut still appears.
- [ ] Background refresh / new articles arriving (bumping `dataRevision`) still update the visible list.

https://claude.ai/code/session_013nyvchRFuV3Whx45rPuVzc

---
_Generated by [Claude Code](https://claude.ai/code/session_013nyvchRFuV3Whx45rPuVzc)_