### PR TITLE
Play YouTube videos via adaptive formats when HLS manifest is absent

### DIFF
--- a/App/YouTube Player/V2/Datatypes/YouTubeAdaptiveFormat.swift
+++ b/App/YouTube Player/V2/Datatypes/YouTubeAdaptiveFormat.swift
@@ -1,0 +1,38 @@
+import Foundation
+import Hanami
+
+/// A byte range within a media file, as reported by an `adaptiveFormats` entry.
+nonisolated struct YouTubeByteRange: Sendable {
+    let start: Int
+    let end: Int
+
+    var length: Int { end - start + 1 }
+}
+
+/// A single adaptive (DASH) stream entry from the player response's
+/// `streamingData.adaptiveFormats`. Each entry carries one elementary track,
+/// so a playable stream needs a video entry and an audio entry combined.
+nonisolated struct YouTubeAdaptiveFormat: Sendable {
+    let itag: Int
+    let url: String
+    let mimeType: String
+    let bitrate: Int
+    let width: Int?
+    let height: Int?
+    let approximateDurationMilliseconds: Int?
+    let contentLength: Int?
+    let initRange: YouTubeByteRange?
+    let indexRange: YouTubeByteRange?
+    let isDefaultAudioTrack: Bool?
+
+    var isVideo: Bool { mimeType.hasPrefix("video/") }
+    var isAudio: Bool { mimeType.hasPrefix("audio/") }
+    var isMP4: Bool { mimeType.contains("mp4") }
+
+    var codecs: String? {
+        guard let opening = mimeType.range(of: "codecs=\"") else { return nil }
+        let remainder = mimeType[opening.upperBound...]
+        guard let closing = remainder.firstIndex(of: "\"") else { return nil }
+        return String(remainder[..<closing])
+    }
+}

--- a/App/YouTube Player/V2/Datatypes/YouTubeHLSSegment.swift
+++ b/App/YouTube Player/V2/Datatypes/YouTubeHLSSegment.swift
@@ -1,0 +1,10 @@
+import Foundation
+import Hanami
+
+/// One media subsegment of a synthesized HLS playlist, described as a byte
+/// range into the backing media file plus its presentation duration.
+nonisolated struct YouTubeHLSSegment: Sendable {
+    let offset: Int
+    let length: Int
+    let duration: Double
+}

--- a/App/YouTube Player/V2/Datatypes/YouTubeLocalHLSStream.swift
+++ b/App/YouTube Player/V2/Datatypes/YouTubeLocalHLSStream.swift
@@ -1,0 +1,12 @@
+import Foundation
+import Hanami
+
+/// A self-contained set of HLS playlists synthesized from `adaptiveFormats`.
+/// The media playlists reference the original googlevideo URLs by byte range,
+/// so only these small text manifests need to be served locally.
+nonisolated struct YouTubeLocalHLSStream: Sendable {
+    let masterPlaylist: String
+    let videoPlaylist: String
+    let audioPlaylist: String
+    let resolution: String?
+}

--- a/App/YouTube Player/V2/Datatypes/YouTubePlaybackSource.swift
+++ b/App/YouTube Player/V2/Datatypes/YouTubePlaybackSource.swift
@@ -1,0 +1,10 @@
+import Foundation
+import Hanami
+
+/// How a video should be handed to `AVPlayer`. Live and legacy responses still
+/// expose a ready-made HLS manifest; newer responses only expose adaptive
+/// formats, which are repackaged into a locally served HLS stream.
+nonisolated enum YouTubePlaybackSource: Sendable {
+    case remoteHLS(URL)
+    case localHLS(YouTubeLocalHLSStream)
+}

