### PR TITLE
Serve mobile YouTube site on iOS to fix 1-minute playback stalls

### DIFF
--- a/App/YouTube Player/YouTubePlayerView+MediaTracks.swift
+++ b/App/YouTube Player/YouTubePlayerView+MediaTracks.swift
@@ -8,6 +8,9 @@ extension YouTubePlayerView {
     /// `setAudioTrack()`. The track list can be empty right after playback
     /// starts, so retry until it resolves.
     func forceOriginalAudio(retriesRemaining: Int = 8) {
+        // Only the desktop MSE player (Mac Catalyst) exposes switchable audio
+        // tracks; the mobile site used on iOS serves a single baked-in track.
+        guard YouTubePlayerWebView.youTubeUserAgent != nil else { return }
         guard !didForceOriginalAudio, let webView else { return }
         webView.evaluateJavaScript(YouTubePlayerScripts.forceOriginalAudioTrack) { [self] result, _ in
             let status = (result as? String) ?? "none"

--- a/App/YouTube Player/YouTubePlayerWebView.swift
+++ b/App/YouTube Player/YouTubePlayerWebView.swift
@@ -164,14 +164,21 @@ struct YouTubePlayerWebView: UIViewRepresentable {
         return components.url ?? url
     }
 
-    /// A desktop Chrome User-Agent. YouTube serves Safari/WKWebView a native
-    /// HLS stream with the dubbed audio baked in and no switchable tracks; with
-    /// a Chrome UA it serves its MSE player instead, which exposes
-    /// `getAvailableAudioTracks()` / `setAudioTrack()` so the original audio can
-    /// be selected.
-    static let youTubeUserAgent =
-        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
-        + "(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
+    /// A desktop Chrome User-Agent, used on Mac Catalyst only. YouTube serves
+    /// Safari/WKWebView a native HLS stream with the dubbed audio baked in and
+    /// no switchable tracks; with a Chrome UA it serves its MSE player instead,
+    /// which exposes `getAvailableAudioTracks()` / `setAudioTrack()` so the
+    /// original audio can be selected. On iOS the desktop player stops inline
+    /// playback after about a minute, so iPhone and iPad use the default
+    /// WKWebView User-Agent (`nil`) and the mobile site instead.
+    static var youTubeUserAgent: String? {
+        #if targetEnvironment(macCatalyst)
+        return "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+            + "(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
+        #else
+        return nil
+        #endif
+    }
 
     static func dismantleUIView(_ uiView: WKWebView, coordinator: Coordinator) {
         uiView.configuration.userContentController.removeScriptMessageHandler(


### PR DESCRIPTION
## Summary

WebView YouTube playback was stopping after about a minute on iPhone (and iPad). The cause is the forced **desktop Chrome User-Agent** applied to every platform, which makes YouTube serve its desktop MSE player. On iOS that player halts inline playback after ~60 seconds.

The desktop UA was originally introduced so the MSE player would expose `setAudioTrack()`, used by `forceOriginalAudio` to pick the original (non-dubbed) audio on auto-dubbed videos. That feature only works with the desktop player.

## Changes

- `YouTubePlayerWebView.swift`: `youTubeUserAgent` is now `String?` and returns the desktop Chrome UA **only on Mac Catalyst**; on iPhone and iPad it returns `nil`, so `WKWebView` uses its default (mobile Safari) User-Agent and YouTube serves the mobile site.
- `YouTubePlayerView+MediaTracks.swift`: `forceOriginalAudio` early-returns when no desktop UA is set, since the mobile site has no switchable audio tracks. The desktop UA presence is the single source of truth.

## Tradeoff (confirmed)

- All iOS devices (iPhone + iPad) now use the mobile site. Mac Catalyst keeps the desktop player.
- Original-audio selection for auto-dubbed videos is disabled on iOS (mobile site serves a single baked-in track). Accepted in exchange for stable playback.

## Notes

- The injected player scripts degrade gracefully on the mobile site: generic `video` selectors still match, while desktop-only references (`#movie_player`, `window._lact`) simply no-op.
- This is an Xcode/iOS project and could not be compiled in the Linux CI environment, so the change has not been verified on-device. Please test inline playback and autoplay on a physical iPhone/iPad.

https://claude.ai/code/session_01TPvwYMgXFgkJ1y8Y8RTeU4

---
_Generated by [Claude Code](https://claude.ai/code/session_01TPvwYMgXFgkJ1y8Y8RTeU4)_