### PR TITLE
Refresh foreground last-refresh timestamp after background task

### DIFF
--- a/App/App.swift
+++ b/App/App.swift
@@ -59,6 +59,7 @@ struct SakuraRSSApp: App {
                     NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)
                 ) { _ in
                     feedManager.updateBadgeCount()
+                    feedManager.reloadRefreshTimestampsFromDefaults()
                     let now = Date()
                     if let last = lastForegroundWorkAt, now.timeIntervalSince(last) < 5 * 60 {
                         return

--- a/Hanami/Feed Manager/FeedManager.swift
+++ b/Hanami/Feed Manager/FeedManager.swift
@@ -42,6 +42,22 @@ public final class FeedManager {
         return raw.mapValues { Date(timeIntervalSince1970: $0) }
     }
 
+    /// Re-reads refresh timestamps from `UserDefaults` so the foreground
+    /// instance picks up writes made by a separate `FeedManager` running in a
+    /// `BGAppRefreshTask` while the app was suspended.
+    public func reloadRefreshTimestampsFromDefaults() {
+        let storedLast = UserDefaults.standard.object(
+            forKey: FeedManager.lastRefreshedAtDefaultsKey
+        ) as? Date
+        if storedLast != lastRefreshedAt {
+            lastRefreshedAt = storedLast
+        }
+        let storedScoped = FeedManager.loadScopedLastRefreshedAt()
+        if storedScoped != scopedLastRefreshedAt {
+            scopedLastRefreshedAt = storedScoped
+        }
+    }
+
     public var searchHistory: [String] = FeedManager.loadSearchHistory() {
         didSet {
             UserDefaults.standard.set(

--- a/Hanami/Feed Manager/FeedManager.swift
+++ b/Hanami/Feed Manager/FeedManager.swift
@@ -42,9 +42,6 @@ public final class FeedManager {
         return raw.mapValues { Date(timeIntervalSince1970: $0) }
     }
 
-    /// Re-reads refresh timestamps from `UserDefaults` so the foreground
-    /// instance picks up writes made by a separate `FeedManager` running in a
-    /// `BGAppRefreshTask` while the app was suspended.
     public func reloadRefreshTimestampsFromDefaults() {
         let storedLast = UserDefaults.standard.object(
             forKey: FeedManager.lastRefreshedAtDefaultsKey

--- a/Hanami/Feed Manager/FeedManager.swift
+++ b/Hanami/Feed Manager/FeedManager.swift
@@ -110,7 +110,7 @@ public final class FeedManager {
 
     @ObservationIgnored public var contentOverrideCache: [Int64: CachedContentOverride] = [:]
 
-    @ObservationIgnored nonisolated(unsafe) private var hideReelsObserver: NSObjectProtocol?
+    @ObservationIgnored nonisolated(unsafe) private var userDefaultsObserver: NSObjectProtocol?
     @ObservationIgnored private var lastObservedHideReels: Bool =
         UserDefaults.standard.bool(forKey: FeedManager.hideInstagramReelsDefaultsKey)
 
@@ -120,20 +120,21 @@ public final class FeedManager {
 
     public init() {
         loadFromDatabase()
-        hideReelsObserver = NotificationCenter.default.addObserver(
+        userDefaultsObserver = NotificationCenter.default.addObserver(
             forName: UserDefaults.didChangeNotification,
             object: UserDefaults.standard,
             queue: nil
         ) { [weak self] _ in
             Task { @MainActor [weak self] in
                 self?.handleHideReelsChangeIfNeeded()
+                self?.reloadRefreshTimestampsFromDefaults()
             }
         }
     }
 
     deinit {
-        if let hideReelsObserver {
-            NotificationCenter.default.removeObserver(hideReelsObserver)
+        if let userDefaultsObserver {
+            NotificationCenter.default.removeObserver(userDefaultsObserver)
         }
     }
 


### PR DESCRIPTION
## Summary

The principal toolbar shows a stale "last refreshed" date after a background refresh completes because the foreground `FeedManager` never re-reads the value written by the background task.

`BGAppRefreshTask` instantiates its own `FeedManager` in `handleAppRefresh` (App/App+BackgroundTasks.swift:87). At the end of `refreshFeeds(in:...)` it sets `self.lastRefreshedAt = Date()`, which the `didSet` observer persists to `UserDefaults`. But the live `@State var feedManager` in `SakuraRSSApp` only reads `lastRefreshedAt` from `UserDefaults` once at init (Hanami/Feed Manager/FeedManager.swift:19), so its in-memory copy — the one the toolbar observes via `HomeView+Toolbar.formattedDate` — stays stale until the app is force-relaunched.

Fix:
- Add `FeedManager.reloadRefreshTimestampsFromDefaults()` which re-reads both `lastRefreshedAt` and `scopedLastRefreshedAt` from `UserDefaults` and assigns them through the observed setters (only when changed) so `@Observable` notifies the toolbar.
- Call it from the `willEnterForegroundNotification` handler in `SakuraRSSApp` before the existing 5-minute throttle, since the read is cheap and must run every time the app resumes.

## Test plan

- [ ] Trigger a background refresh while the app is suspended (e.g. via the `e -l objc -- (void)[[BGTaskScheduler sharedScheduler] _simulateLaunchForTaskWithIdentifier:@"..."]` lldb hook), then bring the app to the foreground and confirm the principal toolbar updates to "just now" / today rather than the prior date.
- [ ] Confirm a foreground pull-to-refresh still updates the toolbar (regression check).
- [ ] Confirm scoped refresh dates (per-section) remain correct after a background refresh + foreground.

https://claude.ai/code/session_01PHu8fs5is4sy5ZZNji5hUc

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHu8fs5is4sy5ZZNji5hUc)_