--- a/App/YouTube Player/V2/LocalHLSResourceLoader.swift
+++ b/App/YouTube Player/V2/LocalHLSResourceLoader.swift
@@ -1,0 +1,60 @@
+import AVFoundation
+import Foundation
+import UniformTypeIdentifiers
+import Hanami
+
+/// Serves a synthesized `YouTubeLocalHLSStream` to `AVPlayer` over a custom URL
+/// scheme. Only the small text playlists are vended here; the media segments
+/// they reference use absolute https URLs that `AVPlayer` fetches directly.
+final class LocalHLSResourceLoader: NSObject, AVAssetResourceLoaderDelegate, @unchecked Sendable {
+
+    static let scheme = "sakurahls"
+    // swiftlint:disable:next force_unwrapping
+    static let masterURL = URL(string: "\(scheme)://stream/master.m3u8")!
+
+    let queue = DispatchQueue(label: "com.sakurarss.localhls")
+    private let playlists: [String: Data]
+
+    init(stream: YouTubeLocalHLSStream) {
+        playlists = [
+            "master.m3u8": Data(stream.masterPlaylist.utf8),
+            "video.m3u8": Data(stream.videoPlaylist.utf8),
+            "audio.m3u8": Data(stream.audioPlaylist.utf8)
+        ]
+        super.init()
+    }
+
+    func resourceLoader(
+        _ resourceLoader: AVAssetResourceLoader,
+        shouldWaitForLoadingOfRequestedResource loadingRequest: AVAssetResourceLoadingRequest
+    ) -> Bool {
+        guard
+            let url = loadingRequest.request.url,
+            url.scheme == Self.scheme
+        else { return false }
+
+        guard let data = playlists[url.lastPathComponent] else {
+            loadingRequest.finishLoading(with: YouTubeBrowseError.missingData)
+            return true
+        }
+
+        if let infoRequest = loadingRequest.contentInformationRequest {
+            infoRequest.contentType = UTType.m3uPlaylist.identifier
+            infoRequest.contentLength = Int64(data.count)
+            infoRequest.isByteRangeAccessSupported = true
+        }
+
+        if let dataRequest = loadingRequest.dataRequest {
+            let offset = Int(dataRequest.requestedOffset)
+            guard offset <= data.count else {
+                loadingRequest.finishLoading()
+                return true
+            }
+            let end = min(offset + dataRequest.requestedLength, data.count)
+            dataRequest.respond(with: data.subdata(in: offset..<end))
+        }
+
+        loadingRequest.finishLoading()
+        return true
+    }
+}

--- a/App/YouTube Player/V2/NewYouTubeClient+AdaptiveFormats.swift
+++ b/App/YouTube Player/V2/NewYouTubeClient+AdaptiveFormats.swift
@@ -1,0 +1,77 @@
+import Foundation
+import Hanami
+
+extension NewYouTubeClient {
+
+    static func parseAdaptiveFormats(_ entries: [[String: Any]]) -> [YouTubeAdaptiveFormat] {
+        entries.compactMap(parseAdaptiveFormat)
+    }
+
+    /// Picks the highest-quality H.264/MP4 video track. AVPlayer's HLS fMP4
+    /// support is reliable for AVC, so VP9/AV1 and WebM tracks are skipped.
+    static func selectVideoFormat(
+        from formats: [YouTubeAdaptiveFormat]
+    ) -> YouTubeAdaptiveFormat? {
+        let candidates = formats.filter {
+            $0.isVideo && $0.isMP4 && ($0.codecs?.hasPrefix("avc1") ?? false)
+        }
+        let withinLimit = candidates.filter { ($0.height ?? 0) <= 1080 }
+        let pool = withinLimit.isEmpty ? candidates : withinLimit
+        return pool.max { lhs, rhs in
+            if (lhs.height ?? 0) != (rhs.height ?? 0) {
+                return (lhs.height ?? 0) < (rhs.height ?? 0)
+            }
+            return lhs.bitrate < rhs.bitrate
+        }
+    }
+
+    /// Picks the highest-bitrate AAC/MP4 audio track, preferring the original
+    /// audio track over dubbed alternatives.
+    static func selectAudioFormat(
+        from formats: [YouTubeAdaptiveFormat]
+    ) -> YouTubeAdaptiveFormat? {
+        let candidates = formats.filter { $0.isAudio && $0.isMP4 }
+        let original = candidates.filter { $0.isDefaultAudioTrack != false }
+        let pool = original.isEmpty ? candidates : original
+        return pool.max { $0.bitrate < $1.bitrate }
+    }
+
+    private static func parseAdaptiveFormat(
+        _ entry: [String: Any]
+    ) -> YouTubeAdaptiveFormat? {
+        guard
+            let itag = entry["itag"] as? Int,
+            let url = entry["url"] as? String,
+            let mimeType = entry["mimeType"] as? String
+        else { return nil }
+        let audioTrack = entry["audioTrack"] as? [String: Any]
+        return YouTubeAdaptiveFormat(
+            itag: itag,
+            url: url,
+            mimeType: mimeType,
+            bitrate: (entry["bitrate"] as? Int) ?? 0,
+            width: entry["width"] as? Int,
+            height: entry["height"] as? Int,
+            approximateDurationMilliseconds: integer(entry["approxDurationMs"]),
+            contentLength: integer(entry["contentLength"]),
+            initRange: byteRange(entry["initRange"]),
+            indexRange: byteRange(entry["indexRange"]),
+            isDefaultAudioTrack: audioTrack?["audioIsDefault"] as? Bool
+        )
+    }
+
+    private static func integer(_ value: Any?) -> Int? {
+        if let int = value as? Int { return int }
+        if let string = value as? String { return Int(string) }
+        return nil
+    }
+
+    private static func byteRange(_ value: Any?) -> YouTubeByteRange? {
+        guard
+            let dictionary = value as? [String: Any],
+            let start = integer(dictionary["start"]),
+            let end = integer(dictionary["end"])
+        else { return nil }
+        return YouTubeByteRange(start: start, end: end)
+    }
+}

