### PR TITLE
Arm autoplay across YouTube ad transitions

### DIFF
--- a/App/YouTube Player/YouTubePlayerScripts+Playback.swift
+++ b/App/YouTube Player/YouTubePlayerScripts+Playback.swift
@@ -54,13 +54,6 @@ extension YouTubePlayerScripts {
                 + (s.adSkippable ? '1' : '0') + ':' + s.advertiserURL;
             if (!force && sig === lastAdSig) return;
             lastAdSig = sig;
-            // YouTube swaps the <video> source during ad <> content
-            // transitions, which leaves the element paused with no
-            // pause event to retrigger the pause guard (and the guard's
-            // end-of-video bail also fires when an ad ends naturally).
-            // Arm the autoplay poller so it picks up the new media as
-            // soon as it is ready. Respect `userPaused` so a manual
-            // pause during an ad survives the natural ad end.
             if (lastIsAd !== null && lastIsAd !== s.isAd
                 && window.__yt && window.__yt.userPaused !== true
                 && typeof window.__yt.armAutoplay === 'function') {

--- a/App/YouTube Player/YouTubePlayerScripts+Playback.swift
+++ b/App/YouTube Player/YouTubePlayerScripts+Playback.swift
@@ -8,6 +8,7 @@ extension YouTubePlayerScripts {
     (function() {
         var lastTimeQuarter = -1;
         var lastAdSig = '';
+        var lastIsAd = null;
         function send(payload) {
             try {
                 window.webkit.messageHandlers.\(playbackMessageHandlerName)
@@ -53,6 +54,19 @@ extension YouTubePlayerScripts {
                 + (s.adSkippable ? '1' : '0') + ':' + s.advertiserURL;
             if (!force && sig === lastAdSig) return;
             lastAdSig = sig;
+            // YouTube swaps the <video> source during ad <> content
+            // transitions, which leaves the element paused with no
+            // pause event to retrigger the pause guard (and the guard's
+            // end-of-video bail also fires when an ad ends naturally).
+            // Arm the autoplay poller so it picks up the new media as
+            // soon as it is ready. Respect `userPaused` so a manual
+            // pause during an ad survives the natural ad end.
+            if (lastIsAd !== null && lastIsAd !== s.isAd
+                && window.__yt && window.__yt.userPaused !== true
+                && typeof window.__yt.armAutoplay === 'function') {
+                window.__yt.armAutoplay(8000);
+            }
+            lastIsAd = s.isAd;
             send({ event: 'ad', isAd: s.isAd,
                 adSkippable: s.adSkippable, advertiserURL: s.advertiserURL });
         }


### PR DESCRIPTION
## Summary

The WebView-based YouTube player pauses for ~5-6 seconds whenever the player crosses an ad/content boundary.

**Root cause:** YouTube swaps the `<video>` element's source between ads and main content, leaving the element transiently paused. Two problems combined to leave the new media stuck:

- The `pauseGuard` (`YouTubePlayerScripts.swift:261`) won't resume when `currentTime >= duration - 0.25`, which is exactly the state at the end of an ad — so when the ad finishes naturally the guard intentionally bails.
- After the source swap, the new media never emits a `pause` event to retrigger the guard, so nothing kicks playback off until YouTube's own JS gets around to it.

The existing `autoplayArmer` polls every 200ms attempting to play any paused video — but it was only armed when the user manually tapped Skip Ad.

**Fix:** track ad-state transitions in `playbackEventBridge.sendAd()` and call `__yt.armAutoplay(8000)` whenever `isAd` flips. The check for `userPaused !== true` preserves a manual pause issued during an ad so the natural ad end doesn't override it.

## Test plan

- [ ] Open a YouTube video with a pre-roll ad — playback resumes promptly when the ad ends or is skipped.
- [ ] Open a YouTube video that triggers a mid-roll ad — content-to-ad and ad-to-content transitions both resume promptly.
- [ ] Pause manually during an ad, let the ad end — video stays paused.
- [ ] Tap Skip Ad — content resumes promptly (existing behavior unaffected).

https://claude.ai/code/session_0117b6Xfqi91kQvtnu4TNMad

---
_Generated by [Claude Code](https://claude.ai/code/session_0117b6Xfqi91kQvtnu4TNMad)_