### PR TITLE
Improve stream resolution logging

### DIFF
--- a/App/YouTube Player/V2/Datatypes/YouTubeBrowseError.swift
+++ b/App/YouTube Player/V2/Datatypes/YouTubeBrowseError.swift
@@ -9,3 +9,20 @@ nonisolated enum YouTubeBrowseError: Error, Sendable {
     case missingData
     case unexpectedResponse(status: Int)
 }
+
+extension YouTubeBrowseError: CustomStringConvertible {
+    var description: String {
+        switch self {
+        case .invalidURL:
+            return "invalidURL (could not construct request URL)"
+        case .compressionFailed:
+            return "compressionFailed (could not gzip request body)"
+        case .decodingFailed:
+            return "decodingFailed (response was not valid JSON or UTF-8)"
+        case .missingData:
+            return "missingData (expected fields were absent from the response)"
+        case .unexpectedResponse(let status):
+            return "unexpectedResponse (HTTP status \(status))"
+        }
+    }
+}

--- a/App/YouTube Player/V2/NewYouTubeClient+Transport.swift
+++ b/App/YouTube Player/V2/NewYouTubeClient+Transport.swift
@@ -71,10 +71,26 @@ extension NewYouTubeClient {
         if let http = response as? HTTPURLResponse {
             log("YouTube", "POST \(endpoint): HTTP \(http.statusCode)")
             if !(200..<300).contains(http.statusCode) {
+                Self.logResponseBody(endpoint: endpoint, data: data)
                 throw YouTubeBrowseError.unexpectedResponse(status: http.statusCode)
             }
         }
+        Self.logResponseBody(endpoint: endpoint, data: data)
         return data
+    }
+
+    private static let responseBodyLogLimit = 8192
+
+    private static func logResponseBody(endpoint: String, data: Data) {
+        guard let text = String(data: data, encoding: .utf8) else {
+            log("YouTube", "Response \(endpoint): \(data.count) bytes (non-UTF8)")
+            return
+        }
+        let truncated = text.count > responseBodyLogLimit
+            // swiftlint:disable:next line_length
+            ? String(text.prefix(responseBodyLogLimit)) + "...(truncated \(text.count - responseBodyLogLimit) chars)"
+            : text
+        log("YouTube", "Response \(endpoint) (\(data.count) bytes):\n\(truncated)")
     }
 
     // swiftlint:disable:this large_tuple

--- a/App/YouTube Player/V2/NewYouTubePlayerView+Loading.swift
+++ b/App/YouTube Player/V2/NewYouTubePlayerView+Loading.swift
@@ -32,6 +32,7 @@ extension NewYouTubePlayerView {
         log("YT NewPlayer", "loadStream videoId=\(videoId) url=\(article.url)")
 
         if playback.currentVideoID == videoId, playback.player != nil {
+            log("YT NewPlayer", "Reusing active player for videoId=\(videoId)")
             await fetchMetadataIfNeeded(videoId: videoId)
             playback.updateMetadata(
                 title: playbackTitle,
@@ -47,7 +48,10 @@ extension NewYouTubePlayerView {
             async let manifestTask = client.hlsPlaylistURL(videoId: videoId)
             async let metadataTask = client.fetchVideoMetadata(videoId: videoId)
             fetchedMetadata = try? await metadataTask
+            log("YT NewPlayer", "Metadata for \(videoId): \(fetchedMetadata == nil ? "unavailable" : "ok")")
             let manifestURL = try await manifestTask
+            // swiftlint:disable:next line_length
+            log("YT NewPlayer", "Stream ready videoId=\(videoId) manifest=\(manifestURL.absoluteString)")
             playback.load(
                 url: manifestURL,
                 videoID: videoId,
@@ -57,7 +61,7 @@ extension NewYouTubePlayerView {
             )
             loadState = .ready
         } catch {
-            log("YT NewPlayer", "Failed to resolve stream: \(error)")
+            log("YT NewPlayer", "Failed to resolve stream videoId=\(videoId): \(error)")
             loadState = .failed
         }
     }


### PR DESCRIPTION
## Summary

When a stream fails to resolve, the `YT NewPlayer` log only showed two opaque lines (e.g. `Failed to resolve stream: missingData`) with no videoId correlation and a bare error case name. The detailed manifest diagnostics live in a *separate* per-module log file (`YouTube`), so the player log on its own was hard to diagnose during testing.

This adds verbose, self-explanatory logging to the stream loading path:

- **`YouTubeBrowseError`** now conforms to `CustomStringConvertible`, so every `\(error)` log line explains what failed instead of printing a bare case name (e.g. `missingData (expected fields were absent from the response)`, `unexpectedResponse (HTTP status 403)`). This improves error logging everywhere the client logs an error, not just `loadStream`.
- **`loadStream`** now logs videoId-correlated context at each branch:
  - reusing an already-active player
  - whether metadata was fetched (`ok` / `unavailable`)
  - the resolved manifest URL on success
  - the videoId alongside the error on failure

## Test plan

- [ ] Open a YouTube web feed item and confirm the `YT NewPlayer` log shows the new `Stream ready ... manifest=...` line on success
- [ ] Trigger a failing video and confirm the failure line includes the videoId and a descriptive error (cross-reference the `YouTube` module log for the manifest diagnostics)

https://claude.ai/code/session_01QtpPgcxTiFSY5822Vzz88b

---
_Generated by [Claude Code](https://claude.ai/code/session_01QtpPgcxTiFSY5822Vzz88b)_