### PR TITLE
Cancel startup refresh from the Today donut

### DIFF
--- a/App/Views/Home/HomeView+Bar.swift
+++ b/App/Views/Home/HomeView+Bar.swift
@@ -59,6 +59,15 @@ extension HomeView {
         return ScopedRefreshState()
     }
 
+    func cancelTodayRefresh() {
+        let scope = "section.all"
+        if feedManager.scopedRefreshes[scope] != nil {
+            feedManager.cancelScopedRefresh(scope: scope)
+        } else {
+            feedManager.cancelRefresh()
+        }
+    }
+
     func reloadBarConfiguration() {
         barConfiguration = .load()
     }

--- a/App/Views/Home/HomeView.swift
+++ b/App/Views/Home/HomeView.swift
@@ -46,7 +46,7 @@ struct HomeView: View {
                         ToolbarItemGroup(placement: .topBarLeading) {
                             FeedRefreshProgressDonut(
                                 progress: todayRefreshState.progress,
-                                onStop: { feedManager.cancelScopedRefresh(scope: "section.all") }
+                                onStop: cancelTodayRefresh
                             )
                         }
                     }


### PR DESCRIPTION
## Summary
- Tapping the Today toolbar progress donut did nothing when the refresh was started by `App.FetchOnStartup`. The donut shows whichever refresh is active for `section.all` (scoped) or the global `refreshAllFeeds` task, but `onStop` only routed to `cancelScopedRefresh(scope:)`. Startup refresh stores its task in `refreshTask`, not `scopedRefreshTasks`, so the cancel was a no-op.
- Added `cancelTodayRefresh()` next to `todayRefreshState` so the cancel path mirrors the same scoped → global fallback the donut already uses for display, and wired the donut's `onStop` to it.

## Test plan
- [ ] Launch the app cold with `App.FetchOnStartup` enabled, wait for the donut to appear in the Today toolbar, tap it, and confirm the refresh stops (donut disappears, principal label returns to the relative date).
- [ ] Trigger a manual pull-to-refresh on the Today (`section.all`) tab and confirm tapping the donut still cancels as before.
- [ ] Repeat the cold-launch test on a slow network to make sure cancellation reaches in-flight feed fetches.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VYhnnkiDiXRp5k9mhciJkF)_