### PR TITLE
Widen Afternoon Brief article window to current time

### DIFF
--- a/App/Classes/Feed Manager/FeedManager+Articles.swift
+++ b/App/Classes/Feed Manager/FeedManager+Articles.swift
@@ -49,13 +49,9 @@ extension FeedManager {
 
     func afternoonBriefArticles() -> [Article] {
         _ = dataRevision
-        let calendar = Calendar.current
         let now = Date()
-        let midnight = calendar.startOfDay(for: now)
-        guard let nineAM = calendar.date(byAdding: .hour, value: 9, to: midnight) else {
-            return []
-        }
-        let articles = (try? database.allArticles(from: nineAM, to: now)) ?? []
+        let midnight = Calendar.current.startOfDay(for: now)
+        let articles = (try? database.allArticles(from: midnight, to: now)) ?? []
         return filterExcludingPodcastsAndVideos(articles)
     }
 


### PR DESCRIPTION
## Summary
- Drop the 9 AM lower bound on the Afternoon Brief article window so morning content isn't excluded; use midnight-to-now to mirror the post-#274 While You Slept window.

## Why
With the 9 AM floor, after `filterExcludingPodcastsAndVideos`, `isPlainRSSArticle` (requires `feedSection == .feeds`), and `BatchSummarizer.hasUsefulContent` strip out podcasts, videos, social, research feeds, and short-snippet articles, the remaining count regularly falls below the 5-article minimum in `SummarySection+Generation.swift:19`. That bails into `markNoContentAvailable()`, which sets `generationFailed = true` and renders the "No headlines" `ContentUnavailableView` — matching the user-reported "always shows no headlines" symptom.

The noon-4pm display window already caps when the card is shown, so widening the article window doesn't broaden user-visible scope; it just gives the LLM enough material to summarize.

## Test plan
- [ ] Open the app between noon and 4 PM with a typical feed mix and verify Afternoon Brief renders headlines instead of the "No headlines" placeholder.
- [ ] Confirm `kind=afternoonBrief` log line in `SummarySection.swift:84` shows a higher article count than before.
- [ ] Verify While You Slept and Today's Summary cards behave unchanged.

https://claude.ai/code/session_01EYFdEXQsQBQXxTkG2kBVm5

---
_Generated by [Claude Code](https://claude.ai/code/session_01EYFdEXQsQBQXxTkG2kBVm5)_