### PR TITLE
Always use matched zoom transition for edit feed sheet on Following tab

### DIFF
--- a/App/Views/Feed/Display Styles/FeedDisplayStyleEnvironment.swift
+++ b/App/Views/Feed/Display Styles/FeedDisplayStyleEnvironment.swift
@@ -80,6 +80,15 @@ extension View {
             self
         }
     }
+
+    @ViewBuilder
+    func matchedSource(id: Int64, in namespace: Namespace.ID?) -> some View {
+        if let namespace {
+            self.matchedTransitionSource(id: id, in: namespace)
+        } else {
+            self
+        }
+    }
 }
 
 private struct ZoomTransitionModifier<WrappedView: View>: View {

--- a/App/Views/Following/FollowingFeedGridCell.swift
+++ b/App/Views/Following/FollowingFeedGridCell.swift
@@ -60,7 +60,7 @@ struct FollowingFeedGridCell: View {
                 }
                 .frame(width: iconSize, height: iconSize)
                 .drawingGroup()
-                .zoomSource(id: feed.id, namespace: editTransitionNamespace)
+                .matchedSource(id: feed.id, in: editTransitionNamespace)
                 .contentShape(
                     .hoverEffect,
                     feed.isCircleIcon


### PR DESCRIPTION
## Summary
- The Following grid cell previously used `zoomSource(...)`, which suppresses the source-side `matchedTransitionSource` whenever the global `Display.ZoomTransition` setting is off, leaving the edit feed sheet without a paired source.
- Added a non-conditional `matchedSource(id:in:)` helper next to `zoomSource(...)` in `FeedDisplayStyleEnvironment.swift`, and switched the Following grid cell to use it so the edit feed sheet always opens with a matched zoom transition.

## Test plan
- [ ] Toggle Settings → Appearance → Zoom Transition off, enter Following tab edit mode, tap a feed, and confirm the edit sheet opens with a matched zoom transition originating from the cell.
- [ ] Toggle Zoom Transition back on and confirm the same matched zoom transition still works.
- [ ] Confirm regular feed navigation (non-edit-mode `NavigationLink`) still respects the Zoom Transition setting elsewhere in the app.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B4SDgnNWeBNjvCtrg8kA3H)_