### PR TITLE
Fix podcast download donut reset and match podcast row button sizes

### DIFF
--- a/App/Display Styles/Podcast/PodcastEpisodeRow.swift
+++ b/App/Display Styles/Podcast/PodcastEpisodeRow.swift
@@ -68,16 +68,17 @@ struct PodcastEpisodeRow: View {
             Spacer(minLength: 0)
 
             if article.isPodcastEpisode {
-                PodcastDownloadButton(article: article, size: 28, lineWidth: 2.5)
+                PodcastDownloadButton(article: article, size: 32, lineWidth: 3)
                 Button {
                     handlePlay()
                 } label: {
                     Image(systemName: isCurrentlyPlaying && audioPlayer.isPlaying
                           ? "pause.circle.fill"
                           : "play.circle.fill")
-                        .font(.title)
+                        .font(.system(size: 32))
                         .foregroundStyle(.accent)
                         .symbolRenderingMode(.multicolor)
+                        .frame(width: 32, height: 32)
                 }
                 .buttonStyle(.plain)
                 .disabled(!canPlay && !isCurrentlyPlaying)

--- a/App/Shared/PodcastDownloadButton.swift
+++ b/App/Shared/PodcastDownloadButton.swift
@@ -105,13 +105,12 @@ struct PodcastDownloadButton: View {
     }
 }
 
-/// Indeterminate spinning donut shown while transcription is running.
 private struct TranscribingDonut: View {
 
     let size: CGFloat
     let lineWidth: CGFloat
 
-    @State private var rotation: Double = 0
+    @State private var isPulsing = false
 
     var body: some View {
         ZStack {
@@ -120,18 +119,17 @@ private struct TranscribingDonut: View {
                 .frame(width: size - lineWidth, height: size - lineWidth)
 
             Circle()
-                .trim(from: 0, to: 0.25)
                 .stroke(.accent, style: StrokeStyle(lineWidth: lineWidth, lineCap: .round))
                 .frame(width: size - lineWidth, height: size - lineWidth)
-                .rotationEffect(.degrees(rotation))
 
             Image(systemName: "waveform")
                 .font(.system(size: size * 0.45))
                 .foregroundStyle(.accent)
+                .opacity(isPulsing ? 0.35 : 1.0)
         }
         .onAppear {
-            withAnimation(.linear(duration: 1.0).repeatForever(autoreverses: false)) {
-                rotation = 360
+            withAnimation(.easeInOut(duration: 0.9).repeatForever(autoreverses: true)) {
+                isPulsing = true
             }
         }
     }

--- a/Hanami/Feed Providers/Podcasts/Downloads/PodcastDownloadManager+Download.swift
+++ b/Hanami/Feed Providers/Podcasts/Downloads/PodcastDownloadManager+Download.swift
@@ -3,9 +3,13 @@ import Foundation
 public extension PodcastDownloadManager {
 
     func downloadEpisode(article: Article) {
-        guard activeDownloads[article.id] == nil else { return }
+        guard activeDownloads[article.id] == nil else {
+            log("PodcastDownload", "Skipping download for article \(article.id): already in progress")
+            return
+        }
         guard let audioURLString = article.audioURL,
               let audioURL = URL(string: audioURLString) else {
+            log("PodcastDownload", "Download failed for article \(article.id): missing or invalid audio URL")
             activeDownloads[article.id] = DownloadProgress(
                 state: .failed,
                 progress: 0,
@@ -14,16 +18,18 @@ public extension PodcastDownloadManager {
             return
         }
 
+        log("PodcastDownload", "Starting download for article \(article.id) from \(audioURL)")
         activeDownloads[article.id] = DownloadProgress(state: .downloading, progress: 0)
 
         let task = Task { @MainActor [weak self] in
             do {
                 try await self?.performDownload(article: article, audioURL: audioURL)
             } catch is CancellationError {
-                // cancelDownload() already cleaned up state.
+                log("PodcastDownload", "Download cancelled for article \(article.id)")
             } catch let urlError as URLError where urlError.code == .cancelled {
-                // Same as above.
+                log("PodcastDownload", "Download URL task cancelled for article \(article.id)")
             } catch {
+                log("PodcastDownload", "Download failed for article \(article.id): \(error)")
                 self?.markFailed(articleID: article.id, error: error.localizedDescription)
             }
         }
@@ -32,12 +38,14 @@ public extension PodcastDownloadManager {
 
     func performDownload(article: Article, audioURL: URL) async throws {
         guard let episodeDir = episodeDirectory(for: article.id) else {
+            log("PodcastDownload", "Storage unavailable for article \(article.id)")
             throw PodcastDownloadError.storageUnavailable
         }
         let name = filename(from: audioURL)
         let destination = episodeDir.appendingPathComponent(name)
         let articleID = article.id
 
+        log("PodcastDownload", "Preparing episode directory at \(episodeDir.path)")
         let dir = episodeDir
         let dest = destination
         try await Task.detached(priority: .utility) {
@@ -50,6 +58,7 @@ public extension PodcastDownloadManager {
             }
         }.value
 
+        log("PodcastDownload", "Starting URLSession download task for article \(articleID)")
         let tempURL: URL = try await withCheckedThrowingContinuation { continuation in
             let sessionTask = urlSession.downloadTask(with: audioURL)
             downloadTasks[articleID] = sessionTask
@@ -59,6 +68,7 @@ public extension PodcastDownloadManager {
         }
 
         downloadTasks[articleID] = nil
+        log("PodcastDownload", "Download finished for article \(articleID), moving file to \(dest.path)")
 
         try await Task.detached(priority: .utility) {
             try FileManager.default.moveItem(at: tempURL, to: dest)
@@ -66,13 +76,17 @@ public extension PodcastDownloadManager {
 
         // Store relative path so it survives container path changes.
         let relativePath = "\(articleID)/\(name)"
+        log("PodcastDownload", "Storing download path '\(relativePath)' for article \(articleID)")
         try DatabaseManager.shared.setDownloadPath(relativePath, for: articleID)
 
         // Transcription failure is non-fatal; we still markCompleted below.
         if await PodcastTranscriber.isAvailable {
+            log("PodcastDownload", "Transcription available, queuing transcription for article \(articleID)")
             activeDownloads[articleID] = DownloadProgress(state: .transcribing, progress: 1.0)
             let title = article.title
             await attemptTranscription(articleID: articleID, fileURL: destination, title: title)
+        } else {
+            log("PodcastDownload", "Transcription unavailable, skipping for article \(articleID)")
         }
 
         markCompleted(articleID: articleID)

--- a/Hanami/Feed Providers/Podcasts/Downloads/PodcastDownloadManager+Download.swift
+++ b/Hanami/Feed Providers/Podcasts/Downloads/PodcastDownloadManager+Download.swift
@@ -70,7 +70,7 @@ public extension PodcastDownloadManager {
 
         // Transcription failure is non-fatal; we still markCompleted below.
         if await PodcastTranscriber.isAvailable {
-            activeDownloads[articleID] = DownloadProgress(state: .transcribing, progress: 0)
+            activeDownloads[articleID] = DownloadProgress(state: .transcribing, progress: 1.0)
             let title = article.title
             await attemptTranscription(articleID: articleID, fileURL: destination, title: title)
         }

--- a/Hanami/Feed Providers/Podcasts/Downloads/PodcastDownloadManager+Lifecycle.swift
+++ b/Hanami/Feed Providers/Podcasts/Downloads/PodcastDownloadManager+Lifecycle.swift
@@ -3,6 +3,7 @@ import Foundation
 public extension PodcastDownloadManager {
 
     func cancelDownload(articleID: Int64) {
+        log("PodcastDownload", "Cancelling download for article \(articleID)")
         downloadTasks[articleID]?.cancel()
         downloadTasks[articleID] = nil
         transcriptionTasks[articleID]?.cancel()
@@ -13,11 +14,13 @@ public extension PodcastDownloadManager {
         activeDownloads[articleID] = nil
         if let dir = episodeDirectory(for: articleID),
            fileManager.fileExists(atPath: dir.path) {
+            log("PodcastDownload", "Removing partial download directory for article \(articleID)")
             try? fileManager.removeItem(at: dir)
         }
     }
 
     func deleteDownload(articleID: Int64) throws {
+        log("PodcastDownload", "Deleting download for article \(articleID)")
         if let dir = episodeDirectory(for: articleID),
            fileManager.fileExists(atPath: dir.path) {
             try fileManager.removeItem(at: dir)
@@ -25,19 +28,26 @@ public extension PodcastDownloadManager {
         try DatabaseManager.shared.setDownloadPath(nil, for: articleID)
         try? DatabaseManager.shared.clearCachedTranscript(for: articleID)
         activeDownloads[articleID] = nil
+        log("PodcastDownload", "Download deleted for article \(articleID)")
     }
 
     func deleteAllDownloads() throws {
-        guard let dir = downloadsDirectory else { return }
+        log("PodcastDownload", "Deleting all downloads")
+        guard let dir = downloadsDirectory else {
+            log("PodcastDownload", "Downloads directory unavailable, skipping deleteAllDownloads")
+            return
+        }
         if fileManager.fileExists(atPath: dir.path) {
             try fileManager.removeItem(at: dir)
             try fileManager.createDirectory(at: dir, withIntermediateDirectories: true)
         }
         let ids = (try? DatabaseManager.shared.downloadedArticleIDs()) ?? []
+        log("PodcastDownload", "Clearing download paths for \(ids.count) article(s)")
         for identifier in ids {
             try? DatabaseManager.shared.setDownloadPath(nil, for: identifier)
             try? DatabaseManager.shared.clearCachedTranscript(for: identifier)
         }
         activeDownloads.removeAll()
+        log("PodcastDownload", "All downloads deleted")
     }
 }

--- a/Hanami/Feed Providers/Podcasts/Downloads/PodcastDownloadManager+Maintenance.swift
+++ b/Hanami/Feed Providers/Podcasts/Downloads/PodcastDownloadManager+Maintenance.swift
@@ -4,22 +4,32 @@ public extension PodcastDownloadManager {
 
     /// Removes download files whose article no longer exists in the database.
     nonisolated static func cleanupOrphanedDownloads() {
+        log("PodcastDownload", "Starting orphaned download cleanup")
         let fileManager = FileManager.default
         guard let container = fileManager.containerURL(
             forSecurityApplicationGroupIdentifier: "group.com.tsubuzaki.SakuraRSS"
-        ) else { return }
+        ) else {
+            log("PodcastDownload", "Cleanup aborted: app group container unavailable")
+            return
+        }
         let root = container.appendingPathComponent("PodcastDownloads", isDirectory: true)
-        guard fileManager.fileExists(atPath: root.path) else { return }
+        guard fileManager.fileExists(atPath: root.path) else {
+            log("PodcastDownload", "Cleanup skipped: PodcastDownloads directory does not exist")
+            return
+        }
         let contents = (try? fileManager.contentsOfDirectory(atPath: root.path)) ?? []
         let validIDs = Set((try? DatabaseManager.shared.downloadedArticleIDs()) ?? [])
+        log("PodcastDownload", "Found \(contents.count) item(s) on disk, \(validIDs.count) valid ID(s) in database")
         for name in contents {
             guard let identifier = Int64(name) else {
                 continue
             }
             if !validIDs.contains(identifier) {
+                log("PodcastDownload", "Removing orphaned download directory for article \(identifier)")
                 try? fileManager.removeItem(at: root.appendingPathComponent(name))
             }
         }
+        log("PodcastDownload", "Orphaned download cleanup complete")
     }
 
     nonisolated static func totalDownloadedSize() -> Int64 {

--- a/Hanami/Feed Providers/Podcasts/Downloads/PodcastDownloadManager+Storage.swift
+++ b/Hanami/Feed Providers/Podcasts/Downloads/PodcastDownloadManager+Storage.swift
@@ -22,6 +22,10 @@ public extension PodcastDownloadManager {
         if last.isEmpty || last == "/" {
             return "episode.mp3"
         }
+        if last.utf8.count > 200 {
+            let ext = audioURL.pathExtension
+            return ext.isEmpty ? "episode.mp3" : "episode.\(ext)"
+        }
         return last
     }
 

--- a/Hanami/Feed Providers/Podcasts/Downloads/PodcastDownloadManager+Transcription.swift
+++ b/Hanami/Feed Providers/Podcasts/Downloads/PodcastDownloadManager+Transcription.swift
@@ -16,6 +16,7 @@ public extension PodcastDownloadManager {
     }
 
     func markCompleted(articleID: Int64) {
+        log("PodcastDownload", "Download completed for article \(articleID)")
         activeDownloads[articleID] = DownloadProgress(state: .completed, progress: 1.0)
         downloadTasks[articleID] = nil
         transcriptionTasks[articleID] = nil
@@ -26,6 +27,7 @@ public extension PodcastDownloadManager {
     }
 
     func markFailed(articleID: Int64, error: String) {
+        log("PodcastDownload", "Download failed for article \(articleID): \(error)")
         activeDownloads[articleID] = DownloadProgress(
             state: .failed,
             progress: 0,

--- a/Hanami/Feed Providers/Podcasts/Downloads/PodcastDownloadManager+URLSessionDelegate.swift
+++ b/Hanami/Feed Providers/Podcasts/Downloads/PodcastDownloadManager+URLSessionDelegate.swift
@@ -19,6 +19,8 @@ public extension PodcastDownloadManager {
             } else {
                 fraction = 0
             }
+            // swiftlint:disable:next line_length
+            log("PodcastDownload", "Progress for article \(articleID): \(totalBytesWritten)/\(totalBytesExpectedToWrite) bytes (\(String(format: "%.1f", fraction * 100))%)")
             activeDownloads[articleID] = DownloadProgress(
                 state: .downloading,
                 progress: fraction
@@ -43,6 +45,7 @@ public extension PodcastDownloadManager {
                   let continuation = downloadContinuations.removeValue(forKey: articleID) else {
                 return
             }
+            log("PodcastDownload", "URLSession finished downloading article \(articleID) to \(tempCopy.path)")
             taskArticleIDs[taskID] = nil
             continuation.resume(returning: tempCopy)
         }
@@ -61,6 +64,7 @@ public extension PodcastDownloadManager {
                   let continuation = downloadContinuations.removeValue(forKey: articleID) else {
                 return
             }
+            log("PodcastDownload", "URLSession task completed with error for article \(articleID): \(error)")
             continuation.resume(throwing: error)
         }
     }


### PR DESCRIPTION
## Summary

- **Download donut reset (progress bug):** When transcription was enabled, the donut visually jumped from a full 100% ring to a thin spinning quarter-circle, which read as the progress resetting to ~0%. The `.transcribing` state now renders a full donut with a pulsing waveform glyph, so the ring fills to 100%, stays full while transcription runs, then transitions to the checkmark. Progress is set to `1.0` on the `.transcribing` state since the download itself is fully complete at that point.
- **Button size mismatch (#288):** The Download and Play buttons in `PodcastEpisodeRow` rendered at slightly different sizes — the download button used a fixed 28pt while the play button used the dynamic `.title` font. Bump both to a matching fixed 32pt with explicit frames.

## Test plan

- [ ] Enable on-device transcription in Podcast settings, download an episode, and verify the donut on `PodcastDownloadButton` fills to 100% and stays full (waveform pulsing) until transcription finishes, then becomes a checkmark.
- [ ] Disable transcription and download again: the donut should fill to 100% and transition straight to the checkmark with no visual reset.
- [ ] Cancel a download mid-transcription: cancellation should still work via tapping the donut.
- [ ] Open a podcast feed using the Podcast display style and verify the Download and Play buttons on each row are the same visual size and aligned.