--- a/App/YouTube Player/V2/NewYouTubeClient+LocalHLS.swift
+++ b/App/YouTube Player/V2/NewYouTubeClient+LocalHLS.swift
@@ -1,0 +1,139 @@
+import Foundation
+import Hanami
+
+extension NewYouTubeClient {
+
+    /// Repackages the adaptive (DASH) formats into a locally servable HLS
+    /// stream: a master playlist plus byte-range media playlists for the chosen
+    /// video and audio tracks.
+    func buildLocalHLSStream(
+        from entries: [[String: Any]],
+        videoId: String
+    ) async throws -> YouTubeLocalHLSStream {
+        let formats = Self.parseAdaptiveFormats(entries)
+        guard
+            let video = Self.selectVideoFormat(from: formats),
+            let audio = Self.selectAudioFormat(from: formats)
+        else {
+            throw YouTubeBrowseError.missingData
+        }
+        async let videoSegments = segments(for: video)
+        async let audioSegments = segments(for: audio)
+        let videoPlaylist = Self.renderMediaPlaylist(
+            format: video, segments: try await videoSegments
+        )
+        let audioPlaylist = Self.renderMediaPlaylist(
+            format: audio, segments: try await audioSegments
+        )
+        // swiftlint:disable:next line_length
+        log("YouTube", "Built local HLS for \(videoId) video itag=\(video.itag) (\(video.width ?? 0)x\(video.height ?? 0)) audio itag=\(audio.itag)")
+        return YouTubeLocalHLSStream(
+            masterPlaylist: Self.renderMasterPlaylist(video: video, audio: audio),
+            videoPlaylist: videoPlaylist,
+            audioPlaylist: audioPlaylist,
+            resolution: Self.resolution(for: video)
+        )
+    }
+
+    private func segments(for format: YouTubeAdaptiveFormat) async throws -> [YouTubeHLSSegment] {
+        guard
+            let indexRange = format.indexRange,
+            let url = URL(string: format.url)
+        else {
+            return Self.singleSegment(for: format)
+        }
+        let indexData = try await fetchRange(
+            url: url, start: indexRange.start, end: indexRange.end
+        )
+        guard
+            let parsed = Self.parseSidx(indexData, indexEndOffset: indexRange.end),
+            !parsed.isEmpty
+        else {
+            return Self.singleSegment(for: format)
+        }
+        return parsed
+    }
+
+    private func fetchRange(url: URL, start: Int, end: Int) async throws -> Data {
+        var request = URLRequest(url: url)
+        request.setValue("bytes=\(start)-\(end)", forHTTPHeaderField: "Range")
+        request.setValue(iosUserAgent, forHTTPHeaderField: "User-Agent")
+        let (data, response) = try await session.data(for: request)
+        if let http = response as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
+            throw YouTubeBrowseError.unexpectedResponse(status: http.statusCode)
+        }
+        return data
+    }
+
+    /// Fallback when no segment index is available: serve the whole media file
+    /// after the init segment as a single HLS segment.
+    private static func singleSegment(for format: YouTubeAdaptiveFormat) -> [YouTubeHLSSegment] {
+        guard let contentLength = format.contentLength else { return [] }
+        let mediaStart = (format.indexRange?.end).map { $0 + 1 }
+            ?? format.initRange.map { $0.end + 1 }
+            ?? 0
+        let length = contentLength - mediaStart
+        guard length > 0 else { return [] }
+        let seconds = Double(format.approximateDurationMilliseconds ?? 0) / 1000.0
+        return [
+            YouTubeHLSSegment(
+                offset: mediaStart,
+                length: length,
+                duration: seconds > 0 ? seconds : 1
+            )
+        ]
+    }
+
+    private static func renderMasterPlaylist(
+        video: YouTubeAdaptiveFormat,
+        audio: YouTubeAdaptiveFormat
+    ) -> String {
+        let videoCodecs = video.codecs ?? "avc1.4d401f"
+        let audioCodecs = audio.codecs ?? "mp4a.40.2"
+        var streamInfo = "#EXT-X-STREAM-INF:BANDWIDTH=\(video.bitrate + audio.bitrate)," +
+            "CODECS=\"\(videoCodecs),\(audioCodecs)\",AUDIO=\"audio\""
+        if let resolution = resolution(for: video) {
+            streamInfo += ",RESOLUTION=\(resolution)"
+        }
+        return [
+            "#EXTM3U",
+            "#EXT-X-VERSION:7",
+            "#EXT-X-INDEPENDENT-SEGMENTS",
+            // swiftlint:disable:next line_length
+            "#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID=\"audio\",NAME=\"Audio\",DEFAULT=YES,AUTOSELECT=YES,URI=\"audio.m3u8\"",
+            streamInfo,
+            "video.m3u8"
+        ].joined(separator: "\n") + "\n"
+    }
+
+    private static func renderMediaPlaylist(
+        format: YouTubeAdaptiveFormat,
+        segments: [YouTubeHLSSegment]
+    ) -> String {
+        let targetDuration = max(1, Int((segments.map(\.duration).max() ?? 1).rounded(.up)))
+        var lines = [
+            "#EXTM3U",
+            "#EXT-X-VERSION:7",
+            "#EXT-X-PLAYLIST-TYPE:VOD",
+            "#EXT-X-TARGETDURATION:\(targetDuration)",
+            "#EXT-X-MEDIA-SEQUENCE:0"
+        ]
+        if let initRange = format.initRange {
+            lines.append(
+                "#EXT-X-MAP:URI=\"\(format.url)\",BYTERANGE=\"\(initRange.length)@\(initRange.start)\""
+            )
+        }
+        for segment in segments {
+            lines.append(String(format: "#EXTINF:%.5f,", segment.duration))
+            lines.append("#EXT-X-BYTERANGE:\(segment.length)@\(segment.offset)")
+            lines.append(format.url)
+        }
+        lines.append("#EXT-X-ENDLIST")
+        return lines.joined(separator: "\n") + "\n"
+    }
+
+    private static func resolution(for format: YouTubeAdaptiveFormat) -> String? {
+        guard let width = format.width, let height = format.height else { return nil }
+        return "\(width)x\(height)"
+    }
+}

