### PR TITLE
Refresh cooldown copy, YouTube player tweaks, PiP ad skip fix

### DIFF
--- a/App/Views/Viewers/YouTube Player/YouTubePlayerScripts.swift
+++ b/App/Views/Viewers/YouTube Player/YouTubePlayerScripts.swift
@@ -543,10 +543,6 @@ nonisolated enum YouTubePlayerScripts {
 
             var desired;
             if (isAd) {
-                // Bind every forward-style PiP control to skip-ad so the
-                // ad ends regardless of which button iOS exposes (seek
-                // forward vs. next track). Backward controls stay unbound
-                // since rewinding during an ad has no useful behavior.
                 desired = {
                     previoustrack: null,
                     nexttrack: performSkipAd,

--- a/App/Views/Viewers/YouTube Player/YouTubePlayerScripts.swift
+++ b/App/Views/Viewers/YouTube Player/YouTubePlayerScripts.swift
@@ -543,13 +543,15 @@ nonisolated enum YouTubePlayerScripts {
 
             var desired;
             if (isAd) {
-                // Null out seek handlers so iOS shows previous/next-track
-                // controls (mapped to skip-ad) instead of seek controls.
+                // Bind every forward-style PiP control to skip-ad so the
+                // ad ends regardless of which button iOS exposes (seek
+                // forward vs. next track). Backward controls stay unbound
+                // since rewinding during an ad has no useful behavior.
                 desired = {
                     previoustrack: null,
                     nexttrack: performSkipAd,
                     seekbackward: null,
-                    seekforward: null
+                    seekforward: performSkipAd
                 };
             } else {
                 desired = {

--- a/App/Views/Viewers/YouTube Player/YouTubePlayerView.swift
+++ b/App/Views/Viewers/YouTube Player/YouTubePlayerView.swift
@@ -157,7 +157,7 @@ struct YouTubePlayerView: View {
 
                     Group {
                         if let feed {
-                            HStack(alignment: .top, spacing: 12) {
+                            HStack(alignment: .center, spacing: 12) {
                                 feedAvatarView
 
                                 VStack(alignment: .leading, spacing: 2) {
@@ -173,7 +173,7 @@ struct YouTubePlayerView: View {
                                 Spacer(minLength: 0)
                             }
                         } else if article.isEphemeral, let fetchedAuthor {
-                            HStack(alignment: .top, spacing: 12) {
+                            HStack(alignment: .center, spacing: 12) {
                                 Text(fetchedAuthor)
                                     .font(.subheadline.bold())
                                 Spacer(minLength: 0)

--- a/Shared/Strings/Settings.xcstrings
+++ b/Shared/Strings/Settings.xcstrings
@@ -4198,55 +4198,55 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Feeds, die innerhalb dieses Zeitraums automatisch aktualisiert wurden, werden übersprungen. Das manuelle Herunterziehen zum Aktualisieren lädt immer alles neu. Neu hinzugefügte Feeds werden sofort geladen."
+            "value" : "Feeds, die innerhalb dieses Zeitraums automatisch aktualisiert wurden, werden übersprungen. Eine manuelle Aktualisierung lädt immer alles neu. Neu hinzugefügte Feeds werden sofort geladen."
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Feeds refreshed automatically within this window are skipped. Pull-to-refresh always refreshes everything. Newly added feeds always refresh."
+            "value" : "Feeds refreshed automatically within this window are skipped. A manual refresh always refreshes everything. Newly added feeds always refresh."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Les flux déjà actualisés automatiquement dans cette fenêtre sont ignorés. Tirer pour actualiser rafraîchit toujours tout. Les nouveaux flux sont toujours actualisés."
+            "value" : "Les flux déjà actualisés automatiquement dans cette fenêtre sont ignorés. Une actualisation manuelle rafraîchit toujours tout. Les nouveaux flux sont toujours actualisés."
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "I feed aggiornati automaticamente entro questa finestra vengono saltati. Il pull-to-refresh aggiorna sempre tutto. I feed appena aggiunti si aggiornano sempre."
+            "value" : "I feed aggiornati automaticamente entro questa finestra vengono saltati. Un aggiornamento manuale aggiorna sempre tutto. I feed appena aggiunti si aggiornano sempre."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "この期間内に自動更新されたフィードはスキップされます。プルダウン更新では常にすべてが更新されます。新しく追加されたフィードは必ず更新されます。"
+            "value" : "この期間内に自動更新されたフィードはスキップされます。手動での更新では常にすべてが更新されます。新しく追加されたフィードは必ず更新されます。"
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "이 기간 동안 자동으로 새로고친 피드는 건너뜁니다. 당겨서 새로고침은 항상 전체를 새로고칩니다. 새로 추가된 피드는 항상 새로고칩니다."
+            "value" : "이 기간 동안 자동으로 새로고친 피드는 건너뜁니다. 수동 새로고침은 항상 전체를 새로고칩니다. 새로 추가된 피드는 항상 새로고칩니다."
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Các nguồn được làm mới tự động trong khoảng thời gian này sẽ bị bỏ qua. Kéo để làm mới luôn làm mới tất cả. Nguồn mới thêm luôn được làm mới."
+            "value" : "Các nguồn được làm mới tự động trong khoảng thời gian này sẽ bị bỏ qua. Làm mới thủ công luôn làm mới tất cả. Nguồn mới thêm luôn được làm mới."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在此时间窗口内自动刷新过的订阅源会被跳过。下拉刷新始终会刷新所有订阅源。新添加的订阅源始终会刷新。"
+            "value" : "在此时间窗口内自动刷新过的订阅源会被跳过。手动刷新始终会刷新所有订阅源。新添加的订阅源始终会刷新。"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在此時間範圍內已自動重新整理的訂閱源會被略過。下拉重新整理一律重新整理全部。新加入的訂閱源一律重新整理。"
+            "value" : "在此時間範圍內已自動重新整理的訂閱源會被略過。手動重新整理一律重新整理全部。新加入的訂閱源一律重新整理。"
           }
         }
       }


### PR DESCRIPTION
## Summary
- Reword the refresh-cooldown footer in `Settings.xcstrings` to use "manual refresh" terminology across all 9 languages (was "プルダウン更新"/"Pull-to-refresh" etc.)
- Vertically center the channel name + upload date stack with the avatar in the YouTube player view (`HStack` alignment changed from `.top` to `.center`)
- Bind PiP `seekforward` to skip-ad during YouTube ads so the system PiP fast-forward button actually skips the ad instead of doing nothing

## Test plan
- [ ] Open Settings and verify the refresh cooldown footer reads correctly in each localized language
- [ ] Open a YouTube video and confirm the channel info row is vertically centered next to the avatar
- [ ] Enter PiP on a YouTube video, wait for an ad, and confirm tapping the fast-forward button skips the ad

https://claude.ai/code/session_015exsfVE2Bg7J2rDqeGcKA7