### PR TITLE
Fix UI lag during feed refresh

### DIFF
--- a/App/Classes/Feed Manager/FeedManager+InstagramProfile.swift
+++ b/App/Classes/Feed Manager/FeedManager+InstagramProfile.swift
@@ -83,7 +83,6 @@ extension FeedManager {
             )
         }
 
-        await MainActor.run { self.bumpDataRevision() }
         if reloadData {
             await loadFromDatabaseInBackground(animated: true)
         }

--- a/App/Classes/Feed Manager/FeedManager+Petal.swift
+++ b/App/Classes/Feed Manager/FeedManager+Petal.swift
@@ -116,7 +116,6 @@ extension FeedManager {
             try database.updateFeedLastFetched(id: feedID, date: Date())
         }.value
 
-        await MainActor.run { self.bumpDataRevision() }
         if reloadData {
             await loadFromDatabaseInBackground(animated: true)
         }

--- a/App/Classes/Feed Manager/FeedManager+Refresh.swift
+++ b/App/Classes/Feed Manager/FeedManager+Refresh.swift
@@ -78,7 +78,6 @@ extension FeedManager {
                 contentOnly: contentOnly
             )
         }.value
-        await MainActor.run { self.bumpDataRevision() }
         if reloadData {
             await loadFromDatabaseInBackground(animated: true)
         }

--- a/App/Classes/Feed Manager/FeedManager+XProfile.swift
+++ b/App/Classes/Feed Manager/FeedManager+XProfile.swift
@@ -85,7 +85,6 @@ extension FeedManager {
             )
         }
 
-        await MainActor.run { self.bumpDataRevision() }
         if reloadData {
             await loadFromDatabaseInBackground(animated: true)
         }

--- a/App/Classes/Feed Manager/FeedManager+YouTubePlaylist.swift
+++ b/App/Classes/Feed Manager/FeedManager+YouTubePlaylist.swift
@@ -79,7 +79,6 @@ extension FeedManager {
             )
         }
 
-        await MainActor.run { self.bumpDataRevision() }
         if reloadData {
             await loadFromDatabaseInBackground(animated: true)
         }


### PR DESCRIPTION
## Summary

Refreshing feeds caused the entire UI to stutter and lag because each per-feed completion called `bumpDataRevision()` on the main actor. `dataRevision` is observed by many heavy hooks across the app — `HomeSectionView.task(id: PreloadKey(...dataRevision...))`, `HomeView.onChange(of: dataRevision)` (top topics), `TodayView.task(id: dataRevision)`, `SummarySection`, `SummaryHeadlinesArticlesView`, `BookmarksContentView`, `EntityArticlesView`, `FeedArticlesView` — most of which kick off DB queries (e.g. `preloadedArticleEntriesAsync` reads all articles with `limit: Int.max`).

With dozens of feeds refreshing concurrently, the per-feed bump fired dozens of times in rapid succession, saturating the main thread and DB and causing the visible lag.

The bump is redundant: every refresh path follows it with `loadFromDatabaseInBackground(...)` (or its bulk-refresh wrapper does), and that function already bumps `dataRevision` after applying the freshly-loaded data. Removing the per-feed bump leaves observers receiving exactly one notification per refresh cycle, paired with the actual data update — which is the desired behavior.

Removed the redundant `await MainActor.run { self.bumpDataRevision() }` from all five provider refresh paths:
- Standard RSS (`FeedManager+Refresh.swift`)
- Petal (`FeedManager+Petal.swift`)
- X (`FeedManager+XProfile.swift`)
- YouTube playlist (`FeedManager+YouTubePlaylist.swift`)
- Instagram (`FeedManager+InstagramProfile.swift`)

## Test plan

- [ ] Pull-to-refresh on Today / All / a section while watching for stutter — UI should stay smooth as the donut counter ticks
- [ ] Pull-to-refresh on a single feed view — articles still appear after refresh completes
- [ ] Add a new feed — newly added feed's articles still appear after the post-add refresh completes
- [ ] Background refresh runs without surfacing stale state (next foreground view shows refreshed articles)
- [ ] Donut progress and "Refreshing X / Y" toolbar counter still update live during a refresh

https://claude.ai/code/session_01WvQTkX9doPf1YRstQREzAV

---
_Generated by [Claude Code](https://claude.ai/code/session_01WvQTkX9doPf1YRstQREzAV)_