### PR TITLE
Surface gathered articles when feed refresh is stopped

### DIFF
--- a/App/Classes/Feed Manager/FeedManager+Refresh.swift
+++ b/App/Classes/Feed Manager/FeedManager+Refresh.swift
@@ -358,11 +358,14 @@ extension FeedManager {
 
     /// Cancels the in-flight refresh task. Feeds whose RSS fetch has already
     /// completed run their pipeline through to insert; feeds still waiting on
-    /// the network drop their work. Triggers a database reload so any articles
-    /// collected up to the cancel point appear immediately.
+    /// the network drop their work. Awaits the refresh task so any pipelines
+    /// already past the network round-trip can flush their inserts, then
+    /// reloads from the database so the gathered articles bump `dataRevision`
+    /// and surface in the UI.
     @MainActor
     func cancelRefresh() {
         log("FeedRefresh", "cancelRefresh hadTask=\(refreshTask != nil) completed=\(refreshCompleted)/\(refreshTotal)")
+        let task = refreshTask
         refreshTask?.cancel()
         refreshTask = nil
         isLoading = false
@@ -370,7 +373,12 @@ extension FeedManager {
         refreshTotal = 0
         pendingRefreshFeedIDs = []
         refreshingFeedIDs = []
-        Task { await self.loadFromDatabaseInBackground(animated: true) }
+        Task {
+            if let task {
+                _ = await task.value
+            }
+            await self.loadFromDatabaseInBackground(animated: true)
+        }
     }
 
 }

--- a/App/Classes/Feed Manager/FeedManager+ScopedRefresh.swift
+++ b/App/Classes/Feed Manager/FeedManager+ScopedRefresh.swift
@@ -106,10 +106,16 @@ extension FeedManager {
     @MainActor
     func cancelScopedRefresh(scope: String) {
         log("FeedRefresh.Scoped", "cancel scope=\(scope)")
+        let task = scopedRefreshTasks[scope]
         scopedRefreshTasks[scope]?.cancel()
         scopedRefreshTasks[scope] = nil
         scopedRefreshes[scope] = nil
-        Task { await self.loadFromDatabaseInBackground(animated: true) }
+        Task {
+            if let task {
+                _ = await task.value
+            }
+            await self.loadFromDatabaseInBackground(animated: true)
+        }
     }
 
     fileprivate func runScopedBoundedRefresh(


### PR DESCRIPTION
## Summary

When the user stopped a feed refresh, articles already fetched and inserted by in-flight pipelines were sometimes not reflected in the UI. The pipelines themselves run inside `Task.detached` blocks so cancellation doesn't abort their inserts, but `cancelRefresh` (and `cancelScopedRefresh`) was firing `loadFromDatabaseInBackground` immediately while the bounded refresh group was still draining its in-flight feeds — the load could read the database before those feeds finished writing.

This change captures the refresh task and awaits its completion before reloading. Awaiting `task.value` doesn't interrupt the wait on awaiter cancellation, so the bounded refresh group fully drains (each in-flight pipeline completes its `insertArticles` call) before `loadFromDatabaseInBackground` runs and bumps `dataRevision`. Articles gathered up to the cancel point now consistently surface in the UI.

## Test plan

- [ ] Start a refresh on Today, tap stop while a few feeds have already begun fetching, confirm any newly fetched articles appear without needing another manual refresh
- [ ] Start a section-scoped refresh, stop it mid-flight, confirm gathered articles surface in that section
- [ ] Stop a refresh that hasn't actually started any pipelines, confirm the existing immediate reload behavior still applies


---
_Generated by [Claude Code](https://claude.ai/code/session_012Xrp3abAAWb9wPGj1vRv5V)_