--- a/App/YouTube Player/V2/NewYouTubeClient+Sidx.swift
+++ b/App/YouTube Player/V2/NewYouTubeClient+Sidx.swift
@@ -1,0 +1,99 @@
+import Foundation
+import Hanami
+
+extension NewYouTubeClient {
+
+    /// Parses an ISO BMFF `sidx` (Segment Index) box into HLS segments.
+    /// `indexEndOffset` is the last byte offset of the `sidx` box within the
+    /// media file, used to anchor the first media subsegment.
+    static func parseSidx(_ data: Data, indexEndOffset: Int) -> [YouTubeHLSSegment]? {
+        let bytes = [UInt8](data)
+        var cursor = 0
+        while cursor + 8 <= bytes.count {
+            let boxSize = Int(readUInt32(bytes, at: cursor))
+            let type = boxType(bytes, at: cursor + 4)
+            if type == "sidx" {
+                return parseSidxBox(bytes, boxStart: cursor, indexEndOffset: indexEndOffset)
+            }
+            guard boxSize > 0 else { return nil }
+            cursor += boxSize
+        }
+        return nil
+    }
+
+    private static func parseSidxBox(
+        _ bytes: [UInt8],
+        boxStart: Int,
+        indexEndOffset: Int
+    ) -> [YouTubeHLSSegment]? {
+        var position = boxStart + 8
+        guard position < bytes.count else { return nil }
+        let version = bytes[position]
+        position += 4                 // version (1) + flags (3)
+        position += 4                 // reference_ID
+        let timescale = readUInt32(bytes, at: position)
+        position += 4
+        guard timescale > 0 else { return nil }
+
+        var firstOffset: UInt64
+        if version == 0 {
+            position += 4             // earliest_presentation_time (32-bit)
+            firstOffset = UInt64(readUInt32(bytes, at: position))
+            position += 4
+        } else {
+            position += 8             // earliest_presentation_time (64-bit)
+            firstOffset = readUInt64(bytes, at: position)
+            position += 8
+        }
+        position += 2                 // reserved
+        let referenceCount = Int(readUInt16(bytes, at: position))
+        position += 2
+
+        var segments: [YouTubeHLSSegment] = []
+        var offset = indexEndOffset + 1 + Int(firstOffset)
+        for _ in 0..<referenceCount {
+            guard position + 12 <= bytes.count else { break }
+            let referencedSize = Int(readUInt32(bytes, at: position) & 0x7FFF_FFFF)
+            position += 4
+            let durationTicks = readUInt32(bytes, at: position)
+            position += 4
+            position += 4             // SAP flags
+            segments.append(
+                YouTubeHLSSegment(
+                    offset: offset,
+                    length: referencedSize,
+                    duration: Double(durationTicks) / Double(timescale)
+                )
+            )
+            offset += referencedSize
+        }
+        return segments.isEmpty ? nil : segments
+    }
+
+    private static func boxType(_ bytes: [UInt8], at offset: Int) -> String {
+        guard offset + 4 <= bytes.count else { return "" }
+        return String(bytes: bytes[offset..<offset + 4], encoding: .ascii) ?? ""
+    }
+
+    private static func readUInt16(_ bytes: [UInt8], at offset: Int) -> UInt16 {
+        guard offset + 2 <= bytes.count else { return 0 }
+        return (UInt16(bytes[offset]) << 8) | UInt16(bytes[offset + 1])
+    }
+
+    private static func readUInt32(_ bytes: [UInt8], at offset: Int) -> UInt32 {
+        guard offset + 4 <= bytes.count else { return 0 }
+        return (UInt32(bytes[offset]) << 24)
+            | (UInt32(bytes[offset + 1]) << 16)
+            | (UInt32(bytes[offset + 2]) << 8)
+            | UInt32(bytes[offset + 3])
+    }
+
+    private static func readUInt64(_ bytes: [UInt8], at offset: Int) -> UInt64 {
+        guard offset + 8 <= bytes.count else { return 0 }
+        var value: UInt64 = 0
+        for index in 0..<8 {
+            value = (value << 8) | UInt64(bytes[offset + index])
+        }
+        return value
+    }
+}

