### PR TITLE
Fix crash opening videos in the new YouTube player (local HLS path)

### DIFF
--- a/App/YouTube Player/V2/LocalHLSResourceLoader.swift
+++ b/App/YouTube Player/V2/LocalHLSResourceLoader.swift
@@ -6,7 +6,7 @@ import Hanami
 /// Serves a synthesized `YouTubeLocalHLSStream` to `AVPlayer` over a custom URL
 /// scheme. Only the small text playlists are vended here; the media segments
 /// they reference use absolute https URLs that `AVPlayer` fetches directly.
-final class LocalHLSResourceLoader: NSObject, AVAssetResourceLoaderDelegate, @unchecked Sendable {
+nonisolated final class LocalHLSResourceLoader: NSObject, AVAssetResourceLoaderDelegate, @unchecked Sendable {
 
     static let scheme = "sakurahls"
     // swiftlint:disable:next force_unwrapping


### PR DESCRIPTION
## Summary

Fixes a crash that occurs when opening a video in the new (V2) YouTube player for videos that fall back to the synthesized **local HLS** playback path.

## Root cause

The crash report's faulting thread (`faultingThread: 1`) is the `com.sakurarss.localhls` queue, terminating with `EXC_BREAKPOINT` / `brk 1` via:

```
_dispatch_assert_queue_fail
dispatch_assert_queue
_swift_task_checkIsolatedSwift
swift_task_isCurrentExecutorWithFlagsImpl
<app frame>
-[NSInvocation invoke]
-[AVAssetResourceLoader _performDelegateSelector:...]
```

The prominent `SVGParser` / `AG::Graph` frames in the report belong to **thread 0** (the main thread's incidental layout work) and are a red herring — `brk 1` is a deliberate Swift-runtime executor-isolation trap, not the memory fault SVG decoding would raise.

The project builds with `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`, so `LocalHLSResourceLoader`'s `AVAssetResourceLoaderDelegate` method was implicitly `@MainActor`-isolated. `AVAssetResourceLoader` invokes that delegate **synchronously on the loader's own background queue**, so the synthesized thunk asserts it is running on the main executor, the assertion fails on the background queue, and the runtime traps. (`@unchecked Sendable` does not affect isolation.)

## Fix

Mark `LocalHLSResourceLoader` as `nonisolated` so it opts out of the module's default main-actor isolation. Its delegate callbacks then run safely on its dedicated queue. This is correct because the type only touches immutable state (`playlists`) and its own serial queue.

## Test plan

- [ ] Open a YouTube video that resolves via the local HLS (adaptive-formats) path and confirm playback starts without crashing.
- [ ] Open a video that resolves via remote HLS and confirm no regression.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DHEQvQ1tXTNMiuTqxMm3vL)_