### PR TITLE
Default to original audio track for auto-dubbed YouTube videos

### DIFF
--- a/App/YouTube Player/V2/Datatypes/YouTubeAdaptiveFormat.swift
+++ b/App/YouTube Player/V2/Datatypes/YouTubeAdaptiveFormat.swift
@@ -24,10 +24,20 @@ nonisolated struct YouTubeAdaptiveFormat: Sendable {
     let initRange: YouTubeByteRange?
     let indexRange: YouTubeByteRange?
     let isDefaultAudioTrack: Bool?
+    let audioTrackDisplayName: String?
 
     var isVideo: Bool { mimeType.hasPrefix("video/") }
     var isAudio: Bool { mimeType.hasPrefix("audio/") }
     var isMP4: Bool { mimeType.contains("mp4") }
+
+    /// Whether this audio track is the video's original (undubbed) rendition.
+    /// YouTube names the original track's `displayName` with an "original"
+    /// suffix (e.g. "English (United States) original"), which is a more
+    /// reliable signal than `audioIsDefault` for auto-dubbed videos where the
+    /// default track follows the requesting locale rather than the source.
+    var isOriginalAudioTrack: Bool {
+        audioTrackDisplayName?.lowercased().contains("original") ?? false
+    }
 
     var codecs: String? {
         guard let opening = mimeType.range(of: "codecs=\"") else { return nil }

--- a/App/YouTube Player/V2/NewYouTubeClient+AdaptiveFormats.swift
+++ b/App/YouTube Player/V2/NewYouTubeClient+AdaptiveFormats.swift
@@ -25,15 +25,26 @@ extension NewYouTubeClient {
         }
     }
 
-    /// Picks the highest-bitrate AAC/MP4 audio track, preferring the original
-    /// audio track over dubbed alternatives.
+    /// Picks the highest-bitrate AAC/MP4 audio track, preferring the video's
+    /// original audio over auto-dubbed alternatives. A track explicitly named
+    /// "original" wins; otherwise the track YouTube marks as default for the
+    /// requesting locale is used, falling back to any available track.
     static func selectAudioFormat(
         from formats: [YouTubeAdaptiveFormat]
     ) -> YouTubeAdaptiveFormat? {
         let candidates = formats.filter { $0.isAudio && $0.isMP4 }
-        let original = candidates.filter { $0.isDefaultAudioTrack != false }
-        let pool = original.isEmpty ? candidates : original
+        let pool = preferredAudioPool(from: candidates)
         return pool.max { $0.bitrate < $1.bitrate }
+    }
+
+    private static func preferredAudioPool(
+        from candidates: [YouTubeAdaptiveFormat]
+    ) -> [YouTubeAdaptiveFormat] {
+        let original = candidates.filter(\.isOriginalAudioTrack)
+        if !original.isEmpty { return original }
+        let defaultTracks = candidates.filter { $0.isDefaultAudioTrack != false }
+        if !defaultTracks.isEmpty { return defaultTracks }
+        return candidates
     }
 
     private static func parseAdaptiveFormat(
@@ -56,7 +67,8 @@ extension NewYouTubeClient {
             contentLength: integer(entry["contentLength"]),
             initRange: byteRange(entry["initRange"]),
             indexRange: byteRange(entry["indexRange"]),
-            isDefaultAudioTrack: audioTrack?["audioIsDefault"] as? Bool
+            isDefaultAudioTrack: audioTrack?["audioIsDefault"] as? Bool,
+            audioTrackDisplayName: audioTrack?["displayName"] as? String
         )
     }
 


### PR DESCRIPTION
## Summary

YouTube's auto-dubbing feature exposes multiple audio renditions (the original plus auto-generated dubs in other languages). The V2 player has two playback paths, and only one of them handled this correctly:

- The **HLS manifest path** (`NewYouTubeClient+HLS.swift`) already prefers a rendition whose name contains `"original"` before falling back to the `DEFAULT` flag.
- The **adaptive-formats / local HLS path** (`NewYouTubeClient+AdaptiveFormats.swift`, added in #305) selected audio **solely** by YouTube's `audioTrack.audioIsDefault` flag. That flag follows the requesting locale and can point at an auto-dubbed track, so this path could play a dub instead of the source audio. The parser also discarded `audioTrack.displayName`, so the "original" signal wasn't even available.

## Changes

- Parse `audioTrack.displayName` into `YouTubeAdaptiveFormat` and add an `isOriginalAudioTrack` helper that matches the `"original"` naming convention.
- `selectAudioFormat` now prefers tracks explicitly named "original", then falls back to the locale-default track, then to any track — mirroring the HLS path's behavior.

## Test plan

- [ ] Play an auto-dubbed YouTube video (one served via adaptive formats, i.e. no HLS manifest) and confirm the original-language audio plays by default rather than a dub.
- [ ] Confirm single-audio-track videos still play normally (no `audioTrack` metadata present).
- [ ] Confirm videos served via the HLS manifest path are unaffected.

https://claude.ai/code/session_01VQJH6Kixjp2fCuMe3EqJGC

---
_Generated by [Claude Code](https://claude.ai/code/session_01VQJH6Kixjp2fCuMe3EqJGC)_