### PR TITLE
Fix While You Slept hiding when opened mid-morning

### DIFF
--- a/App/Classes/Feed Manager/FeedManager+Articles.swift
+++ b/App/Classes/Feed Manager/FeedManager+Articles.swift
@@ -32,16 +32,15 @@ extension FeedManager {
         return applyAllRules(all)
     }
 
-    /// Articles published between local 00:00 and 09:00, used for the
-    /// While You Slept summary card on the Today tab.
+    /// Articles published between local 00:00 and now, used for the
+    /// While You Slept summary card on the Today tab. The card itself only
+    /// displays in the 6am-noon window, so the upper bound naturally caps
+    /// at noon when the user is on Today.
     func overnightArticles() -> [Article] {
         _ = dataRevision
-        let calendar = Calendar.current
-        let midnight = calendar.startOfDay(for: Date())
-        guard let nineAM = calendar.date(byAdding: .hour, value: 9, to: midnight) else {
-            return []
-        }
-        let allOvernight = (try? database.allArticles(from: midnight, to: nineAM)) ?? []
+        let now = Date()
+        let midnight = Calendar.current.startOfDay(for: now)
+        let allOvernight = (try? database.allArticles(from: midnight, to: now)) ?? []
         return filterExcludingPodcastsAndVideos(allOvernight)
     }
 

--- a/App/Classes/Feed Manager/FeedManager+Articles.swift
+++ b/App/Classes/Feed Manager/FeedManager+Articles.swift
@@ -32,10 +32,6 @@ extension FeedManager {
         return applyAllRules(all)
     }
 
-    /// Articles published between local 00:00 and now, used for the
-    /// While You Slept summary card on the Today tab. The card itself only
-    /// displays in the 6am-noon window, so the upper bound naturally caps
-    /// at noon when the user is on Today.
     func overnightArticles() -> [Article] {
         _ = dataRevision
         let now = Date()


### PR DESCRIPTION
## Summary

When the app is opened for the first time after 9 AM (e.g. 10:14 AM), While You Slept fails to render. `SummarySection.shouldShow` (App/Views/Home/Summary Cards/SummarySection.swift:60) gates visibility on `articleCount > 0`, where `articleCount` comes from `overnightArticles()`. Since #271, that query was capped at midnight–9 AM, and Afternoon Brief doesn't start until noon — so any feed that publishes between 9 AM and noon (or the user simply having no overnight items) results in an empty card window with no fallback.

This widens `overnightArticles()` back to midnight–now. The 6 AM–noon display window in `SummaryCardKind.isInTimeWindow` already caps the upper bound at noon for the user, so this still semantically represents "what came in while you slept" without leaving a 9–12 dead zone.

## Test plan

- [ ] Open the app for the first time at ~10:00 with feeds that published only after 9 AM — While You Slept renders.
- [ ] Open the app at 7:30 — While You Slept still renders with overnight articles only (functionally unchanged at that hour).
- [ ] Open the app at 12:30 — Afternoon Brief renders, While You Slept does not (display window logic unchanged).
- [ ] Cached headlines from a prior open today are still served from cache (no re-generation).


---
_Generated by [Claude Code](https://claude.ai/code/session_01P9vjf6zbZib6jEFakzgNZc)_