### PR TITLE
Update summary card display and article windows

### DIFF
--- a/App/Classes/Feed Manager/FeedManager+Articles.swift
+++ b/App/Classes/Feed Manager/FeedManager+Articles.swift
@@ -32,12 +32,16 @@ extension FeedManager {
         return applyAllRules(all)
     }
 
+    /// Articles published between local 00:00 and 09:00, used for the
+    /// While You Slept summary card on the Today tab.
     func overnightArticles() -> [Article] {
         _ = dataRevision
         let calendar = Calendar.current
-        let now = Date()
-        let midnight = calendar.startOfDay(for: now)
-        let allOvernight = (try? database.allArticles(from: midnight, to: now)) ?? []
+        let midnight = calendar.startOfDay(for: Date())
+        guard let nineAM = calendar.date(byAdding: .hour, value: 9, to: midnight) else {
+            return []
+        }
+        let allOvernight = (try? database.allArticles(from: midnight, to: nineAM)) ?? []
         return filterExcludingPodcastsAndVideos(allOvernight)
     }
 
@@ -48,17 +52,17 @@ extension FeedManager {
         return filterExcludingPodcastsAndVideos(allToday)
     }
 
-    /// Articles published between local 12:00 and now, used for the
+    /// Articles published between local 09:00 and now, used for the
     /// Afternoon Brief summary card on the Today tab.
     func afternoonBriefArticles() -> [Article] {
         _ = dataRevision
         let calendar = Calendar.current
         let now = Date()
         let midnight = calendar.startOfDay(for: now)
-        guard let noon = calendar.date(byAdding: .hour, value: 12, to: midnight) else {
+        guard let nineAM = calendar.date(byAdding: .hour, value: 9, to: midnight) else {
             return []
         }
-        let articles = (try? database.allArticles(from: noon, to: now)) ?? []
+        let articles = (try? database.allArticles(from: nineAM, to: now)) ?? []
         return filterExcludingPodcastsAndVideos(articles)
     }
 

--- a/App/Enums/SummaryCardKind.swift
+++ b/App/Enums/SummaryCardKind.swift
@@ -35,9 +35,9 @@ enum SummaryCardKind {
     func isInTimeWindow(_ date: Date) -> Bool {
         let hour = Calendar.current.component(.hour, from: date)
         switch self {
-        case .todaysSummary: return hour >= 21
+        case .todaysSummary: return hour >= 18
         case .whileYouSlept: return hour >= 6 && hour < 12
-        case .afternoonBrief: return hour >= 12 && hour < 21
+        case .afternoonBrief: return hour >= 12 && hour < 16
         }
     }
 


### PR DESCRIPTION
## Summary

Adjusts the visibility windows and the article ranges feeding each Apple Intelligence summary card so they line up with the requested schedule:

- **While You Slept** — display window unchanged (6 AM – noon); article window narrowed to **midnight – 9 AM** (was midnight – now).
- **Afternoon Brief** — display window narrowed to **noon – 4 PM** (was noon – 9 PM); article window shifted to **9 AM – now** (was noon – now).
- **Today's Summary** — display window expanded to **6 PM – midnight** (was 9 PM onward); article window unchanged (entire day).

Implemented by editing the hour comparisons in `SummaryCardKind.isInTimeWindow(_:)` and the `Date` boundaries used by `overnightArticles()` / `afternoonBriefArticles()` in `FeedManager+Articles`. No localized strings were added or changed (the only displayed footer, `AppleIntelligence.Footer`, doesn't reference specific hours).

## Test plan

- [ ] At 7 AM local: only the While You Slept card is visible; its underlying article query returns items published from midnight up to 9 AM (and nothing later).
- [ ] At 1 PM local: only the Afternoon Brief card is visible; its query returns items published from 9 AM up through the current moment.
- [ ] At 3:30 PM local: Afternoon Brief is still visible; at 4:00 PM local it disappears.
- [ ] Between 4 PM and 6 PM local: no summary card is shown.
- [ ] At 7 PM local: Today's Summary becomes visible and stays visible through 11:59 PM; its article window covers the full day.
- [ ] `ForceWhileYouSlept` / `ForceAfternoonBrief` / `ForceTodaysSummary` overrides still bypass the time window.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D6ZYX6T1Fux9WPexLmhdgL)_