### PR TITLE
Improve summary headline generation

### DIFF
--- a/App/App+URLHandling.swift
+++ b/App/App+URLHandling.swift
@@ -58,6 +58,7 @@ extension SakuraRSSApp {
         case "fixup":
             DatabaseManager.shared.fixup()
             UserDefaults.standard.removeObject(forKey: "App.DatabaseVersion")
+            UserDefaults.standard.removeObject(forKey: "SummaryHeadlines.PromptVersion")
         case "arisishere":
             Task { await feedManager.deleteAllArticlesAndRefresh() }
         case "bigbang":

--- a/App/Home/Summary Cards/SummarySection+Generation.swift
+++ b/App/Home/Summary Cards/SummarySection+Generation.swift
@@ -17,7 +17,7 @@ extension SummarySection {
                 summary: article.summary
             )
         }
-        if allArticles.count < 5 {
+        if allArticles.count < 3 {
             log(
                 "Summary",
                 "no eligible articles to summarize (\(allArticles.count) after filter); marking unavailable"
@@ -28,41 +28,113 @@ extension SummarySection {
 
         await MainActor.run { isGenerating = true }
 
-        let articles = Array(allArticles.prefix(Self.articleConsiderationLimit))
+        let personalizationOn = Self.personalizationEnabled
+        let feedAccessCounts: [Int64: Int] = personalizationOn
+            ? ((try? DatabaseManager.shared.feedAccessCounts(
+                since: date.addingTimeInterval(-30 * 24 * 3600)
+            )) ?? [:])
+            : [:]
+        let sortedArticles = sortByEngagement(
+            allArticles,
+            feedAccessCounts: feedAccessCounts
+        )
+        let articles = Array(sortedArticles.prefix(Self.articleConsiderationLimit))
         let articlesByID = Dictionary(uniqueKeysWithValues: articles.map { ($0.id, $0) })
-        let inputs = headlineInputs(for: articles)
-        let instructions = composeInstructions(date: date)
+        let preferredFeeds = preferredFeedIDs(
+            from: articles,
+            feedAccessCounts: feedAccessCounts
+        )
+        let inputs = headlineInputs(for: articles, preferredFeedIDs: preferredFeeds)
+        let instructions = composeInstructions(
+            date: date,
+            personalizationOn: personalizationOn,
+            includePreferredHint: !preferredFeeds.isEmpty
+        )
         let entityMap = await loadEntityMap(for: articles)
 
-        do {
-            let events = try await HeadlineSummarizer.summarize(
-                articles: inputs,
-                instructions: instructions,
-                entityMap: entityMap
-            )
-            let resolved = resolveHeadlines(events: events, articlesByID: articlesByID)
-            await applyGenerated(resolved, for: date)
-        } catch {
-            await MainActor.run {
-                isGenerating = false
-                hasGenerated = true
-                generationFailed = true
-                generationError = error.localizedDescription
-            }
+        let outcome = await HeadlineSummarizer.summarize(
+            articles: inputs,
+            instructions: instructions,
+            entityMap: entityMap,
+            preferredFeedIDs: preferredFeeds
+        )
+        let resolved = resolveHeadlines(events: outcome.events, articlesByID: articlesByID)
+        if resolved.isEmpty {
+            await markGenerationFailed(error: outcome.error)
+            return
+        }
+        await applyGenerated(
+            resolved,
+            for: date,
+            partialGeneration: outcome.error != nil,
+            articleCountAtGeneration: articles.count
+        )
+    }
+
+    static var personalizationEnabled: Bool {
+        // Default ON: missing key means the user hasn't visited Settings yet.
+        (UserDefaults.standard.object(forKey: "Intelligence.Personalization.Enabled") as? Bool) ?? true
+    }
+
+    private func sortByEngagement(
+        _ articles: [Article],
+        feedAccessCounts: [Int64: Int]
+    ) -> [Article] {
+        guard !feedAccessCounts.isEmpty else { return articles }
+        return articles.sorted { lhs, rhs in
+            let lhsScore = feedAccessCounts[lhs.feedID] ?? 0
+            let rhsScore = feedAccessCounts[rhs.feedID] ?? 0
+            if lhsScore != rhsScore { return lhsScore > rhsScore }
+            let lhsDate = lhs.publishedDate ?? .distantPast
+            let rhsDate = rhs.publishedDate ?? .distantPast
+            return lhsDate > rhsDate
         }
     }
 
-    private func composeInstructions(date: Date) -> String {
+    /// Top quartile (at minimum one) of distinct feeds present in the
+    /// candidate batch that have any positive access count. Returns empty
+    /// when personalization is off or the user has no engagement history.
+    private func preferredFeedIDs(
+        from articles: [Article],
+        feedAccessCounts: [Int64: Int]
+    ) -> Set<Int64> {
+        guard !feedAccessCounts.isEmpty else { return [] }
+        let candidateFeedIDs = Set(articles.map(\.feedID))
+        let scored: [(feedID: Int64, count: Int)] = candidateFeedIDs.compactMap { feedID in
+            let count = feedAccessCounts[feedID] ?? 0
+            guard count > 0 else { return nil }
+            return (feedID, count)
+        }
+        guard !scored.isEmpty else { return [] }
+        let sorted = scored.sorted { $0.count > $1.count }
+        let quartile = max(1, sorted.count / 4)
+        return Set(sorted.prefix(quartile).map(\.feedID))
+    }
+
+    private func composeInstructions(
+        date: Date,
+        personalizationOn: Bool,
+        includePreferredHint: Bool
+    ) -> String {
         let template = String(localized: "SummaryHeadlines.SharedPrompt", table: "Home")
         let timeWindow = String(localized: kind.timeWindowPhrase)
-        let baseInstructions = String(format: template, timeWindow)
-        let topicHints = topEntityHints(for: date)
+        var baseInstructions = String(format: template, timeWindow)
+        if includePreferredHint {
+            let hint = String(localized: "SummaryHeadlines.PreferredHint", table: "Home")
+            baseInstructions = "\(baseInstructions)\n\n\(hint)"
+        }
+        let topicHints = topEntityHints(for: date, personalizationOn: personalizationOn)
         guard !topicHints.isEmpty else { return baseInstructions }
         let prefix = String(localized: "SummaryHeadlines.TopicHintPrefix", table: "Home")
         return "\(baseInstructions)\n\n\(prefix)\n\(topicHints)"
     }
 
-    private func applyGenerated(_ resolved: [SummaryHeadline], for date: Date) async {
+    private func applyGenerated(
+        _ resolved: [SummaryHeadline],
+        for date: Date,
+        partialGeneration: Bool,
+        articleCountAtGeneration: Int
+    ) async {
         await MainActor.run {
             isGenerating = false
             hasGenerated = true
@@ -73,9 +145,26 @@ extension SummarySection {
             }
             withAnimation(.smooth.speed(2.0)) { headlines = resolved }
             hasSummary = true
+            cachedIsPartial = partialGeneration
+            cachedArticleCountAtGeneration = articleCountAtGeneration
             try? DatabaseManager.shared.cacheSummaryHeadlines(
-                resolved, ofType: kind.cacheType, for: date
+                resolved, ofType: kind.cacheType, for: date,
+                partialGeneration: partialGeneration,
+                articleCountAtGeneration: articleCountAtGeneration
             )
+        }
+    }
+
+    private func markGenerationFailed(error: Error?) async {
+        await MainActor.run {
+            isGenerating = false
+            hasGenerated = true
+            generationFailed = true
+            if let error {
+                generationError = error.localizedDescription
+            } else {
+                generationError = String(localized: "SummaryHeadlines.NoEventsExtracted", table: "Home")
+            }
         }
     }
 
@@ -107,13 +196,24 @@ extension SummarySection {
         return feed.feedSection == .feeds
     }
 
-    private func headlineInputs(for articles: [Article]) -> [HeadlineSummarizer.Input] {
+    private func headlineInputs(
+        for articles: [Article],
+        preferredFeedIDs: Set<Int64>
+    ) -> [HeadlineSummarizer.Input] {
         articles.map { article in
             let feed = feedManager.feed(forArticle: article)
-            let source = feed?.title ?? ""
-            let snippet = String((article.summary ?? "").prefix(Self.snippetCharLimit))
+            let baseSource = feed?.title ?? ""
+            let source = preferredFeedIDs.contains(article.feedID)
+                ? "\(baseSource) ★"
+                : baseSource
+            let raw = article.summary ?? article.content ?? ""
+            let snippet = String(raw.prefix(Self.snippetCharLimit))
             let body = "ID: \(article.id)\n[\(source)] \(article.title)\n\(snippet)"
-            return HeadlineSummarizer.Input(articleID: article.id, description: body)
+            return HeadlineSummarizer.Input(
+                articleID: article.id,
+                feedID: article.feedID,
+                description: body
+            )
         }
     }
 
@@ -157,20 +257,34 @@ extension SummarySection {
         }.value
     }
 
-    /// Top topics + people from the past week. Empty when Content Insights
-    /// is off or no entities were extracted.
-    private func topEntityHints(for date: Date) -> String {
+    /// Top topics + people. When personalization is on, ranked over the
+    /// articles the user has opened in the past 30 days; otherwise ranked
+    /// globally over the past week. Empty when Content Insights is off or
+    /// no entities were extracted.
+    private func topEntityHints(for date: Date, personalizationOn: Bool) -> String {
         let defaults = UserDefaults.standard
         guard defaults.bool(forKey: "Intelligence.ContentInsights.Enabled") else { return "" }
 
         let database = DatabaseManager.shared
-        let sevenDaysAgo = date.addingTimeInterval(-7 * 24 * 3600)
-        let topicsAndPlaces = (try? database.topEntities(
-            types: ["organization", "place"], since: sevenDaysAgo, limit: Self.topEntityHintLimit
-        )) ?? []
-        let people = (try? database.topEntities(
-            type: "person", since: sevenDaysAgo, limit: Self.topEntityHintLimit
-        )) ?? []
+        let topicsAndPlaces: [(name: String, count: Int)]
+        let people: [(name: String, count: Int)]
+        if personalizationOn {
+            let thirtyDaysAgo = date.addingTimeInterval(-30 * 24 * 3600)
+            topicsAndPlaces = (try? database.topAccessedEntities(
+                types: ["organization", "place"], since: thirtyDaysAgo, limit: Self.topEntityHintLimit
+            )) ?? []
+            people = (try? database.topAccessedEntities(
+                types: ["person"], since: thirtyDaysAgo, limit: Self.topEntityHintLimit
+            )) ?? []
+        } else {
+            let sevenDaysAgo = date.addingTimeInterval(-7 * 24 * 3600)
+            topicsAndPlaces = (try? database.topEntities(
+                types: ["organization", "place"], since: sevenDaysAgo, limit: Self.topEntityHintLimit
+            )) ?? []
+            people = (try? database.topEntities(
+                type: "person", since: sevenDaysAgo, limit: Self.topEntityHintLimit
+            )) ?? []
+        }
 
         var ranked = topicsAndPlaces + people
         ranked.sort { lhs, rhs in lhs.count > rhs.count }

--- a/App/Home/Summary Cards/SummarySection.swift
+++ b/App/Home/Summary Cards/SummarySection.swift
@@ -22,6 +22,8 @@ struct SummarySection: View {
     @State var hasGenerated = false
     @State var generationFailed = false
     @State var generationError: String?
+    @State var cachedIsPartial: Bool = false
+    @State var cachedArticleCountAtGeneration: Int = 0
     @State private var deferredForLowPowerMode = false
     @State private var articleCount: Int = 0
 
@@ -85,6 +87,16 @@ struct SummarySection: View {
             log("Summary", "kind=\(kind) revision=\(feedManager.dataRevision) count=\(count)")
             withAnimation(.smooth.speed(2.0)) {
                 articleCount = count
+            }
+            if hasGenerated,
+               cachedIsPartial,
+               !isGenerating,
+               count >= cachedArticleCountAtGeneration + 3 {
+                log(
+                    "Summary",
+                    "auto-regen: partial cache + \(count - cachedArticleCountAtGeneration) more articles"
+                )
+                await regenerateHeadlines()
             }
         }
         .onAppear { isVisible?.wrappedValue = shouldShow }
@@ -241,8 +253,10 @@ struct SummarySection: View {
         if let cached = try? DatabaseManager.shared.cachedSummaryHeadlines(
             ofType: kind.cacheType,
             for: today
-        ), !cached.isEmpty {
-            headlines = cached
+        ), !cached.headlines.isEmpty {
+            headlines = cached.headlines
+            cachedIsPartial = cached.partialGeneration
+            cachedArticleCountAtGeneration = cached.articleCountAtGeneration
             hasGenerated = true
             hasSummary = true
             return
@@ -282,6 +296,8 @@ struct SummarySection: View {
             generationFailed = false
             generationError = nil
             deferredForLowPowerMode = false
+            cachedIsPartial = false
+            cachedArticleCountAtGeneration = 0
         }
         await generateHeadlines(for: today)
     }

--- a/App/Lists/ListEditSheet.swift
+++ b/App/Lists/ListEditSheet.swift
@@ -174,21 +174,20 @@ struct ListEditSheet: View {
             feedManager.updateList(list, name: trimmedName, icon: selectedIcon,
                                    displayStyle: list.displayStyle)
         } else {
-            if (try? feedManager.createList(name: trimmedName, icon: selectedIcon)) != nil {
-                if let newList = feedManager.lists.last {
-                    for id in selectedFeedIDs {
-                        if let feed = feedManager.feedsByID[id] {
-                            feedManager.addFeedToList(newList, feed: feed)
-                        }
+            if let newListID = try? feedManager.createList(name: trimmedName, icon: selectedIcon),
+               let newList = feedManager.lists.first(where: { $0.id == newListID }) {
+                for id in selectedFeedIDs {
+                    if let feed = feedManager.feedsByID[id] {
+                        feedManager.addFeedToList(newList, feed: feed)
                     }
-                    if let displayStyle = resolvedDisplayStyle {
-                        feedManager.updateList(
-                            newList,
-                            name: trimmedName,
-                            icon: selectedIcon,
-                            displayStyle: displayStyle
-                        )
-                    }
+                }
+                if let displayStyle = resolvedDisplayStyle {
+                    feedManager.updateList(
+                        newList,
+                        name: trimmedName,
+                        icon: selectedIcon,
+                        displayStyle: displayStyle
+                    )
                 }
             }
         }

--- a/App/Profile/Intelligence/OnDeviceIntelligenceSettingsView.swift
+++ b/App/Profile/Intelligence/OnDeviceIntelligenceSettingsView.swift
@@ -4,10 +4,15 @@ import Hanami
 
 struct OnDeviceIntelligenceSettingsView: View {
 
+    @Environment(FeedManager.self) private var feedManager
+
     @AppStorage("TodaysSummary.Enabled") private var todaysSummaryEnabled: Bool = false
     @AppStorage("AfternoonBrief.Enabled") private var afternoonBriefEnabled: Bool = false
     @AppStorage("WhileYouSlept.Enabled") private var whileYouSleptEnabled: Bool = false
     @AppStorage("Intelligence.ContentInsights.Enabled") private var contentInsightsEnabled: Bool = false
+    @AppStorage("Intelligence.Personalization.Enabled") private var personalizationEnabled: Bool = true
+
+    @State private var showingClearConfirmation = false
 
     private var isAppleIntelligenceAvailable: Bool {
         SystemLanguageModel.default.availability == .available
@@ -29,12 +34,35 @@ struct OnDeviceIntelligenceSettingsView: View {
 
             Section {
                 Toggle(String(localized: "ContentInsights", table: "Settings"), isOn: $contentInsightsEnabled)
+                Toggle(String(localized: "Personalization", table: "Settings"), isOn: $personalizationEnabled)
+                Button(role: .destructive) {
+                    showingClearConfirmation = true
+                } label: {
+                    Text(String(localized: "Personalization.ClearHistory", table: "Settings"))
+                }
             } footer: {
-                Text(String(localized: "ContentInsights.Footer", table: "Settings"))
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(String(localized: "ContentInsights.Footer", table: "Settings"))
+                    Text(String(localized: "Personalization.Footer", table: "Settings"))
+                }
             }
         }
         .navigationTitle(String(localized: "Section.InsightsAndIntelligence", table: "Settings"))
         .toolbarTitleDisplayMode(.inline)
         .sakuraBackground()
+        .confirmationDialog(
+            String(localized: "Personalization.ClearHistory.Confirm.Title", table: "Settings"),
+            isPresented: $showingClearConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button(
+                String(localized: "Personalization.ClearHistory", table: "Settings"),
+                role: .destructive
+            ) {
+                feedManager.clearAccessHistory()
+            }
+        } message: {
+            Text(String(localized: "Personalization.ClearHistory.Confirm.Message", table: "Settings"))
+        }
     }
 }

--- a/Hanami/Database Manager/Articles/DatabaseManager+ArticlesRecentlyAccessed.swift
+++ b/Hanami/Database Manager/Articles/DatabaseManager+ArticlesRecentlyAccessed.swift
@@ -26,4 +26,61 @@ public nonisolated extension DatabaseManager {
     func clearAccessHistory() throws {
         try database.run(articles.update(articleLastAccessed <- nil))
     }
+
+    /// Per-feed count of articles the user has explicitly opened since the
+    /// given date. Drives implicit feed engagement ranking.
+    func feedAccessCounts(since date: Date) throws -> [Int64: Int] {
+        let sql = """
+            SELECT feed_id, COUNT(*) AS cnt
+            FROM articles
+            WHERE last_accessed IS NOT NULL
+              AND last_accessed >= ?
+            GROUP BY feed_id
+            """
+        log("SQLite", "feedAccessCounts(since:) - \(sql)")
+        var result: [Int64: Int] = [:]
+        for row in try database.prepare(sql, date.timeIntervalSince1970) {
+            guard let feedId = row[0] as? Int64,
+                  let count = row[1] as? Int64 else { continue }
+            result[feedId] = Int(count)
+        }
+        return result
+    }
+
+    /// Top entities by frequency, restricted to articles the user has
+    /// explicitly opened since the given date. Pass `nil` for `types` to
+    /// include every entity type.
+    func topAccessedEntities(
+        types: [String]?,
+        since date: Date,
+        limit: Int
+    ) throws -> [(name: String, count: Int)] {
+        var bindings: [Binding?] = [date.timeIntervalSince1970 as Binding?]
+        var typeClause = ""
+        if let types, !types.isEmpty {
+            let placeholders = types.map { _ in "?" }.joined(separator: ", ")
+            typeClause = "AND ne.type IN (\(placeholders))"
+            bindings.append(contentsOf: types.map { $0 as Binding? })
+        }
+        bindings.append(limit as Binding?)
+        let sql = """
+            SELECT ne.name, COUNT(*) AS cnt
+            FROM nlp_entities ne
+            JOIN articles a ON ne.article_id = a.id
+            WHERE a.last_accessed IS NOT NULL
+              AND a.last_accessed >= ?
+              \(typeClause)
+            GROUP BY LOWER(ne.name)
+            ORDER BY cnt DESC
+            LIMIT ?
+            """
+        log("SQLite", "topAccessedEntities(types:since:limit:) - \(sql)")
+        var results: [(name: String, count: Int)] = []
+        for row in try database.prepare(sql, bindings) {
+            if let name = row[0] as? String, let count = row[1] as? Int64 {
+                results.append((name: name, count: Int(count)))
+            }
+        }
+        return results
+    }
 }

--- a/Hanami/Database Manager/DatabaseManager+FixUp.swift
+++ b/Hanami/Database Manager/DatabaseManager+FixUp.swift
@@ -48,9 +48,10 @@ public nonisolated extension DatabaseManager {
         // summary_cache table
         _ = try? database.run(summaryCache.addColumn(summaryCacheContent, defaultValue: ""))
 
-        // summary_headlines table is created in createTables. Wipe rows on
-        // version-change fixup so a fresh schema/prompt change starts clean.
-        _ = try? database.run(summaryHeadlines.delete())
+        // summary_headlines table is created in createTables. The row
+        // wipe is now keyed to HeadlineSummarizer.promptVersion via
+        // wipeSummaryHeadlinesIfPromptVersionChanged so a bugfix bump
+        // that doesn't touch the prompt no longer discards cached rows.
         _ = try? database.run(summaryHeadlines.addColumn(summaryHeadlinePartialGeneration, defaultValue: false))
         _ = try? database.run(summaryHeadlines.addColumn(summaryHeadlineArticleCountAtGeneration, defaultValue: 0))
 

--- a/Hanami/Database Manager/DatabaseManager+FixUp.swift
+++ b/Hanami/Database Manager/DatabaseManager+FixUp.swift
@@ -51,6 +51,8 @@ public nonisolated extension DatabaseManager {
         // summary_headlines table is created in createTables. Wipe rows on
         // version-change fixup so a fresh schema/prompt change starts clean.
         _ = try? database.run(summaryHeadlines.delete())
+        _ = try? database.run(summaryHeadlines.addColumn(summaryHeadlinePartialGeneration, defaultValue: false))
+        _ = try? database.run(summaryHeadlines.addColumn(summaryHeadlineArticleCountAtGeneration, defaultValue: 0))
 
         // Drop the legacy plain-text summary cache; the carousel replaces it.
         _ = try? database.run(summaryCache.delete())

--- a/Hanami/Database Manager/DatabaseManager+Schema.swift
+++ b/Hanami/Database Manager/DatabaseManager+Schema.swift
@@ -100,6 +100,10 @@ public nonisolated extension DatabaseManager {
     var summaryHeadlineArticleIDs: SQLite.Expression<String> { SQLite.Expression<String>("article_ids") }
     var summaryHeadlineFeedIDs: SQLite.Expression<String> { SQLite.Expression<String>("feed_ids") }
     var summaryHeadlineThumbnailURL: SQLite.Expression<String?> { SQLite.Expression<String?>("thumbnail_url") }
+    var summaryHeadlinePartialGeneration: SQLite.Expression<Bool> { SQLite.Expression<Bool>("partial_generation") }
+    var summaryHeadlineArticleCountAtGeneration: SQLite.Expression<Int> {
+        SQLite.Expression<Int>("article_count_at_generation")
+    }
 
     // MARK: - Feed Rules
 

--- a/Hanami/Database Manager/DatabaseManager+SummaryHeadlines.swift
+++ b/Hanami/Database Manager/DatabaseManager+SummaryHeadlines.swift
@@ -1,6 +1,22 @@
 import Foundation
 @preconcurrency import SQLite
 
+public struct CachedSummaryHeadlinesResult: Sendable {
+    public let headlines: [SummaryHeadline]
+    public let partialGeneration: Bool
+    public let articleCountAtGeneration: Int
+
+    public init(
+        headlines: [SummaryHeadline],
+        partialGeneration: Bool,
+        articleCountAtGeneration: Int
+    ) {
+        self.headlines = headlines
+        self.partialGeneration = partialGeneration
+        self.articleCountAtGeneration = articleCountAtGeneration
+    }
+}
+
 public nonisolated extension DatabaseManager {
 
     // MARK: - Summary Headlines Cache
@@ -8,18 +24,22 @@ public nonisolated extension DatabaseManager {
     func cachedSummaryHeadlines(
         ofType type: SummaryCacheType,
         for date: Date
-    ) throws -> [SummaryHeadline] {
+    ) throws -> CachedSummaryHeadlinesResult {
         let key = summaryHeadlineDateKey(for: date)
         let query = summaryHeadlines
             .filter(summaryHeadlineType == type.rawValue && summaryHeadlineDate == key)
             .order(summaryHeadlineOrdinal.asc)
         var results: [SummaryHeadline] = []
+        var partial = false
+        var articleCount = 0
         for row in try database.prepare(query) {
             let headline = row[summaryHeadlineText]
             let articleIDs = decodeIDs(row[summaryHeadlineArticleIDs])
             let feedIDs = decodeIDs(row[summaryHeadlineFeedIDs])
             let thumbnail = row[summaryHeadlineThumbnailURL]
             guard !articleIDs.isEmpty else { continue }
+            partial = row[summaryHeadlinePartialGeneration] || partial
+            articleCount = max(articleCount, row[summaryHeadlineArticleCountAtGeneration])
             results.append(
                 SummaryHeadline(
                     headline: headline,
@@ -29,7 +49,11 @@ public nonisolated extension DatabaseManager {
                 )
             )
         }
-        return results
+        return CachedSummaryHeadlinesResult(
+            headlines: results,
+            partialGeneration: partial,
+            articleCountAtGeneration: articleCount
+        )
     }
 
     func clearCachedSummaryHeadlines(
@@ -45,7 +69,9 @@ public nonisolated extension DatabaseManager {
     func cacheSummaryHeadlines(
         _ headlines: [SummaryHeadline],
         ofType type: SummaryCacheType,
-        for date: Date
+        for date: Date,
+        partialGeneration: Bool = false,
+        articleCountAtGeneration: Int = 0
     ) throws {
         let key = summaryHeadlineDateKey(for: date)
         try database.transaction {
@@ -60,7 +86,9 @@ public nonisolated extension DatabaseManager {
                     summaryHeadlineText <- item.headline,
                     summaryHeadlineArticleIDs <- encodeIDs(item.articleIDs),
                     summaryHeadlineFeedIDs <- encodeIDs(item.feedIDs),
-                    summaryHeadlineThumbnailURL <- item.thumbnailURL
+                    summaryHeadlineThumbnailURL <- item.thumbnailURL,
+                    summaryHeadlinePartialGeneration <- partialGeneration,
+                    summaryHeadlineArticleCountAtGeneration <- articleCountAtGeneration
                 ))
             }
         }

--- a/Hanami/Database Manager/DatabaseManager+SummaryHeadlines.swift
+++ b/Hanami/Database Manager/DatabaseManager+SummaryHeadlines.swift
@@ -1,7 +1,7 @@
 import Foundation
 @preconcurrency import SQLite
 
-public struct CachedSummaryHeadlinesResult: Sendable {
+public nonisolated struct CachedSummaryHeadlinesResult: Sendable {
     public let headlines: [SummaryHeadline]
     public let partialGeneration: Bool
     public let articleCountAtGeneration: Int

--- a/Hanami/Database Manager/DatabaseManager+SummaryHeadlines.swift
+++ b/Hanami/Database Manager/DatabaseManager+SummaryHeadlines.swift
@@ -98,6 +98,18 @@ public nonisolated extension DatabaseManager {
         try database.run(summaryHeadlines.delete())
     }
 
+    /// Wipes the summary_headlines cache when the running app's prompt
+    /// version differs from the version that produced the cached rows.
+    /// Runs every launch; cheap when versions match.
+    func wipeSummaryHeadlinesIfPromptVersionChanged() {
+        let key = "SummaryHeadlines.PromptVersion"
+        let stored = UserDefaults.standard.object(forKey: key) as? Int
+        let current = HeadlineSummarizer.promptVersion
+        guard stored != current else { return }
+        _ = try? database.run(summaryHeadlines.delete())
+        UserDefaults.standard.set(current, forKey: key)
+    }
+
     // MARK: - Encoding Helpers
 
     private func encodeIDs(_ ids: [Int64]) -> String {

--- a/Hanami/Database Manager/DatabaseManager.swift
+++ b/Hanami/Database Manager/DatabaseManager.swift
@@ -19,6 +19,7 @@ public nonisolated final class DatabaseManager: @unchecked Sendable {
             try Self.applyConnectionPragmas(database)
             try createTables()
             fixupIfVersionChanged()
+            wipeSummaryHeadlinesIfPromptVersionChanged()
             invalidateStaleParserCache()
             migrateContentInsightsToggle()
             invalidateStaleSimilarContentCache()

--- a/Hanami/Database Manager/DatabaseManager.swift
+++ b/Hanami/Database Manager/DatabaseManager.swift
@@ -195,6 +195,8 @@ public nonisolated final class DatabaseManager: @unchecked Sendable {
             table.column(summaryHeadlineArticleIDs)
             table.column(summaryHeadlineFeedIDs)
             table.column(summaryHeadlineThumbnailURL)
+            table.column(summaryHeadlinePartialGeneration, defaultValue: false)
+            table.column(summaryHeadlineArticleCountAtGeneration, defaultValue: 0)
             table.primaryKey(summaryHeadlineType, summaryHeadlineDate, summaryHeadlineOrdinal)
         })
     }

--- a/Hanami/Feed Manager/FeedManager+Lists.swift
+++ b/Hanami/Feed Manager/FeedManager+Lists.swift
@@ -4,10 +4,12 @@ public extension FeedManager {
 
     // MARK: - List CRUD
 
-    func createList(name: String, icon: String) throws {
+    @discardableResult
+    func createList(name: String, icon: String) throws -> Int64 {
         let sortOrder = lists.count
-        try database.insertList(name: name, icon: icon, sortOrder: sortOrder)
+        let newID = try database.insertList(name: name, icon: icon, sortOrder: sortOrder)
         loadFromDatabase()
+        return newID
     }
 
     func updateList(_ list: FeedList, name: String, icon: String, displayStyle: String?) {

--- a/Hanami/Feed Manager/FeedManager+PendingReads.swift
+++ b/Hanami/Feed Manager/FeedManager+PendingReads.swift
@@ -52,7 +52,6 @@ public extension FeedManager {
         let dbm = database
         Task.detached(priority: .utility) {
             try? dbm.markArticlesRead(ids: idArray, read: true)
-            try? dbm.updateLastAccessed(articleIDs: idArray)
         }
     }
 

--- a/Hanami/Hanami.swift
+++ b/Hanami/Hanami.swift
@@ -1,2 +1,1 @@
 import Foundation
-

--- a/Hanami/RSS Parser/RSSParser.swift
+++ b/Hanami/RSS Parser/RSSParser.swift
@@ -70,9 +70,13 @@ public nonisolated final class RSSParser: NSObject, XMLParserDelegate, @unchecke
 
     // MARK: - XMLParserDelegate
 
-    public func parser(_: XMLParser, didStartElement elementName: String,
-                namespaceURI _: String?, qualifiedName _: String?,
-                attributes attributeDict: [String: String] = [:]) {
+    public func parser(
+        _: XMLParser,
+        didStartElement elementName: String,
+        namespaceURI _: String?,
+        qualifiedName _: String?,
+        attributes attributeDict: [String: String] = [:]
+    ) {
         currentElement = elementName
         currentAttributes = attributeDict
         handleStartElement(elementName, attributes: attributeDict)
@@ -194,8 +198,12 @@ public nonisolated final class RSSParser: NSObject, XMLParserDelegate, @unchecke
         }
     }
 
-    public func parser(_: XMLParser, didEndElement elementName: String,
-                namespaceURI _: String?, qualifiedName _: String?) {
+    public func parser(
+        _: XMLParser,
+        didEndElement elementName: String,
+        namespaceURI _: String?,
+        qualifiedName _: String?
+    ) {
         if elementName == "image" {
             isInsideImage = false
         } else if elementName == "item" || elementName == "entry" {

--- a/Hanami/Summarization/HeadlineSummarizer+Clustering.swift
+++ b/Hanami/Summarization/HeadlineSummarizer+Clustering.swift
@@ -8,11 +8,13 @@ extension HeadlineSummarizer {
     /// organizations) so articles about the same story end up in the same
     /// batch. Articles without entities, or whose entities don't overlap
     /// with anyone else's, become singleton clusters. Order within a cluster
-    /// preserves the original order. Larger clusters are returned first so
-    /// they get first dibs on batch space.
+    /// preserves the original order. Clusters containing at least one
+    /// preferred-feed article are returned first; remaining ties break on
+    /// cluster size and original article order.
     static func clusterByEntities(
         inputs: [Input],
         entityMap: [Int64: Set<String>],
+        preferredFeedIDs: Set<Int64> = [],
         sharedThreshold: Int = 2
     ) -> [[Input]] {
         guard !inputs.isEmpty else { return [] }
@@ -54,6 +56,11 @@ extension HeadlineSummarizer {
         }
         return groups
             .sorted { lhs, rhs in
+                let lhsPreferred = lhs.value.contains { preferredFeedIDs.contains($0.feedID) }
+                let rhsPreferred = rhs.value.contains { preferredFeedIDs.contains($0.feedID) }
+                if lhsPreferred != rhsPreferred {
+                    return lhsPreferred && !rhsPreferred
+                }
                 if lhs.value.count != rhs.value.count {
                     return lhs.value.count > rhs.value.count
                 }

--- a/Hanami/Summarization/HeadlineSummarizer.swift
+++ b/Hanami/Summarization/HeadlineSummarizer.swift
@@ -27,17 +27,30 @@ public enum HeadlineSummarizer {
 
     nonisolated static let logModule = "Summary"
     static let batchCharLimit = 3000
-    public static let snippetCharLimit = 150
+    public static let snippetCharLimit = 300
     public static let maxArticlesConsidered = 30
-    static let maxEvents = 5
     static let maxConcurrentBatches = 3
+
+    /// Cap on returned events that scales with input size so light days
+    /// don't get padded out to five headlines.
+    public static func maxEvents(for inputCount: Int) -> Int {
+        switch inputCount {
+        case ..<5: return 1
+        case 5..<10: return 2
+        case 10..<18: return 3
+        case 18..<25: return 4
+        default: return 5
+        }
+    }
 
     public struct Input: Sendable {
         public let articleID: Int64
+        public let feedID: Int64
         public let description: String
 
-        public init(articleID: Int64, description: String) {
+        public init(articleID: Int64, feedID: Int64 = 0, description: String) {
             self.articleID = articleID
+            self.feedID = feedID
             self.description = description
         }
     }
@@ -47,15 +60,23 @@ public enum HeadlineSummarizer {
         public let articleIDs: [Int64]
     }
 
+    /// Returns surviving events alongside the last non-guardrail error, if
+    /// any. Callers persist partial results when events is non-empty even
+    /// if error is set, so a cancelled batch doesn't wipe the section.
     public static func summarize(
         articles: [Input],
         instructions: String,
-        entityMap: [Int64: Set<String>] = [:]
-    ) async throws -> [ResolvedEvent] {
+        entityMap: [Int64: Set<String>] = [:],
+        preferredFeedIDs: Set<Int64> = []
+    ) async -> (events: [ResolvedEvent], error: Error?) {
         let filtered = articles.filter { input in
             !RejectPatterns.matchesAny(input.description)
         }
-        let clusters = clusterByEntities(inputs: filtered, entityMap: entityMap)
+        let clusters = clusterByEntities(
+            inputs: filtered,
+            entityMap: entityMap,
+            preferredFeedIDs: preferredFeedIDs
+        )
         let clusterSizes = clusters.map(\.count)
         log(
             logModule,
@@ -66,7 +87,7 @@ public enum HeadlineSummarizer {
         log(logModule, "instructions length=\(instructions.count) chars")
         guard !batches.isEmpty else {
             log(logModule, "no batches after filtering; returning empty")
-            return []
+            return ([], nil)
         }
 
         let (events, lastNonGuardrailError) = await runBatches(
@@ -76,16 +97,20 @@ public enum HeadlineSummarizer {
 
         if events.isEmpty {
             if let lastNonGuardrailError {
-                log(logModule, "all batches failed; throwing: \(lastNonGuardrailError.localizedDescription)")
-                throw lastNonGuardrailError
+                log(
+                    logModule,
+                    "all batches failed; surfacing error: \(lastNonGuardrailError.localizedDescription)"
+                )
+            } else {
+                log(logModule, "no events extracted from any batch")
             }
-            log(logModule, "no events extracted from any batch")
-            return []
+            return ([], lastNonGuardrailError)
         }
-        let deduped = Array(deduplicate(events).prefix(maxEvents))
-        log(logModule, "raw events=\(events.count) after dedup+cap=\(deduped.count)")
+        let cap = maxEvents(for: articles.count)
+        let deduped = Array(deduplicate(events).prefix(cap))
+        log(logModule, "raw events=\(events.count) after dedup+cap(\(cap))=\(deduped.count)")
         let translated = await translateHeadlinesIfNeeded(deduped)
-        return translated
+        return (translated, lastNonGuardrailError)
     }
 
     /// Detects each headline's language and runs a translation pass on

--- a/Hanami/Summarization/HeadlineSummarizer.swift
+++ b/Hanami/Summarization/HeadlineSummarizer.swift
@@ -36,7 +36,7 @@ public enum HeadlineSummarizer {
     /// rows. The DB wipes the summary_headlines cache on next launch
     /// when this differs from the stored value, independent of app
     /// version.
-    public static let promptVersion = 2
+    public nonisolated static let promptVersion = 2
 
     /// Cap on returned events that scales with input size so light days
     /// don't get padded out to five headlines.

--- a/Hanami/Summarization/HeadlineSummarizer.swift
+++ b/Hanami/Summarization/HeadlineSummarizer.swift
@@ -31,6 +31,13 @@ public enum HeadlineSummarizer {
     public static let maxArticlesConsidered = 30
     static let maxConcurrentBatches = 3
 
+    /// Bump whenever the headline prompt template, input format, event
+    /// cap, or resolver changes in a way that would invalidate cached
+    /// rows. The DB wipes the summary_headlines cache on next launch
+    /// when this differs from the stored value, independent of app
+    /// version.
+    public static let promptVersion = 2
+
     /// Cap on returned events that scales with input size so light days
     /// don't get padded out to five headlines.
     public static func maxEvents(for inputCount: Int) -> Int {

--- a/SakuraRSS.xcodeproj/project.pbxproj
+++ b/SakuraRSS.xcodeproj/project.pbxproj
@@ -768,7 +768,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.6.1;
+				MARKETING_VERSION = 1.6.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.tsubuzaki.SakuraRSS.Open-Article";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -804,7 +804,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.6.1;
+				MARKETING_VERSION = 1.6.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.tsubuzaki.SakuraRSS.Open-Article";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -982,7 +982,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.6.1;
+				MARKETING_VERSION = 1.6.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.SakuraRSS;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -1033,7 +1033,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.6.1;
+				MARKETING_VERSION = 1.6.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.SakuraRSS;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -1070,7 +1070,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.6.1;
+				MARKETING_VERSION = 1.6.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.tsubuzaki.SakuraRSS.Add-Feed";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -1107,7 +1107,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.6.1;
+				MARKETING_VERSION = 1.6.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.tsubuzaki.SakuraRSS.Add-Feed";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -1145,7 +1145,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.6.1;
+				MARKETING_VERSION = 1.6.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.SakuraRSS.Widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -1183,7 +1183,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.6.1;
+				MARKETING_VERSION = 1.6.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.SakuraRSS.Widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/Shared/Strings/Home.xcstrings
+++ b/Shared/Strings/Home.xcstrings
@@ -3663,6 +3663,65 @@
           }
         }
       }
+    },
+    "SummaryHeadlines.PreferredHint": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bevorzuge Ereignisse aus Artikeln, die mit ★ markiert sind."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Prioritize events drawn from articles marked with ★."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Privilégie les événements tirés des articles marqués d'une ★."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dai la priorità agli eventi tratti dagli articoli contrassegnati con ★."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "★が付いた記事から得られた出来事を優先してください。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "★ 표시가 있는 기사에서 추출한 사건을 우선적으로 다루세요."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ưu tiên các sự kiện được rút ra từ các bài viết được đánh dấu ★."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "优先选择标有 ★ 的文章中的事件。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "優先選擇標有 ★ 的文章中的事件。"
+          }
+        }
+      }
     }
   },
   "version": "1.1"

--- a/Shared/Strings/Settings.xcstrings
+++ b/Shared/Strings/Settings.xcstrings
@@ -7495,6 +7495,301 @@
           }
         }
       }
+    },
+    "Personalization" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Schlagzeilen personalisieren"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Personalize Headlines"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Personnaliser les titres"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Personalizza i titoli"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "見出しをパーソナライズ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "헤드라인 맞춤화"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cá nhân hóa tiêu đề"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "个性化标题"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "個人化標題"
+          }
+        }
+      }
+    },
+    "Personalization.Footer" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nutze, was du auf diesem Gerät liest, um Schlagzeilen und Themenhinweise zu sortieren. Diese Daten verlassen das Gerät nie."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Use what you read on this device to rank headlines and topic hints. This data never leaves your device."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Utilise ce que tu lis sur cet appareil pour classer les titres et les suggestions de sujets. Ces données ne quittent jamais l'appareil."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usa ciò che leggi su questo dispositivo per ordinare titoli e suggerimenti di argomenti. Questi dati non lasciano mai il dispositivo."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このデバイスで読んだ内容を使って見出しやトピックの提案を並べ替えます。データがデバイスから外に出ることはありません。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 기기에서 읽은 콘텐츠를 사용해 헤드라인과 주제 힌트의 순위를 정합니다. 이 데이터는 기기 외부로 전송되지 않습니다."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dùng những gì bạn đọc trên thiết bị này để xếp hạng tiêu đề và gợi ý chủ đề. Dữ liệu này không bao giờ rời khỏi thiết bị."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "根据你在此设备上阅读的内容对标题和主题提示进行排序。此数据不会离开你的设备。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "根據你在此裝置上閱讀的內容對標題和主題提示進行排序。此資料不會離開你的裝置。"
+          }
+        }
+      }
+    },
+    "Personalization.ClearHistory" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verlauf löschen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Clear Engagement History"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Effacer l'historique d'engagement"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancella cronologia di lettura"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "閲覧履歴を消去"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "참여 기록 지우기"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Xóa lịch sử tương tác"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除互动历史"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除互動紀錄"
+          }
+        }
+      }
+    },
+    "Personalization.ClearHistory.Confirm.Title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verlauf löschen?"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Clear engagement history?"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Effacer l'historique ?"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancellare la cronologia?"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "閲覧履歴を消去しますか？"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "참여 기록을 지울까요?"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Xóa lịch sử tương tác?"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要清除互动历史吗？"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要清除互動紀錄嗎？"
+          }
+        }
+      }
+    },
+    "Personalization.ClearHistory.Confirm.Message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dies entfernt die Aufzeichnung der von dir geöffneten Artikel. Die Personalisierung wird zurückgesetzt, bis du weitere Artikel liest."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This removes the record of articles you've opened. Personalization will reset until you read more articles."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cela supprime l'enregistrement des articles que tu as ouverts. La personnalisation sera réinitialisée jusqu'à ce que tu lises d'autres articles."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Questo rimuove la cronologia degli articoli che hai aperto. La personalizzazione si reimposta finché non leggi altri articoli."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開いた記事の履歴を削除します。新しい記事を読むまでパーソナライズはリセットされます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "열어본 기사 기록을 삭제합니다. 새 기사를 읽기 전까지 맞춤 설정이 초기화됩니다."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thao tác này xóa bản ghi các bài viết bạn đã mở. Cá nhân hóa sẽ được đặt lại cho đến khi bạn đọc thêm bài."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "这将删除你打开过的文章记录,个性化将在你阅读更多文章前重置。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "這會刪除你開啟過的文章紀錄,個人化將在你閱讀更多文章前重設。"
+          }
+        }
+      }
     }
   },
   "version" : "1.1"


### PR DESCRIPTION
## Summary

Improves the three Home summary headline cards (`todaysSummary`, `whileYouSlept`, `afternoonBrief`) generated by `HeadlineSummarizer`. Implementation in progress on this branch; landing as a sequence of commits.

### Planned changes
- **Bug fix (landed)**: `flushDebouncedReads` no longer writes `articleLastAccessed` for scroll-past mark-read. Only explicit article opens count as engagement.
- **Personalization (opt-out)**: derive feed/topic preference from existing `articleLastAccessed` + `nlp_entities` data; gate behind `Intelligence.Personalization.Enabled` (default on) in Settings, with a "Clear engagement history" button.
- **Richer input**: snippet limit 150 → 300 chars, falls back to `article.content` when `article.summary` is missing.
- **Scaled event ceiling**: max events scales 1–5 based on input count; eligibility floor lowered from 5 to 3.
- **Resilient cancel path**: `HeadlineSummarizer.summarize` returns partial events + optional error so already-generated events survive cancellation; partial caches auto-regenerate when ≥3 more articles arrive.

### Test plan
- [ ] Manual: scroll past unread articles, confirm `feedAccessCounts` returns 0 for those feeds; tap-open three articles in different feeds, confirm counts of 1.
- [ ] Manual: toggle Personalization off, confirm headline output matches pre-change behavior.
- [ ] Manual: force-quit mid-generation, confirm partial headlines survive; pull-to-refresh after new articles triggers regeneration.
- [ ] Manual: switch system locale to non-English, confirm new strings render correctly.
- [ ] `swiftlint` clean on changed files.

---
_Generated by [Claude Code](https://claude.ai/code/session_0148Zsgeq6ULiZNBe9ZjDHNK)_