### PR TITLE
Wrap table cell text instead of clipping horizontally

### DIFF
--- a/App/Views/Viewers/Article Detail/Content Blocks/TableBlockView.swift
+++ b/App/Views/Viewers/Article Detail/Content Blocks/TableBlockView.swift
@@ -24,26 +24,29 @@ struct TableBlockView: View {
     }
 
     var body: some View {
-        Grid(alignment: .topLeading, horizontalSpacing: 0, verticalSpacing: 0) {
-            if !header.isEmpty {
-                gridRow(header, isHeader: true, background: .clear)
-                Divider().gridCellUnsizedAxes(.horizontal)
-            }
-            ForEach(Array(rows.enumerated()), id: \.offset) { index, row in
-                let background: Color = index.isMultiple(of: 2)
-                    ? .clear
-                    : .secondary.opacity(0.06)
-                gridRow(row, isHeader: false, background: background)
-                if index < rows.count - 1 {
+        ScrollView(.horizontal, showsIndicators: false) {
+            Grid(alignment: .topLeading, horizontalSpacing: 0, verticalSpacing: 0) {
+                if !header.isEmpty {
+                    gridRow(header, isHeader: true, background: .clear)
                     Divider().gridCellUnsizedAxes(.horizontal)
                 }
+                ForEach(Array(rows.enumerated()), id: \.offset) { index, row in
+                    let background: Color = index.isMultiple(of: 2)
+                        ? .clear
+                        : .secondary.opacity(0.06)
+                    gridRow(row, isHeader: false, background: background)
+                    if index < rows.count - 1 {
+                        Divider().gridCellUnsizedAxes(.horizontal)
+                    }
+                }
             }
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(.secondary.opacity(0.55), lineWidth: 1.5)
+            )
+            .clipShape(.rect(cornerRadius: 8))
         }
-        .overlay(
-            RoundedRectangle(cornerRadius: 8)
-                .stroke(.secondary.opacity(0.55), lineWidth: 1.5)
-        )
-        .clipShape(.rect(cornerRadius: 8))
+        .scrollClipDisabled()
     }
 
     @ViewBuilder

--- a/App/Views/Viewers/Article Detail/Content Blocks/TableBlockView.swift
+++ b/App/Views/Viewers/Article Detail/Content Blocks/TableBlockView.swift
@@ -24,28 +24,26 @@ struct TableBlockView: View {
     }
 
     var body: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            Grid(alignment: .topLeading, horizontalSpacing: 0, verticalSpacing: 0) {
-                if !header.isEmpty {
-                    gridRow(header, isHeader: true, background: .clear)
+        Grid(alignment: .topLeading, horizontalSpacing: 0, verticalSpacing: 0) {
+            if !header.isEmpty {
+                gridRow(header, isHeader: true, background: .clear)
+                Divider().gridCellUnsizedAxes(.horizontal)
+            }
+            ForEach(Array(rows.enumerated()), id: \.offset) { index, row in
+                let background: Color = index.isMultiple(of: 2)
+                    ? .clear
+                    : .secondary.opacity(0.06)
+                gridRow(row, isHeader: false, background: background)
+                if index < rows.count - 1 {
                     Divider().gridCellUnsizedAxes(.horizontal)
                 }
-                ForEach(Array(rows.enumerated()), id: \.offset) { index, row in
-                    let background: Color = index.isMultiple(of: 2)
-                        ? .clear
-                        : .secondary.opacity(0.06)
-                    gridRow(row, isHeader: false, background: background)
-                    if index < rows.count - 1 {
-                        Divider().gridCellUnsizedAxes(.horizontal)
-                    }
-                }
             }
-            .overlay(
-                RoundedRectangle(cornerRadius: 8)
-                    .stroke(.secondary.opacity(0.55), lineWidth: 1.5)
-            )
-            .clipShape(.rect(cornerRadius: 8))
         }
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(.secondary.opacity(0.55), lineWidth: 1.5)
+        )
+        .clipShape(.rect(cornerRadius: 8))
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary
- Tables in content view were clipping cell text on the right edge because `TableBlockView` wrapped its `Grid` in a horizontal `ScrollView`, which proposes infinite width to its content. `SelectableText` cells then laid out on a single line and got clipped at the column boundary.
- Removing the horizontal `ScrollView` lets the `Grid` inherit the parent's finite width, so cell text wraps onto multiple lines and nothing clips on the horizontal edges.

## Test plan
- [ ] Open a content item that contains a table (e.g. the WABetaInfo "Liquid Glass" article shown in the report)
- [ ] Verify that long cell text wraps onto multiple lines and is not clipped at the right column edge
- [ ] Verify multi-column tables still render with rounded border, header row, and alternating row backgrounds
- [ ] Verify that tables with `colspan`/`rowspan` still lay out correctly

https://claude.ai/code/session_01V4s3i2upm6ZD7Fu7uDmRxD

---
_Generated by [Claude Code](https://claude.ai/code/session_01V4s3i2upm6ZD7Fu7uDmRxD)_