### PR TITLE
Fix YouTube player crash when serving local HLS playlists

### DIFF
--- a/App/YouTube Player/V2/LocalHLSResourceLoader.swift
+++ b/App/YouTube Player/V2/LocalHLSResourceLoader.swift
@@ -46,12 +46,15 @@ final class LocalHLSResourceLoader: NSObject, AVAssetResourceLoaderDelegate, @un
 
         if let dataRequest = loadingRequest.dataRequest {
             let offset = Int(dataRequest.requestedOffset)
-            guard offset <= data.count else {
+            guard offset >= 0, offset <= data.count else {
                 loadingRequest.finishLoading()
                 return true
             }
-            let end = min(offset + dataRequest.requestedLength, data.count)
-            dataRequest.respond(with: data.subdata(in: offset..<end))
+            let remaining = data.count - offset
+            let length = min(dataRequest.requestedLength, remaining)
+            if length > 0 {
+                dataRequest.respond(with: data.subdata(in: offset..<(offset + length)))
+            }
         }
 
         loadingRequest.finishLoading()


### PR DESCRIPTION
## Summary

After #305, the app crashes when loading a YouTube video that resolves to the new adaptive-formats (local HLS) playback path.

The crash is an arithmetic-overflow trap in `LocalHLSResourceLoader`. When `AVPlayer` requests all data to the end of a playlist resource, it sets `dataRequest.requestedLength` to a near-`Int.max` sentinel. The old code computed `offset + dataRequest.requestedLength` *before* clamping to `data.count`. At any non-zero offset (e.g. the data request that follows an initial content-type sniff), that addition overflows `Int` and traps, crashing the app every time a video goes through the local HLS path.

## Fix

Cap the response length to the remaining bytes (`data.count - offset`) before computing the byte range, so `offset + length` can never exceed `data.count`. This removes both the overflow and any chance of an out-of-range `subdata(in:)`.

## Test plan

- [ ] Play a YouTube video whose player response exposes only `adaptiveFormats` (no `hlsManifestUrl`) and confirm it loads and plays instead of crashing
- [ ] Confirm live/legacy videos that still expose `hlsManifestUrl` (remote HLS path) continue to play

https://claude.ai/code/session_01URTPWFJju561f61RHnWfXm

---
_Generated by [Claude Code](https://claude.ai/code/session_01URTPWFJju561f61RHnWfXm)_