### PR TITLE
Route PiP fast-forward to Skip Ad and disable rewind during ads

### DIFF
--- a/App/YouTube Player/V2/NewYouTubePlayerView.swift
+++ b/App/YouTube Player/V2/NewYouTubePlayerView.swift
@@ -155,13 +155,25 @@ struct NewYouTubePlayerView: View {
             NewYouTubePlayerRepresentable(controller: playback)
         case .failed:
             Color.black.overlay {
-                VStack(spacing: 8) {
-                    Image(systemName: "exclamationmark.triangle")
-                        .font(.title)
-                    Text(String(localized: "YouTube.NewPlayer.LoadFailed", table: "Integrations"))
-                        .font(.subheadline)
+                VStack(spacing: 12) {
+                    VStack(spacing: 8) {
+                        Image(systemName: "exclamationmark.triangle")
+                            .font(.title)
+                        Text(String(localized: "YouTube.NewPlayer.LoadFailed", table: "Integrations"))
+                            .font(.subheadline)
+                    }
+                    .foregroundStyle(.secondary)
+                    Button {
+                        Task {
+                            loadState = .loading
+                            await loadStream()
+                        }
+                    } label: {
+                        Text(String(localized: "YouTube.NewPlayer.Retry", table: "Integrations"))
+                    }
+                    .buttonStyle(.bordered)
+                    .tint(.white)
                 }
-                .foregroundStyle(.secondary)
             }
         }
     }

--- a/App/YouTube Player/YouTubePlayerScripts+PiP.swift
+++ b/App/YouTube Player/YouTubePlayerScripts+PiP.swift
@@ -87,6 +87,9 @@ extension YouTubePlayerScripts {
 
         function performSkipAd() {
             if (!isShowingAd()) return;
+            // Arm autoplay before the skip so the post-ad video swap plays
+            // without the usual startup delay.
+            resumePlayback();
             var btn = findSkipButton();
             if (btn) {
                 clickSkipButton(btn);
@@ -113,15 +116,19 @@ extension YouTubePlayerScripts {
             })();
         }
 
+        // No-op handler; setting `null` would let the user agent fall back
+        // to its default seek behavior.
+        function blockRewind() {}
+
         function apply() {
             var isAd = isShowingAd();
 
             var desired;
             if (isAd) {
                 desired = {
-                    previoustrack: null,
+                    previoustrack: blockRewind,
                     nexttrack: performSkipAd,
-                    seekbackward: null,
+                    seekbackward: blockRewind,
                     seekforward: performSkipAd
                 };
             } else {

--- a/App/YouTube Player/YouTubePlayerScripts+PiP.swift
+++ b/App/YouTube Player/YouTubePlayerScripts+PiP.swift
@@ -87,8 +87,6 @@ extension YouTubePlayerScripts {
 
         function performSkipAd() {
             if (!isShowingAd()) return;
-            // Arm autoplay before the skip so the post-ad video swap plays
-            // without the usual startup delay.
             resumePlayback();
             var btn = findSkipButton();
             if (btn) {
@@ -116,8 +114,6 @@ extension YouTubePlayerScripts {
             })();
         }
 
-        // No-op handler; setting `null` would let the user agent fall back
-        // to its default seek behavior.
         function blockRewind() {}
 
         function apply() {

--- a/Shared/Strings/Integrations.xcstrings
+++ b/Shared/Strings/Integrations.xcstrings
@@ -2832,6 +2832,65 @@
           }
         }
       }
+    },
+    "YouTube.NewPlayer.Retry": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erneut versuchen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retry"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réessayer"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Riprova"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "再試行"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "재시도"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thử lại"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重试"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重試"
+          }
+        }
+      }
     }
   },
   "version": "1.1"


### PR DESCRIPTION
## Summary

- During ads the system PiP overlay's rewind button still scrubbed the ad backward because `pipAdControls` set `previoustrack`/`seekbackward` to `null`, and per the Media Session spec a null handler leaves the user agent's default seek behavior in place.
- Register a no-op handler for `previoustrack` and `seekbackward` while an ad is showing so the PiP rewind/previous-track buttons are truly inert.
- `seekforward` and `nexttrack` continue to invoke `performSkipAd`, so the PiP fast-forward button still acts as Skip Ad.
- `performSkipAd` now calls `resumePlayback` (which fires `__yt.armAutoplay(12000)`) up front so the post-ad video swap autoplays without the usual startup delay, in addition to the existing post-skip arming.

## Test plan

- [ ] Start a YouTube video, let an ad start, enter PiP, and confirm the fast-forward button skips the ad.
- [ ] Confirm the PiP rewind button does nothing while an ad is showing.
- [ ] Confirm rewind/fast-forward in PiP work normally once the ad ends.
- [ ] Confirm playback resumes promptly after the ad skip without the usual delay.

https://claude.ai/code/session_01RFzAFfxbViZuKEVB5wvYMH

---
_Generated by [Claude Code](https://claude.ai/code/session_01RFzAFfxbViZuKEVB5wvYMH)_