### PR TITLE
Suspend new YouTube player overlay auto-hide while scrubbing

### DIFF
--- a/App/Views/Shared/SeekBarView.swift
+++ b/App/Views/Shared/SeekBarView.swift
@@ -14,6 +14,7 @@ struct SeekBarView: View {
     var segments: [(start: Double, end: Double)] = []
     var labelLayout: SeekBarLabelLayout = .below
     let onSeek: (TimeInterval) -> Void
+    var onScrubbingChanged: ((Bool) -> Void)?
 
     @State private var isDragging = false
     @State private var dragTime: TimeInterval = 0
@@ -103,6 +104,7 @@ struct SeekBarView: View {
                         if !isDragging {
                             isDragging = true
                             dragTime = currentTime
+                            onScrubbingChanged?(true)
                         }
                         let fraction = max(0, min(value.location.x / trackWidth, 1))
                         dragTime = TimeInterval(fraction) * duration
@@ -114,6 +116,7 @@ struct SeekBarView: View {
                         }
                         onSeek(dragTime)
                         isDragging = false
+                        onScrubbingChanged?(false)
                     }
             )
             .opacity(isDisabled ? 0.4 : 1.0)

--- a/App/Views/Viewers/YouTube Player/V2/NewYouTubePlayerOverlayControls.swift
+++ b/App/Views/Viewers/YouTube Player/V2/NewYouTubePlayerOverlayControls.swift
@@ -128,6 +128,13 @@ struct NewYouTubePlayerOverlayControls: View {
                 onSeek: { time in
                     playback.seek(to: time)
                     scheduleAutoHide()
+                },
+                onScrubbingChanged: { isScrubbing in
+                    if isScrubbing {
+                        hideTask?.cancel()
+                    } else {
+                        scheduleAutoHide()
+                    }
                 }
             )
             .tint(.white)


### PR DESCRIPTION
## Summary
- Add an optional `onScrubbingChanged` callback to `SeekBarView` that fires when the user's finger lands on / leaves the track.
- Wire the callback into `NewYouTubePlayerOverlayControls` so the auto-hide timer is cancelled while scrubbing and only re-armed once the finger lifts.

## Test plan
- [ ] Open a video in the new YouTube player and start scrubbing on the seek bar — overlay stays visible the entire time the finger is held down, even past the usual 3-second auto-hide.
- [ ] Release the seek bar — overlay auto-hides ~3 seconds later when playback is active.
- [ ] Tap-only interactions on the overlay still auto-hide as before.

https://claude.ai/code/session_01NLbMdCBCopYvQgjUjZKoyb

---
_Generated by [Claude Code](https://claude.ai/code/session_01NLbMdCBCopYvQgjUjZKoyb)_