--- a/App/YouTube Player/V2/NewYouTubeClient+Stream.swift
+++ b/App/YouTube Player/V2/NewYouTubeClient+Stream.swift
@@ -32,6 +32,28 @@ extension NewYouTubeClient {
         return nil
     }
 
+    /// Resolves how a video should be played. Live and legacy responses still
+    /// expose `hlsManifestUrl`, which `AVPlayer` can play directly. Newer
+    /// responses only expose `adaptiveFormats`, which are repackaged into a
+    /// locally served HLS stream.
+    func resolvePlaybackSource(videoId: String) async throws -> YouTubePlaybackSource {
+        let manifest = try await fetchPlayerResponse(videoId: videoId)
+        guard let streamingData = manifest["streamingData"] as? [String: Any] else {
+            Self.logManifestDiagnostics(videoId: videoId, manifest: manifest)
+            throw YouTubeBrowseError.missingData
+        }
+        if let manifestString = streamingData["hlsManifestUrl"] as? String,
+           let manifestURL = URL(string: manifestString) {
+            return .remoteHLS(manifestURL)
+        }
+        if let adaptiveFormats = streamingData["adaptiveFormats"] as? [[String: Any]],
+           !adaptiveFormats.isEmpty {
+            return .localHLS(try await buildLocalHLSStream(from: adaptiveFormats, videoId: videoId))
+        }
+        Self.logManifestDiagnostics(videoId: videoId, manifest: manifest)
+        throw YouTubeBrowseError.missingData
+    }
+
     /// Returns the HLS playlist URL for a given video. `AVPlayer` can play this
     /// URL directly without further parsing.
     func hlsPlaylistURL(videoId: String) async throws -> URL {

--- a/App/YouTube Player/V2/NewYouTubePlaybackController.swift
+++ b/App/YouTube Player/V2/NewYouTubePlaybackController.swift
@@ -37,6 +37,7 @@ final class NewYouTubePlaybackController: NSObject {
     @ObservationIgnored var cachedArtwork: MPMediaItemArtwork?
     @ObservationIgnored private var pictureInPictureController: AVPictureInPictureController?
     @ObservationIgnored private var lastPostedElapsedTime: TimeInterval = -1
+    @ObservationIgnored private var resourceLoader: LocalHLSResourceLoader?
 
     @ObservationIgnored private var timeObserverToken: Any?
     @ObservationIgnored private var rateObservation: NSKeyValueObservation?
@@ -56,10 +57,10 @@ final class NewYouTubePlaybackController: NSObject {
         super.init()
     }
 
-    /// Loads a new HLS stream for the given video. If the same video is already
+    /// Loads a new stream for the given video. If the same video is already
     /// loaded, this is a no-op and the existing player keeps playing.
     func load(
-        url: URL,
+        source: YouTubePlaybackSource,
         videoID: String,
         title: String? = nil,
         artist: String? = nil,
@@ -72,7 +73,7 @@ final class NewYouTubePlaybackController: NSObject {
         clear()
         YouTubeAudioSession.prepare()
         YouTubeAudioSession.activate()
-        let newPlayer = AVPlayer(url: url)
+        let newPlayer = AVPlayer(playerItem: makePlayerItem(for: source))
         newPlayer.appliesMediaSelectionCriteriaAutomatically = false
         let originalCriteria = AVPlayerMediaSelectionCriteria(
             preferredLanguages: nil,
@@ -83,6 +84,19 @@ final class NewYouTubePlaybackController: NSObject {
         currentVideoID = videoID
         applyMetadata(title: title, artist: artist, artworkURLString: artworkURLString)
         newPlayer.play()
+    }
+
+    private func makePlayerItem(for source: YouTubePlaybackSource) -> AVPlayerItem {
+        switch source {
+        case .remoteHLS(let url):
+            return AVPlayerItem(asset: AVURLAsset(url: url))
+        case .localHLS(let stream):
+            let loader = LocalHLSResourceLoader(stream: stream)
+            resourceLoader = loader
+            let asset = AVURLAsset(url: LocalHLSResourceLoader.masterURL)
+            asset.resourceLoader.setDelegate(loader, queue: loader.queue)
+            return AVPlayerItem(asset: asset)
+        }
     }
 
     func updateMetadata(title: String?, artist: String?, artworkURLString: String?) {
@@ -108,6 +122,7 @@ final class NewYouTubePlaybackController: NSObject {
         detachObservers()
         player?.pause()
         pictureInPictureController = nil
+        resourceLoader = nil
         player = nil
         currentVideoID = nil
         nowPlayingTitle = nil

--- a/App/YouTube Player/V2/NewYouTubePlayerView+Loading.swift
+++ b/App/YouTube Player/V2/NewYouTubePlayerView+Loading.swift
@@ -45,15 +45,14 @@ extension NewYouTubePlayerView {
 
         do {
             let client = try await NewYouTubeClient.bootstrap()
-            async let manifestTask = client.hlsPlaylistURL(videoId: videoId)
+            async let sourceTask = client.resolvePlaybackSource(videoId: videoId)
             async let metadataTask = client.fetchVideoMetadata(videoId: videoId)
             fetchedMetadata = try? await metadataTask
             log("YT NewPlayer", "Metadata for \(videoId): \(fetchedMetadata == nil ? "unavailable" : "ok")")
-            let manifestURL = try await manifestTask
-            // swiftlint:disable:next line_length
-            log("YT NewPlayer", "Stream ready videoId=\(videoId) manifest=\(manifestURL.absoluteString)")
+            let source = try await sourceTask
+            logStreamReady(videoId: videoId, source: source)
             playback.load(
-                url: manifestURL,
+                source: source,
                 videoID: videoId,
                 title: playbackTitle,
                 artist: playbackArtist,
@@ -63,6 +62,16 @@ extension NewYouTubePlayerView {
         } catch {
             log("YT NewPlayer", "Failed to resolve stream videoId=\(videoId): \(error)")
             loadState = .failed
+        }
+    }
+
+    private func logStreamReady(videoId: String, source: YouTubePlaybackSource) {
+        switch source {
+        case .remoteHLS(let url):
+            log("YT NewPlayer", "Stream ready videoId=\(videoId) remoteHLS=\(url.absoluteString)")
+        case .localHLS(let stream):
+            // swiftlint:disable:next line_length
+            log("YT NewPlayer", "Stream ready videoId=\(videoId) localHLS resolution=\(stream.resolution ?? "unknown")")
         }
     }
 


### PR DESCRIPTION
## Why

The logs showed every `loadStream` failing with `missingData (expected fields were absent from the response)` even though the iOS player call returned `status: OK`.

Reading the raw response bodies revealed the actual cause: the iOS player response no longer contains `hlsManifestUrl`. Its `streamingData` now only has:

```
streamingData keys=adaptiveFormats, aspectRatio, expiresInSeconds, serverAbrStreamingUrl
formats=0 adaptive=124 hls=false dash=false serverAbr=true
```

i.e. YouTube moved the iOS client to SABR (`serverAbrStreamingUrl`) + per-track `adaptiveFormats` and dropped the master HLS playlist for VOD. Each `adaptiveFormats` entry carries a fully-formed, directly-playable `url`, but they are separate video-only / audio-only tracks (`formats=0`, no muxed progressive), which is exactly why the player relied on HLS — `AVPlayer` takes one URL.

So nothing was actually missing from YouTube's response; the resolver was just hard-requiring one field that's now gone.

## What

Resolve playback into two cases:

- **HLS case (unchanged):** if `hlsManifestUrl` is present (live / legacy), feed it straight to `AVPlayer` as before.
- **Adaptive (SABR) case (new):** otherwise, synthesize a local HLS stream from `adaptiveFormats`:
  - pick the best AVC/MP4 video track and the original AAC/MP4 audio track (HLS fMP4 reliably supports AVC + AAC; VP9/AV1/WebM and dubbed tracks are skipped),
  - fetch and parse each track's `sidx` box to build real byte-range segments (with a single-segment fallback when no index is available),
  - emit a master + two media playlists whose segment URIs are the original googlevideo URLs, served to `AVPlayer` through an `AVAssetResourceLoaderDelegate` over a custom scheme. Only the small text playlists go through the loader; the media bytes are fetched directly by `AVPlayer` via range requests.

### Files
- New datatypes: `YouTubeAdaptiveFormat`, `YouTubeHLSSegment`, `YouTubeLocalHLSStream`, `YouTubePlaybackSource`
- New client extensions: `+AdaptiveFormats` (parse/select), `+LocalHLS` (playlist building), `+Sidx` (segment index parsing)
- `LocalHLSResourceLoader` to vend the synthesized playlists
- `resolvePlaybackSource(videoId:)` replaces the HLS-only entry point on the load path; `NewYouTubePlaybackController.load` now takes a `YouTubePlaybackSource`

## Test plan
- [ ] Build the iOS target (could not compile/run in the cloud Linux container — needs a local Xcode build)
- [ ] Play a regular VOD that previously failed (e.g. a Short like `itHkM0mEuBw`) and confirm `Stream ready ... localHLS` followed by playback with audio
- [ ] Confirm a livestream (still returns `hlsManifestUrl`) plays via the unchanged remote-HLS path
- [ ] Verify seeking, Picture in Picture, and Now Playing still work on a synthesized stream
- [ ] Spot-check a multi-audio-track video picks the original audio, not a dub

https://claude.ai/code/session_01KAxWh1jYdcn3c2zt1U4b6a

---
_Generated by [Claude Code](https://claude.ai/code/session_01KAxWh1jYdcn3c2zt1U4b6a)_