### PR TITLE
Performance: smoother scrolling, faster article loads, refreshes, and subscriptions

### DIFF
--- a/App/Core/Media Presenter/MediaPresenter.swift
+++ b/App/Core/Media Presenter/MediaPresenter.swift
@@ -20,7 +20,16 @@ final class MediaPresenter {
 
     private init() {}
 
+    /// Refills the `content` blob for persisted articles. Callers hand in the
+    /// content-light list projection; the players read `content`, so resolve the
+    /// full row here. Ephemeral articles (no DB row) keep their in-memory value.
+    private func resolvingFullContent(_ article: Article) -> Article {
+        guard !article.isEphemeral else { return article }
+        return (try? DatabaseManager.shared.article(byID: article.id)) ?? article
+    }
+
     func presentYouTube(_ article: Article) {
+        let article = resolvingFullContent(article)
         if let detachedHandler {
             // Detached windows own per-window sessions and run their own
             // adoption on appear; skip the shared-session mutation.
@@ -45,6 +54,7 @@ final class MediaPresenter {
     }
 
     func presentPodcast(_ article: Article) {
+        let article = resolvingFullContent(article)
         if let detachedHandler {
             detachedHandler(.podcast(article))
         } else {

--- a/App/Display Styles/Cards/CardsStyleView.swift
+++ b/App/Display Styles/Cards/CardsStyleView.swift
@@ -93,6 +93,7 @@ struct CardsStyleView: View {
         .navigationDestination(item: $selectedArticle) { article in
             let raw = feedManager.article(byID: article.id) ?? article
             ArticleDetailView(article: raw, marksReadOnAppear: false)
+                .id(raw.id)
                 .zoomTransition(sourceID: article.id, in: zoomNamespace)
         }
         .onAppear {

--- a/App/Display Styles/Cards/CardsStyleView.swift
+++ b/App/Display Styles/Cards/CardsStyleView.swift
@@ -93,7 +93,6 @@ struct CardsStyleView: View {
         .navigationDestination(item: $selectedArticle) { article in
             let raw = feedManager.article(byID: article.id) ?? article
             ArticleDetailView(article: raw, marksReadOnAppear: false)
-                .id(raw.id)
                 .zoomTransition(sourceID: article.id, in: zoomNamespace)
         }
         .onAppear {

--- a/App/Display Styles/Feed/CarouselImageView.swift
+++ b/App/Display Styles/Feed/CarouselImageView.swift
@@ -4,6 +4,8 @@ import Hanami
 /// Image fitted to a fixed height; width follows the natural aspect ratio.
 struct CarouselImageView: View {
 
+    static let maxPixelSize: CGFloat = 800
+
     let url: URL
     let height: CGFloat
     @State private var image: UIImage?
@@ -12,7 +14,9 @@ struct CarouselImageView: View {
         self.url = url
         self.height = height
         // Paint memory-cache hits on first render to avoid placeholder flash during scroll.
-        _image = State(initialValue: ImageMemoryCache.shared.image(forKey: url.absoluteString))
+        _image = State(initialValue: ImageMemoryCache.shared.image(
+            forKey: CachedAsyncImage<EmptyView>.cacheKey(url, CarouselImageView.maxPixelSize)
+        ))
     }
 
     var body: some View {
@@ -35,7 +39,9 @@ struct CarouselImageView: View {
         }
         .task(priority: .utility) {
             if image != nil { return }
-            let loaded = await CachedAsyncImage<EmptyView>.loadImage(from: url)
+            let loaded = await CachedAsyncImage<EmptyView>.loadImage(
+                from: url, maxPixelSize: CarouselImageView.maxPixelSize
+            )
             if Task.isCancelled { return }
             image = loaded
         }

--- a/App/Display Styles/Feed/FeedArticleRow.swift
+++ b/App/Display Styles/Feed/FeedArticleRow.swift
@@ -241,7 +241,7 @@ struct FeedArticleRow: View {
                 imageAspectRatio = nil
                 return
             }
-            let image = await CachedAsyncImage<EmptyView>.loadImage(from: url)
+            let image = await CachedAsyncImage<EmptyView>.loadImage(from: url, maxPixelSize: 1200)
             guard !Task.isCancelled, let image else { return }
             let pixelWidth = image.size.width * image.scale
             let pixelHeight = image.size.height * image.scale

--- a/App/Display Styles/Inbox/InboxArticleRow.swift
+++ b/App/Display Styles/Inbox/InboxArticleRow.swift
@@ -18,7 +18,7 @@ struct InboxArticleRow: View {
                 .padding(.top, 6)
 
             if let imageURL = article.imageURL, let url = URL(string: imageURL) {
-                CachedAsyncImage(url: url) {
+                CachedAsyncImage(url: url, maxPixelSize: 144) {
                     FeedIconPlaceholder(
                         icon: icon,
                         acronymIcon: acronymIcon,

--- a/App/Display Styles/Magazine/MagazineArticleCard.swift
+++ b/App/Display Styles/Magazine/MagazineArticleCard.swift
@@ -20,7 +20,7 @@ struct MagazineArticleCard: View {
                     Color.clear
                         .frame(height: 120)
                         .overlay {
-                            CachedAsyncImage(url: url, alignment: shouldCenterImage ? .center : .top) {
+                            CachedAsyncImage(url: url, maxPixelSize: 1200, alignment: shouldCenterImage ? .center : .top) {
                                 Rectangle()
                                     .fill(.secondary.opacity(0.15))
                             }

--- a/App/Display Styles/Magazine/MagazineStyleView.swift
+++ b/App/Display Styles/Magazine/MagazineStyleView.swift
@@ -67,7 +67,6 @@ struct MagazineStyleView: View {
             }
             .padding(.bottom)
         }
-        .animation(.smooth.speed(2.0), value: articles)
         .trackScrollActivity()
     }
 }

--- a/App/Display Styles/Masonry/MasonryArticleCard.swift
+++ b/App/Display Styles/Masonry/MasonryArticleCard.swift
@@ -32,6 +32,7 @@ struct MasonryArticleCard: View {
                         .overlay {
                             CachedAsyncImage(
                                 url: url,
+                                maxPixelSize: 800,
                                 onImageLoaded: { image in
                                     guard image.size.height > 0 else { return }
                                     imageAspectRatio = image.size.width / image.size.height

--- a/App/Display Styles/Masonry/MasonryStyleView.swift
+++ b/App/Display Styles/Masonry/MasonryStyleView.swift
@@ -78,7 +78,6 @@ struct MasonryStyleView: View {
             }
             .padding(.bottom)
         }
-        .animation(.smooth.speed(2.0), value: articles)
         .trackScrollActivity()
     }
 }

--- a/App/Display Styles/Photos/PhotosArticleCard.swift
+++ b/App/Display Styles/Photos/PhotosArticleCard.swift
@@ -95,7 +95,7 @@ struct PhotosArticleCard: View {
                     let effectiveRatio = max(imageAspectRatio ?? 4.0/5.0, 4.0/5.0)
                     TabView(selection: $currentPage) {
                         ForEach(Array(urls.enumerated()), id: \.offset) { index, url in
-                            CachedAsyncImage(url: url) {
+                            CachedAsyncImage(url: url, maxPixelSize: 1600) {
                                 Rectangle()
                                     .fill(.secondary.opacity(0.1))
                             }
@@ -114,7 +114,7 @@ struct PhotosArticleCard: View {
                             .padding(.bottom, 8)
                     }
                     .task {
-                        let loaded = await CachedAsyncImage<EmptyView>.loadImage(from: urls[0])
+                        let loaded = await CachedAsyncImage<EmptyView>.loadImage(from: urls[0], maxPixelSize: 1600)
                         photoImage = loaded
                         if let loaded, loaded.size.height > 0 {
                             imageAspectRatio = loaded.size.width / loaded.size.height
@@ -233,7 +233,7 @@ struct PhotosArticleCard: View {
             guard article.carouselImageURLs.count <= 1,
                   let imageURL = article.imageURL,
                   let url = URL(string: imageURL) else { return }
-            let loaded = await CachedAsyncImage<EmptyView>.loadImage(from: url)
+            let loaded = await CachedAsyncImage<EmptyView>.loadImage(from: url, maxPixelSize: 1600)
             guard !Task.isCancelled, let loaded, loaded.size.height > 0 else { return }
             let pixelWidth = loaded.size.width * loaded.scale
             let pixelHeight = loaded.size.height * loaded.scale

--- a/App/Display Styles/Video/VideoArticleCard.swift
+++ b/App/Display Styles/Video/VideoArticleCard.swift
@@ -32,7 +32,7 @@ struct VideoArticleCard: View {
                 Color.clear
                     .aspectRatio(16 / 9, contentMode: .fit)
                     .overlay {
-                        CachedAsyncImage(url: url) {
+                        CachedAsyncImage(url: url, maxPixelSize: 1200) {
                             Rectangle()
                                 .fill(.secondary.opacity(0.15))
                         }

--- a/App/Feed View/FeedArticlesView.swift
+++ b/App/Feed View/FeedArticlesView.swift
@@ -90,9 +90,8 @@ struct FeedArticlesView: View {
         return articles
     }
 
-    /// Live assembly that performs the database fetches. Used for the initial
-    /// frame and the infrequent `visibility.capture` sites that need an
-    /// up-to-date snapshot before the cache-refresh handlers fire.
+    /// Live assembly that performs the database fetches; used for the initial
+    /// frame and the visibility-capture sites that need a current snapshot.
     private func currentRawArticles() -> [Article] {
         assembleArticles(
             windowed: feedManager.articles(withPreloadedIDs: slicedIDs),
@@ -100,10 +99,8 @@ struct FeedArticlesView: View {
         )
     }
 
-    /// Cached assembly read by `body` and the visibility trackers. Once the
-    /// window has loaded this reads only in-memory state, so scroll-driven body
-    /// re-evaluations (e.g. the visibility tracker ticking) never hit the
-    /// database.
+    /// Cached assembly read by `body` and the visibility trackers, so
+    /// scroll-driven re-evaluations don't hit the database.
     private var rawArticles: [Article] {
         guard hasLoadedWindow else { return currentRawArticles() }
         return assembleArticles(windowed: fetchedArticles, undated: undatedTail)

--- a/App/Feed View/FeedArticlesView.swift
+++ b/App/Feed View/FeedArticlesView.swift
@@ -20,6 +20,9 @@ struct FeedArticlesView: View {
     @State private var hasScrolledPastTitle: Bool = false
     @State private var effectiveDisplayStyle: FeedDisplayStyle?
     @State private var prominentColors: [Color] = []
+    @State private var fetchedArticles: [Article] = []
+    @State private var undatedTail: [Article] = []
+    @State private var hasLoadedWindow = false
 
     private var batchingMode: BatchingMode {
         DoomscrollingMode.effectiveBatchingMode(storedBatchingMode)
@@ -65,24 +68,54 @@ struct FeedArticlesView: View {
         return nil
     }
 
-    private var rawArticles: [Article] {
+    private var slicedIDs: [Int64] {
         let batcher = self.batcher
-        let slicedIDs: [Int64]
         if batchingMode.isCountBased {
-            slicedIDs = batcher.ids(limit: loadedCount)
+            return batcher.ids(limit: loadedCount)
         } else if batchingMode.isDateBased {
-            slicedIDs = batcher.ids(since: loadedSinceDate)
+            return batcher.ids(since: loadedSinceDate)
         } else {
-            slicedIDs = preloadedEntries.map(\.id)
+            return preloadedEntries.map(\.id)
         }
-        var articles = feedManager.articles(withPreloadedIDs: slicedIDs)
+    }
+
+    private func assembleArticles(windowed: [Article], undated: [Article]) -> [Article] {
+        var articles = windowed
         if loadMoreAction == nil {
-            articles += feedManager.undatedArticles(for: feed)
+            articles += undated
         }
         if hideReels && feed.isInstagramFeed {
             articles = articles.filter { !$0.url.contains("/reel/") }
         }
         return articles
+    }
+
+    /// Live assembly that performs the database fetches. Used for the initial
+    /// frame and the infrequent `visibility.capture` sites that need an
+    /// up-to-date snapshot before the cache-refresh handlers fire.
+    private func currentRawArticles() -> [Article] {
+        assembleArticles(
+            windowed: feedManager.articles(withPreloadedIDs: slicedIDs),
+            undated: feedManager.undatedArticles(for: feed)
+        )
+    }
+
+    /// Cached assembly read by `body` and the visibility trackers. Once the
+    /// window has loaded this reads only in-memory state, so scroll-driven body
+    /// re-evaluations (e.g. the visibility tracker ticking) never hit the
+    /// database.
+    private var rawArticles: [Article] {
+        guard hasLoadedWindow else { return currentRawArticles() }
+        return assembleArticles(windowed: fetchedArticles, undated: undatedTail)
+    }
+
+    private func refreshWindowedArticles() {
+        fetchedArticles = feedManager.articles(withPreloadedIDs: slicedIDs)
+        hasLoadedWindow = true
+    }
+
+    private func refreshUndatedTail() {
+        undatedTail = feedManager.undatedArticles(for: feed)
     }
 
     var styleSupportsRichHeader: Bool {
@@ -209,10 +242,15 @@ struct FeedArticlesView: View {
                 latestArticleDate: latestArticleDateForFeed()
             )
             loadedCount = batchingMode.initialCount()
-            visibility.capture(from: rawArticles, isEnabled: hideViewedContent)
+            visibility.capture(from: currentRawArticles(), isEnabled: hideViewedContent)
+        }
+        .onChange(of: slicedIDs) { _, _ in
+            refreshWindowedArticles()
         }
         .onChange(of: feedManager.dataRevision) { _, _ in
             reloadPreloadedEntries()
+            refreshWindowedArticles()
+            refreshUndatedTail()
         }
         .onChange(of: hideViewedContent) { _, _ in
             reloadPreloadedEntries()
@@ -222,10 +260,10 @@ struct FeedArticlesView: View {
                 latestArticleDate: latestArticleDateForFeed()
             )
             loadedCount = newMode.initialCount()
-            visibility.capture(from: rawArticles, isEnabled: hideViewedContent)
+            visibility.capture(from: currentRawArticles(), isEnabled: hideViewedContent)
         }
         .onChange(of: doomscrollingMode) { _, _ in
-            visibility.capture(from: rawArticles, isEnabled: hideViewedContent)
+            visibility.capture(from: currentRawArticles(), isEnabled: hideViewedContent)
         }
         .onChange(of: feedExists) { _, exists in
             if !exists { dismiss() }
@@ -276,8 +314,10 @@ extension FeedArticlesView {
             return
         }
         preloadedEntries = entries
+        refreshWindowedArticles()
+        refreshUndatedTail()
         if hideViewedContent, visibility.visibleIDs == nil, !preloadedEntries.isEmpty {
-            visibility.capture(from: rawArticles, isEnabled: hideViewedContent)
+            visibility.capture(from: currentRawArticles(), isEnabled: hideViewedContent)
         }
     }
 

--- a/App/Home/HomeSectionView.swift
+++ b/App/Home/HomeSectionView.swift
@@ -69,6 +69,8 @@ struct HomeSectionView: View {
     @State private var scrollToTopTick: Int = 0
     @State private var lastLoadedSource: HomeContentSource?
     @State private var lastLoadedHideViewed: Bool?
+    @State private var fetchedArticles: [Article] = []
+    @State private var hasLoadedWindow = false
 
     private var batchingMode: BatchingMode {
         DoomscrollingMode.effectiveBatchingMode(storedBatchingMode)
@@ -92,21 +94,38 @@ struct HomeSectionView: View {
         return nil
     }
 
-    var rawArticles: [Article] {
+    private var slicedIDs: [Int64] {
         let batcher = self.batcher
-        let slicedIDs: [Int64]
         if batchingMode.isCountBased {
-            slicedIDs = batcher.ids(limit: loadedCount)
+            return batcher.ids(limit: loadedCount)
         } else if batchingMode.isDateBased {
-            slicedIDs = batcher.ids(since: loadedSinceDate)
+            return batcher.ids(since: loadedSinceDate)
         } else {
-            slicedIDs = preloadedEntries.map(\.id)
+            return preloadedEntries.map(\.id)
         }
-        var articles = feedManager.articles(withPreloadedIDs: slicedIDs)
-        if hideInstagramReels {
-            articles = articles.filter { !$0.url.contains("/reel/") }
-        }
-        return articles
+    }
+
+    private func assembleArticles(_ windowed: [Article]) -> [Article] {
+        guard hideInstagramReels else { return windowed }
+        return windowed.filter { !$0.url.contains("/reel/") }
+    }
+
+    /// Live assembly that performs the database fetch; used for the initial
+    /// frame and the visibility-capture sites that need a current snapshot.
+    private func currentRawArticles() -> [Article] {
+        assembleArticles(feedManager.articles(withPreloadedIDs: slicedIDs))
+    }
+
+    /// Cached assembly read by `body` and the visibility trackers, so
+    /// scroll-driven re-evaluations don't hit the database.
+    var rawArticles: [Article] {
+        guard hasLoadedWindow else { return currentRawArticles() }
+        return assembleArticles(fetchedArticles)
+    }
+
+    private func refreshWindowedArticles() {
+        fetchedArticles = feedManager.articles(withPreloadedIDs: slicedIDs)
+        hasLoadedWindow = true
     }
 
     private func reloadPreloadedEntries() async {
@@ -141,8 +160,9 @@ struct HomeSectionView: View {
             return
         }
         preloadedEntries = entries
+        refreshWindowedArticles()
         if hideViewedContent, visibility.visibleIDs == nil, !preloadedEntries.isEmpty {
-            visibility.capture(from: rawArticles, isEnabled: hideViewedContent)
+            visibility.capture(from: currentRawArticles(), isEnabled: hideViewedContent)
         }
     }
 
@@ -152,7 +172,7 @@ struct HomeSectionView: View {
         feedManager.flushDebouncedReads()
         withAnimation(.smooth.speed(2.0)) {
             visibility.beginRefresh(
-                from: rawArticles,
+                from: currentRawArticles(),
                 isEnabled: hideViewedContent,
                 recaptureVisible: true
             )
@@ -176,7 +196,7 @@ struct HomeSectionView: View {
         feedManager.flushDebouncedReads()
         withAnimation(.smooth.speed(2.0)) {
             visibility.beginRefresh(
-                from: rawArticles,
+                from: currentRawArticles(),
                 isEnabled: hideViewedContent,
                 recaptureVisible: true
             )
@@ -266,7 +286,7 @@ struct HomeSectionView: View {
                     latestArticleDate: latestArticleDate()
                 )
                 loadedCount = batchingMode.initialCount()
-                visibility.capture(from: rawArticles, isEnabled: hideViewedContent)
+                visibility.capture(from: currentRawArticles(), isEnabled: hideViewedContent)
                 hasInitializedSinceDate = true
             }
             lastLoadedSource = source
@@ -277,10 +297,13 @@ struct HomeSectionView: View {
                 latestArticleDate: latestArticleDate()
             )
             loadedCount = newMode.initialCount()
-            visibility.capture(from: rawArticles, isEnabled: hideViewedContent)
+            visibility.capture(from: currentRawArticles(), isEnabled: hideViewedContent)
         }
         .onChange(of: doomscrollingMode) { _, _ in
-            visibility.capture(from: rawArticles, isEnabled: hideViewedContent)
+            visibility.capture(from: currentRawArticles(), isEnabled: hideViewedContent)
+        }
+        .onChange(of: slicedIDs) { _, _ in
+            refreshWindowedArticles()
         }
     }
 

--- a/App/Shared/ArticleDestinationView.swift
+++ b/App/Shared/ArticleDestinationView.swift
@@ -48,26 +48,37 @@ struct ArticleDestinationView: View {
         return mode
     }
 
+    /// Stable per-article identity. Ephemeral articles all share `id == 0`, so
+    /// they key on the URL instead; otherwise navigating between two ephemeral
+    /// articles (or any reused detail view) leaves the previous content on
+    /// screen because the id-keyed loader never re-runs.
+    private var articleIdentity: String {
+        article.isEphemeral ? article.url : String(article.id)
+    }
+
     var body: some View {
         let article = rawArticle
-        if article.isPodcastEpisode {
-            PodcastEpisodeView(article: article, audioPlayer: audioPlayer)
-        } else if article.isYouTubeURL {
-            YouTubePlayerView(article: article, session: youTubeSession)
-        } else if effectiveOpenMode == .clearThisPage,
-                  let url = URL(string: article.url) {
-            ClearThisPageView(article: article, url: url)
-        } else if effectiveOpenMode == .readability,
-                  let url = URL(string: article.url) {
-            ReadabilityView(article: article, url: url)
-        } else if effectiveOpenMode == .archivePh,
-                  let url = URL(string: article.url) {
-            ArchivePhView(article: article, url: url)
-        } else {
-            ArticleDetailView(
-                article: article,
-                ephemeralTextMode: article.isEphemeral ? overrideTextMode : nil
-            )
+        Group {
+            if article.isPodcastEpisode {
+                PodcastEpisodeView(article: article, audioPlayer: audioPlayer)
+            } else if article.isYouTubeURL {
+                YouTubePlayerView(article: article, session: youTubeSession)
+            } else if effectiveOpenMode == .clearThisPage,
+                      let url = URL(string: article.url) {
+                ClearThisPageView(article: article, url: url)
+            } else if effectiveOpenMode == .readability,
+                      let url = URL(string: article.url) {
+                ReadabilityView(article: article, url: url)
+            } else if effectiveOpenMode == .archivePh,
+                      let url = URL(string: article.url) {
+                ArchivePhView(article: article, url: url)
+            } else {
+                ArticleDetailView(
+                    article: article,
+                    ephemeralTextMode: article.isEphemeral ? overrideTextMode : nil
+                )
+            }
         }
+        .id(articleIdentity)
     }
 }

--- a/App/Shared/ArticleDestinationView.swift
+++ b/App/Shared/ArticleDestinationView.swift
@@ -48,37 +48,26 @@ struct ArticleDestinationView: View {
         return mode
     }
 
-    /// Stable per-article identity. Ephemeral articles all share `id == 0`, so
-    /// they key on the URL instead; otherwise navigating between two ephemeral
-    /// articles (or any reused detail view) leaves the previous content on
-    /// screen because the id-keyed loader never re-runs.
-    private var articleIdentity: String {
-        article.isEphemeral ? article.url : String(article.id)
-    }
-
     var body: some View {
         let article = rawArticle
-        Group {
-            if article.isPodcastEpisode {
-                PodcastEpisodeView(article: article, audioPlayer: audioPlayer)
-            } else if article.isYouTubeURL {
-                YouTubePlayerView(article: article, session: youTubeSession)
-            } else if effectiveOpenMode == .clearThisPage,
-                      let url = URL(string: article.url) {
-                ClearThisPageView(article: article, url: url)
-            } else if effectiveOpenMode == .readability,
-                      let url = URL(string: article.url) {
-                ReadabilityView(article: article, url: url)
-            } else if effectiveOpenMode == .archivePh,
-                      let url = URL(string: article.url) {
-                ArchivePhView(article: article, url: url)
-            } else {
-                ArticleDetailView(
-                    article: article,
-                    ephemeralTextMode: article.isEphemeral ? overrideTextMode : nil
-                )
-            }
+        if article.isPodcastEpisode {
+            PodcastEpisodeView(article: article, audioPlayer: audioPlayer)
+        } else if article.isYouTubeURL {
+            YouTubePlayerView(article: article, session: youTubeSession)
+        } else if effectiveOpenMode == .clearThisPage,
+                  let url = URL(string: article.url) {
+            ClearThisPageView(article: article, url: url)
+        } else if effectiveOpenMode == .readability,
+                  let url = URL(string: article.url) {
+            ReadabilityView(article: article, url: url)
+        } else if effectiveOpenMode == .archivePh,
+                  let url = URL(string: article.url) {
+            ArchivePhView(article: article, url: url)
+        } else {
+            ArticleDetailView(
+                article: article,
+                ephemeralTextMode: article.isEphemeral ? overrideTextMode : nil
+            )
         }
-        .id(articleIdentity)
     }
 }

--- a/App/Shared/CachedAsyncImage.swift
+++ b/App/Shared/CachedAsyncImage.swift
@@ -111,10 +111,8 @@ struct CachedAsyncImage<Placeholder: View>: View {
         CachedAsyncImageConfig.maxDisplayPixelSize
     }
 
-    /// Memory-cache key. The full-size default keeps the bare URL so existing
-    /// readers (and the raw-URL lookup in `CarouselImageView`) still hit;
-    /// smaller thumbnail requests get a size-suffixed key so a list row and a
-    /// hero image of the same URL don't clobber each other.
+    /// Full-size requests keep the bare URL (so existing callers and the
+    /// `CarouselImageView` raw-URL lookup still hit); thumbnails get a size suffix.
     nonisolated static func cacheKey(_ url: URL, _ maxPixelSize: CGFloat) -> String {
         maxPixelSize == CachedAsyncImageConfig.maxDisplayPixelSize
             ? url.absoluteString

--- a/App/Shared/CachedAsyncImage.swift
+++ b/App/Shared/CachedAsyncImage.swift
@@ -32,6 +32,7 @@ private enum CachedAsyncImageConfig {
 struct CachedAsyncImage<Placeholder: View>: View {
 
     let url: URL?
+    let maxPixelSize: CGFloat
     let alignment: Alignment
     let onImageLoaded: ((UIImage) -> Void)?
     let placeholder: () -> Placeholder
@@ -41,17 +42,19 @@ struct CachedAsyncImage<Placeholder: View>: View {
 
     init(
         url: URL?,
+        maxPixelSize: CGFloat = CachedAsyncImageConfig.maxDisplayPixelSize,
         alignment: Alignment = .center,
         onImageLoaded: ((UIImage) -> Void)? = nil,
         @ViewBuilder placeholder: @escaping () -> Placeholder
     ) {
         self.url = url
+        self.maxPixelSize = maxPixelSize
         self.alignment = alignment
         self.onImageLoaded = onImageLoaded
         self.placeholder = placeholder
         let initial: UIImage? = {
             guard let url, !url.absoluteString.hasPrefix("data:") else { return nil }
-            return ImageMemoryCache.shared.image(forKey: url.absoluteString)
+            return ImageMemoryCache.shared.image(forKey: Self.cacheKey(url, maxPixelSize))
         }()
         _image = State(initialValue: initial)
         _isLoading = State(initialValue: initial == nil)
@@ -93,7 +96,7 @@ struct CachedAsyncImage<Placeholder: View>: View {
                 isLoading = false
                 return
             }
-            let loadedImage = await Self.loadImage(from: url)
+            let loadedImage = await Self.loadImage(from: url, maxPixelSize: maxPixelSize)
             if Task.isCancelled { return }
             image = loadedImage
             if let loadedImage {
@@ -108,15 +111,29 @@ struct CachedAsyncImage<Placeholder: View>: View {
         CachedAsyncImageConfig.maxDisplayPixelSize
     }
 
-    nonisolated static func loadImage(from url: URL) async -> UIImage? {
+    /// Memory-cache key. The full-size default keeps the bare URL so existing
+    /// readers (and the raw-URL lookup in `CarouselImageView`) still hit;
+    /// smaller thumbnail requests get a size-suffixed key so a list row and a
+    /// hero image of the same URL don't clobber each other.
+    nonisolated static func cacheKey(_ url: URL, _ maxPixelSize: CGFloat) -> String {
+        maxPixelSize == CachedAsyncImageConfig.maxDisplayPixelSize
+            ? url.absoluteString
+            : "\(url.absoluteString)|\(Int(maxPixelSize))"
+    }
+
+    nonisolated static func loadImage(
+        from url: URL,
+        maxPixelSize: CGFloat = CachedAsyncImageConfig.maxDisplayPixelSize
+    ) async -> UIImage? {
         let urlString = url.absoluteString
 
         if urlString.hasPrefix("data:") {
             return nil
         }
 
+        let key = cacheKey(url, maxPixelSize)
         let memoryCache = ImageMemoryCache.shared
-        if let cached = memoryCache.image(forKey: urlString) {
+        if let cached = memoryCache.image(forKey: key) {
             _ = cached.ensureIconDerivedMetrics()
             return cached
         }
@@ -125,10 +142,10 @@ struct CachedAsyncImage<Placeholder: View>: View {
 
         if let cachedData = try? database.cachedImageData(for: urlString),
            let cachedImage = ImageDownsampler.downsample(
-               cachedData, maxPixelSize: maxDisplayPixelSize
+               cachedData, maxPixelSize: maxPixelSize
            ) ?? UIImage(data: cachedData) {
             _ = cachedImage.ensureIconDerivedMetrics()
-            memoryCache.setImage(cachedImage, forKey: urlString)
+            memoryCache.setImage(cachedImage, forKey: key)
             log("Image", "Cache hit for \(urlString) (\(cachedData.count) bytes)")
             return cachedImage
         }
@@ -140,17 +157,17 @@ struct CachedAsyncImage<Placeholder: View>: View {
             let statusCode = (response as? HTTPURLResponse)?.statusCode
             log("Image", "Downloaded \(urlString): \(data.count) bytes, HTTP \(statusCode ?? 0)")
             let downsampled = ImageDownsampler.downsample(
-                data, maxPixelSize: maxDisplayPixelSize
+                data, maxPixelSize: maxPixelSize
             ) ?? UIImage(data: data)
             guard let downsampled else {
                 log("Image", "Failed to decode image data from \(urlString) (\(data.count) bytes)")
                 return nil
             }
             _ = downsampled.ensureIconDerivedMetrics()
-            if memoryCache.image(forKey: urlString) == nil {
+            if memoryCache.image(forKey: key) == nil {
                 try? database.cacheImageData(data, for: urlString)
             }
-            memoryCache.setImage(downsampled, forKey: urlString)
+            memoryCache.setImage(downsampled, forKey: key)
             return downsampled
         } catch {
             log("Image", "Download failed for \(urlString): \(error.localizedDescription)")

--- a/App/Shared/IconProgressBadge.swift
+++ b/App/Shared/IconProgressBadge.swift
@@ -13,21 +13,34 @@ struct IconProgressBadge: View {
     var cornerRadius: CGFloat = 12
 
     var body: some View {
-        TimelineView(.periodic(from: .now, by: 1)) { context in
-            if let progress = cooldownProgress(now: context.date) {
-                ZStack {
-                    shape
-                        .fill(Color.clear)
-                    PieSliceShape(progress: 1 - progress)
-                        .fill(Color.black.opacity(0.4))
-                        .clipShape(shape)
+        if isCooldownActive {
+            TimelineView(.periodic(from: .now, by: 1)) { context in
+                if let progress = cooldownProgress(now: context.date) {
+                    ZStack {
+                        shape
+                            .fill(Color.clear)
+                        PieSliceShape(progress: 1 - progress)
+                            .fill(Color.black.opacity(0.4))
+                            .clipShape(shape)
+                    }
+                    .frame(width: size, height: size)
+                    .allowsHitTesting(false)
+                } else {
+                    Color.clear.frame(width: size, height: size)
                 }
-                .frame(width: size, height: size)
-                .allowsHitTesting(false)
-            } else {
-                Color.clear.frame(width: size, height: size)
             }
+        } else {
+            Color.clear.frame(width: size, height: size)
         }
+    }
+
+    /// Whether a cooldown is currently elapsing. When false the periodic
+    /// timeline is skipped entirely so idle feed icons don't re-render once a
+    /// second.
+    private var isCooldownActive: Bool {
+        guard let lastFetched, cooldown > 0 else { return false }
+        let elapsed = Date().timeIntervalSince(lastFetched)
+        return elapsed >= 0 && elapsed < cooldown
     }
 
     private var shape: AnyShape {

--- a/Hanami/Content Resolver/ContentResolver.swift
+++ b/Hanami/Content Resolver/ContentResolver.swift
@@ -5,7 +5,7 @@ import Foundation
 public final class ContentResolver {
 
     /// Bumped whenever extraction logic changes.
-    public nonisolated static let parserVersion = 20260510_162900
+    public nonisolated static let parserVersion = 20260527_000000
 
     public let article: Article
     public let articleSourceOverride: ArticleSource?

--- a/Hanami/Database Manager/Articles/DatabaseManager+ArticlesQueries.swift
+++ b/Hanami/Database Manager/Articles/DatabaseManager+ArticlesQueries.swift
@@ -255,4 +255,112 @@ public nonisolated extension DatabaseManager {
         }
         return results
     }
+
+    // MARK: - List Projections
+
+    /// The following variants mirror the queries above but omit the `content`
+    /// blob (see `selectingListColumns`). They back the scrollable lists, where
+    /// `content` is never displayed; the reader re-fetches the full row by id.
+
+    func articlesList(withIDs ids: [Int64]) throws -> [Article] {
+        guard !ids.isEmpty else { return [] }
+        let query = selectingListColumns(articles)
+            .filter(ids.contains(articleID))
+            .order(articlePublishedDate.desc)
+        return try database.prepare(query).map(rowToListArticle)
+    }
+
+    func unreadArticlesList(forFeedID fid: Int64) throws -> [Article] {
+        let query = selectingListColumns(articles)
+            .filter(articleFeedID == fid && articleIsRead == false)
+            .order(articlePublishedDate.desc)
+        return try database.prepare(query).map(rowToListArticle)
+    }
+
+    func articlesList(forFeedID fid: Int64, limit: Int? = nil) throws -> [Article] {
+        var query = selectingListColumns(articles)
+            .filter(articleFeedID == fid)
+            .order(articlePublishedDate.desc)
+        if let limit {
+            query = query.limit(limit)
+        }
+        return try database.prepare(query).map(rowToListArticle)
+    }
+
+    func articlesList(forFeedIDs feedIDs: [Int64], limit: Int, requireUnread: Bool = false) throws -> [Article] {
+        guard !feedIDs.isEmpty else { return [] }
+        var query = selectingListColumns(articles).filter(feedIDs.contains(articleFeedID))
+        if requireUnread {
+            query = query.filter(articleIsRead == false)
+        }
+        return try database
+            .prepare(query.order(articlePublishedDate.desc).limit(limit))
+            .map(rowToListArticle)
+    }
+
+    func articlesList(forFeedID fid: Int64, since date: Date) throws -> [Article] {
+        let query = selectingListColumns(articles)
+            .filter(articleFeedID == fid
+                    && articlePublishedDate >= date.timeIntervalSince1970)
+            .order(articlePublishedDate.desc)
+        return try database.prepare(query).map(rowToListArticle)
+    }
+
+    func undatedArticlesList(forFeedID fid: Int64) throws -> [Article] {
+        let query = selectingListColumns(articles)
+            .filter(articleFeedID == fid && articlePublishedDate == nil)
+            .order(articleID.desc)
+        return try database.prepare(query).map(rowToListArticle)
+    }
+
+    func articlesList(forFeedIDs feedIDs: Set<Int64>, since date: Date) throws -> [Article] {
+        guard !feedIDs.isEmpty else { return [] }
+        let query = selectingListColumns(articles)
+            .filter(feedIDs.contains(articleFeedID)
+                    && articlePublishedDate >= date.timeIntervalSince1970)
+            .order(articlePublishedDate.desc)
+        return try database.prepare(query).map(rowToListArticle)
+    }
+
+    func undatedArticlesList(forFeedIDs feedIDs: Set<Int64>) throws -> [Article] {
+        guard !feedIDs.isEmpty else { return [] }
+        let query = selectingListColumns(articles)
+            .filter(feedIDs.contains(articleFeedID) && articlePublishedDate == nil)
+            .order(articleID.desc)
+        return try database.prepare(query).map(rowToListArticle)
+    }
+
+    func allArticlesList(limit: Int = 100) throws -> [Article] {
+        let query = selectingListColumns(articles)
+            .order(articlePublishedDate.desc)
+            .limit(limit)
+        return try database.prepare(query).map(rowToListArticle)
+    }
+
+    func allArticlesList(since date: Date, limit: Int? = 200) throws -> [Article] {
+        var query = selectingListColumns(articles)
+            .filter(articlePublishedDate >= date.timeIntervalSince1970)
+            .order(articlePublishedDate.desc)
+        if let limit {
+            query = query.limit(limit)
+        }
+        return try database.prepare(query).map(rowToListArticle)
+    }
+
+    func allArticlesList(before date: Date, limit: Int = 200) throws -> [Article] {
+        let query = selectingListColumns(articles)
+            .filter(articlePublishedDate < date.timeIntervalSince1970 || articlePublishedDate == nil)
+            .order(articlePublishedDate.desc)
+            .limit(limit)
+        return try database.prepare(query).map(rowToListArticle)
+    }
+
+    func allArticlesList(from startDate: Date, to endDate: Date, limit: Int = 200) throws -> [Article] {
+        let query = selectingListColumns(articles)
+            .filter(articlePublishedDate >= startDate.timeIntervalSince1970
+                    && articlePublishedDate < endDate.timeIntervalSince1970)
+            .order(articlePublishedDate.desc)
+            .limit(limit)
+        return try database.prepare(query).map(rowToListArticle)
+    }
 }

--- a/Hanami/Database Manager/Articles/DatabaseManager+ArticlesRowMapping.swift
+++ b/Hanami/Database Manager/Articles/DatabaseManager+ArticlesRowMapping.swift
@@ -25,4 +25,49 @@ public nonisolated extension DatabaseManager {
             duration: row[articleDuration]
         )
     }
+
+    /// Restricts a query to the columns rendered in lists, omitting the heavy
+    /// `content` blob so list loads never read full extracted HTML into memory.
+    func selectingListColumns(_ query: Table) -> Table {
+        query.select(
+            articleID,
+            articleFeedID,
+            articleTitle,
+            articleURL,
+            articleAuthor,
+            articleSummary,
+            articleImageURL,
+            articleCarouselURLs,
+            articlePublishedDate,
+            articleIsRead,
+            articleIsBookmarked,
+            articleAudioURL,
+            articleDuration
+        )
+    }
+
+    /// Maps a row selected via `selectingListColumns`. `content` is intentionally
+    /// `nil`; the reader re-fetches the full row by id when an article is opened.
+    func rowToListArticle(_ row: Row) -> Article {
+        let carouselRaw = row[articleCarouselURLs]
+        let carouselURLs = carouselRaw?
+            .split(separator: "\n")
+            .map(String.init) ?? []
+        return Article(
+            id: row[articleID],
+            feedID: row[articleFeedID],
+            title: row[articleTitle],
+            url: row[articleURL],
+            author: row[articleAuthor],
+            summary: row[articleSummary],
+            content: nil,
+            imageURL: row[articleImageURL],
+            carouselImageURLs: carouselURLs,
+            publishedDate: row[articlePublishedDate].map { Date(timeIntervalSince1970: $0) },
+            isRead: row[articleIsRead],
+            isBookmarked: row[articleIsBookmarked],
+            audioURL: row[articleAudioURL],
+            duration: row[articleDuration]
+        )
+    }
 }

--- a/Hanami/Feed Manager/FeedManager+Articles.swift
+++ b/Hanami/Feed Manager/FeedManager+Articles.swift
@@ -24,7 +24,7 @@ public extension FeedManager {
     func todayArticles() -> [Article] {
         _ = dataRevision
         let startOfToday = Calendar.current.startOfDay(for: Date())
-        var all = (try? database.allArticles(since: startOfToday)) ?? []
+        var all = (try? database.allArticlesList(since: startOfToday)) ?? []
         let muted = mutedFeedIDs
         if !muted.isEmpty {
             all = all.filter { !muted.contains($0.feedID) }
@@ -58,7 +58,7 @@ public extension FeedManager {
     func olderArticles(limit: Int = 200) -> [Article] {
         _ = dataRevision
         let startOfToday = Calendar.current.startOfDay(for: Date())
-        var all = (try? database.allArticles(before: startOfToday, limit: limit)) ?? []
+        var all = (try? database.allArticlesList(before: startOfToday, limit: limit)) ?? []
         let muted = mutedFeedIDs
         if !muted.isEmpty {
             all = all.filter { !muted.contains($0.feedID) }
@@ -69,13 +69,13 @@ public extension FeedManager {
     func articles(for feed: Feed, limit: Int? = nil, requireUnread: Bool = false) -> [Article] {
         _ = dataRevision
         guard requireUnread, let limit else {
-            let all = (try? database.articles(forFeedID: feed.id, limit: limit)) ?? []
+            let all = (try? database.articlesList(forFeedID: feed.id, limit: limit)) ?? []
             return applyRules(all, feedID: feed.id)
         }
         var fetchLimit = max(limit * 4, 100)
         let maxIterations = 20
         for _ in 0..<maxIterations {
-            let all = (try? database.articles(forFeedID: feed.id, limit: fetchLimit)) ?? []
+            let all = (try? database.articlesList(forFeedID: feed.id, limit: fetchLimit)) ?? []
             let pool = applyRules(all, feedID: feed.id)
             let unread = pool.filter { !$0.isRead }
             if unread.count >= limit || pool.count < fetchLimit {
@@ -83,19 +83,19 @@ public extension FeedManager {
             }
             fetchLimit *= 2
         }
-        let all = (try? database.articles(forFeedID: feed.id, limit: fetchLimit)) ?? []
+        let all = (try? database.articlesList(forFeedID: feed.id, limit: fetchLimit)) ?? []
         return Array(applyRules(all, feedID: feed.id).filter { !$0.isRead }.prefix(limit))
     }
 
     func articles(for feed: Feed, since date: Date) -> [Article] {
         _ = dataRevision
-        let all = (try? database.articles(forFeedID: feed.id, since: date)) ?? []
+        let all = (try? database.articlesList(forFeedID: feed.id, since: date)) ?? []
         return applyRules(all, feedID: feed.id)
     }
 
     func undatedArticles(for feed: Feed) -> [Article] {
         _ = dataRevision
-        let all = (try? database.undatedArticles(forFeedID: feed.id)) ?? []
+        let all = (try? database.undatedArticlesList(forFeedID: feed.id)) ?? []
         return applyRules(all, feedID: feed.id)
     }
 
@@ -111,7 +111,7 @@ public extension FeedManager {
             let chunkStart = FeedManager.chunkStart(for: earlier)
             guard chunkStart < cursor else { return nil }
             let chunkEnd = FeedManager.chunkEnd(for: chunkStart)
-            let chunkArticles = (try? database.articles(forFeedID: feed.id, since: chunkStart)) ?? []
+            let chunkArticles = (try? database.articlesList(forFeedID: feed.id, since: chunkStart)) ?? []
             let inChunk = chunkArticles.filter { ($0.publishedDate ?? .distantPast) < chunkEnd }
             if !applyRules(inChunk, feedID: feed.id).isEmpty {
                 return chunkStart
@@ -138,7 +138,7 @@ public extension FeedManager {
 
     func articles(since date: Date) -> [Article] {
         _ = dataRevision
-        var all = (try? database.allArticles(since: date, limit: nil)) ?? []
+        var all = (try? database.allArticlesList(since: date, limit: nil)) ?? []
         let muted = mutedFeedIDs
         if !muted.isEmpty {
             all = all.filter { !muted.contains($0.feedID) }
@@ -160,7 +160,7 @@ public extension FeedManager {
             let chunkStart = FeedManager.chunkStart(for: earlier)
             guard chunkStart < cursor else { return nil }
             let chunkEnd = FeedManager.chunkEnd(for: chunkStart)
-            let chunkArticles = (try? database.allArticles(from: chunkStart, to: chunkEnd, limit: 10000)) ?? []
+            let chunkArticles = (try? database.allArticlesList(from: chunkStart, to: chunkEnd, limit: 10000)) ?? []
             var visible = muted.isEmpty ? chunkArticles : chunkArticles.filter { !muted.contains($0.feedID) }
             visible = applyAllRules(visible)
             if !visible.isEmpty {
@@ -299,7 +299,7 @@ public extension FeedManager {
                 .map(\.id)
         )
         guard !sectionFeedIDs.isEmpty else { return [] }
-        let pool = (try? database.articles(forFeedIDs: sectionFeedIDs, since: date)) ?? []
+        let pool = (try? database.articlesList(forFeedIDs: sectionFeedIDs, since: date)) ?? []
         return applyAllRules(pool)
     }
 
@@ -312,7 +312,7 @@ public extension FeedManager {
                 .map(\.id)
         )
         guard !sectionFeedIDs.isEmpty else { return [] }
-        let pool = (try? database.undatedArticles(forFeedIDs: sectionFeedIDs)) ?? []
+        let pool = (try? database.undatedArticlesList(forFeedIDs: sectionFeedIDs)) ?? []
         return applyAllRules(pool)
     }
 
@@ -327,7 +327,7 @@ public extension FeedManager {
             guard let chunkStart = nextArticleChunk(before: cursor) else { return nil }
             guard chunkStart < cursor else { return nil }
             let chunkEnd = FeedManager.chunkEnd(for: chunkStart)
-            let chunkArticles = (try? database.allArticles(from: chunkStart, to: chunkEnd, limit: 10000)) ?? []
+            let chunkArticles = (try? database.allArticlesList(from: chunkStart, to: chunkEnd, limit: 10000)) ?? []
             var visible = muted.isEmpty ? chunkArticles : chunkArticles.filter { !muted.contains($0.feedID) }
             visible = applyAllRules(visible).filter { sectionFeedIDs.contains($0.feedID) }
             if !visible.isEmpty {

--- a/Hanami/Feed Manager/FeedManager+Articles.swift
+++ b/Hanami/Feed Manager/FeedManager+Articles.swift
@@ -235,21 +235,21 @@ public extension FeedManager {
     func markAllRead(feed: Feed) {
         stagedReadChanges.removeAll()
         try? database.markAllRead(feedID: feed.id)
-        loadFromDatabase()
+        Task { await loadFromDatabaseInBackground(animated: true) }
         updateBadgeCount()
     }
 
     func markAllRead() {
         stagedReadChanges.removeAll()
         try? database.markAllRead()
-        loadFromDatabase()
+        Task { await loadFromDatabaseInBackground(animated: true) }
         updateBadgeCount()
     }
 
     func markAllUnread() {
         stagedReadChanges.removeAll()
         try? database.markAllUnread()
-        loadFromDatabase()
+        Task { await loadFromDatabaseInBackground(animated: true) }
         updateBadgeCount()
     }
 
@@ -275,7 +275,7 @@ public extension FeedManager {
 
     func clearAccessHistory() {
         try? database.clearAccessHistory()
-        loadFromDatabase()
+        Task { await loadFromDatabaseInBackground() }
     }
 
     // MARK: - Section Queries
@@ -344,7 +344,7 @@ public extension FeedManager {
         for feed in sectionFeeds {
             try? database.markAllRead(feedID: feed.id)
         }
-        loadFromDatabase()
+        Task { await loadFromDatabaseInBackground(animated: true) }
         updateBadgeCount()
     }
 

--- a/Hanami/Feed Manager/FeedManager+Batching.swift
+++ b/Hanami/Feed Manager/FeedManager+Batching.swift
@@ -8,7 +8,7 @@ public extension FeedManager {
         _ = dataRevision
         if !requireUnread {
             let fetchLimit = max(limit * 4, 100)
-            var all = (try? database.allArticles(limit: fetchLimit)) ?? []
+            var all = (try? database.allArticlesList(limit: fetchLimit)) ?? []
             let muted = mutedFeedIDs
             if !muted.isEmpty {
                 all = all.filter { !muted.contains($0.feedID) }
@@ -19,7 +19,7 @@ public extension FeedManager {
         let maxIterations = 20
         let muted = mutedFeedIDs
         for _ in 0..<maxIterations {
-            var all = (try? database.allArticles(limit: fetchLimit)) ?? []
+            var all = (try? database.allArticlesList(limit: fetchLimit)) ?? []
             if !muted.isEmpty {
                 all = all.filter { !muted.contains($0.feedID) }
             }
@@ -30,7 +30,7 @@ public extension FeedManager {
             }
             fetchLimit *= 2
         }
-        var all = (try? database.allArticles(limit: fetchLimit)) ?? []
+        var all = (try? database.allArticlesList(limit: fetchLimit)) ?? []
         if !muted.isEmpty {
             all = all.filter { !muted.contains($0.feedID) }
         }
@@ -40,7 +40,7 @@ public extension FeedManager {
     func hasMoreArticles(beyond count: Int) -> Bool {
         _ = dataRevision
         let fetchLimit = count + max(count, 100)
-        var all = (try? database.allArticles(limit: fetchLimit)) ?? []
+        var all = (try? database.allArticlesList(limit: fetchLimit)) ?? []
         let muted = mutedFeedIDs
         if !muted.isEmpty {
             all = all.filter { !muted.contains($0.feedID) }
@@ -67,7 +67,7 @@ public extension FeedManager {
         var fetchLimit = max(limit * 4, 100)
         let maxIterations = 20
         for _ in 0..<maxIterations {
-            let raw = (try? database.articles(
+            let raw = (try? database.articlesList(
                 forFeedIDs: feedIDList,
                 limit: fetchLimit,
                 requireUnread: requireUnread
@@ -91,7 +91,7 @@ public extension FeedManager {
         let sectionFeedIDs = sectionFeedIDsExcludingMuted(section)
         guard !sectionFeedIDs.isEmpty else { return false }
         let feedIDList = Array(sectionFeedIDs)
-        let pool = (try? database.articles(forFeedIDs: feedIDList, limit: count + 1)) ?? []
+        let pool = (try? database.articlesList(forFeedIDs: feedIDList, limit: count + 1)) ?? []
         return applyAllRules(pool).count > count
     }
 
@@ -120,7 +120,7 @@ public extension FeedManager {
 
     func hasMoreArticles(for feed: Feed, beyond count: Int) -> Bool {
         _ = dataRevision
-        let all = (try? database.articles(forFeedID: feed.id, limit: count + 1)) ?? []
+        let all = (try? database.articlesList(forFeedID: feed.id, limit: count + 1)) ?? []
         return applyRules(all, feedID: feed.id).count > count
     }
 
@@ -197,7 +197,7 @@ public extension FeedManager {
             iterations += 1
             guard (try? database.earliestArticleDate(before: cursor)) ?? nil != nil else { return nil }
             guard let newStart = calendar.date(byAdding: .day, value: -days, to: cursor) else { return nil }
-            let windowArticles = (try? database.allArticles(from: newStart, to: cursor, limit: 10000)) ?? []
+            let windowArticles = (try? database.allArticlesList(from: newStart, to: cursor, limit: 10000)) ?? []
             var visible = muted.isEmpty ? windowArticles : windowArticles.filter { !muted.contains($0.feedID) }
             visible = applyAllRules(visible).filter { listFeedIDs.contains($0.feedID) }
             visible = applyListRules(visible, listID: list.id)
@@ -229,7 +229,7 @@ public extension FeedManager {
             iterations += 1
             guard (try? database.earliestArticleDate(before: cursor)) ?? nil != nil else { return nil }
             guard let newStart = calendar.date(byAdding: .day, value: -days, to: cursor) else { return nil }
-            let windowArticles = (try? database.allArticles(from: newStart, to: cursor, limit: 10000)) ?? []
+            let windowArticles = (try? database.allArticlesList(from: newStart, to: cursor, limit: 10000)) ?? []
             var visible = muted.isEmpty ? windowArticles : windowArticles.filter { !muted.contains($0.feedID) }
             visible = applyAllRules(visible)
             if requireUnread {
@@ -261,7 +261,7 @@ public extension FeedManager {
             iterations += 1
             guard (try? database.earliestArticleDate(before: cursor)) ?? nil != nil else { return nil }
             guard let newStart = calendar.date(byAdding: .day, value: -days, to: cursor) else { return nil }
-            let windowArticles = (try? database.allArticles(from: newStart, to: cursor, limit: 10000)) ?? []
+            let windowArticles = (try? database.allArticlesList(from: newStart, to: cursor, limit: 10000)) ?? []
             var visible = muted.isEmpty ? windowArticles : windowArticles.filter { !muted.contains($0.feedID) }
             visible = applyAllRules(visible).filter { sectionFeedIDs.contains($0.feedID) }
             if requireUnread {
@@ -292,7 +292,7 @@ public extension FeedManager {
                 return nil
             }
             guard let newStart = calendar.date(byAdding: .day, value: -days, to: cursor) else { return nil }
-            let windowArticles = ((try? database.articles(forFeedID: feed.id, since: newStart)) ?? [])
+            let windowArticles = ((try? database.articlesList(forFeedID: feed.id, since: newStart)) ?? [])
                 .filter { ($0.publishedDate ?? .distantPast) < cursor }
             var visible = applyRules(windowArticles, feedID: feed.id)
             if requireUnread {

--- a/Hanami/Feed Manager/FeedManager+CRUDAsync.swift
+++ b/Hanami/Feed Manager/FeedManager+CRUDAsync.swift
@@ -3,10 +3,10 @@ import UIKit
 
 public extension FeedManager {
 
-    /// Async variant of `addFeed(url:title:siteURL:...)` that pre-fetches
-    /// provider-specific metadata (display name, profile photo) before
-    /// inserting so the feed appears in the list with its final title and
-    /// icon, rather than briefly showing a handle placeholder.
+    /// Async variant of `addFeed(url:title:siteURL:...)` that inserts the feed
+    /// immediately with a placeholder title and acronym icon so the row (and the
+    /// dismissed sheet) appear without waiting on the network, then enriches the
+    /// title and icon and runs the first refresh in the background.
     @discardableResult
     func addFeedFetchingMetadata(
         url: String,
@@ -32,29 +32,25 @@ public extension FeedManager {
             }
         }
 
-        let prefetched = await prefetchAddFeedMetadata(siteURL: siteURL)
-        let resolvedTitle: String
-        if let displayName = prefetched.displayName,
-           !displayName.isEmpty {
-            resolvedTitle = displayName
-        } else {
-            resolvedTitle = title
-        }
-
         let feedID = try database.insertFeed(
-            title: resolvedTitle, url: url, siteURL: siteURL,
+            title: title, url: url, siteURL: siteURL,
             description: description, iconURL: nil,
             category: category, isPodcast: isPodcast
         )
-
-        await applyPrefetchedIcon(prefetched, feedID: feedID, url: url, title: resolvedTitle)
-        generateAcronymIcon(feedID: feedID, title: resolvedTitle)
+        generateAcronymIcon(feedID: feedID, title: title)
 
         let newFeed = try? database.feed(byID: feedID)
         await loadFromDatabaseInBackground()
-        if let newFeed {
-            Task {
-                try? await refreshFeed(newFeed)
+
+        Task { [weak self] in
+            guard let self else { return }
+            await self.enrichInsertedFeed(
+                feedID: feedID, url: url, siteURL: siteURL,
+                category: category, fallbackTitle: title
+            )
+            await self.loadFromDatabaseInBackground()
+            if let enriched = try? self.database.feed(byID: feedID) {
+                try? await self.refreshFeed(enriched)
             }
         }
         return newFeed

--- a/Hanami/Feed Manager/FeedManager+Lookups.swift
+++ b/Hanami/Feed Manager/FeedManager+Lookups.swift
@@ -14,8 +14,11 @@ public extension FeedManager {
 
     /// Returns the raw article (no Content Override applied). The viewer relies on this
     /// to display the original RSS data; lists go through the override pipeline instead.
+    ///
+    /// Always reads from the database so the full `content` blob is present: the
+    /// in-memory `articles` cache is a list projection that omits `content`.
     func article(byID id: Int64) -> Article? {
-        articles.first { $0.id == id } ?? (try? database.article(byID: id))
+        (try? database.article(byID: id))
     }
 
 }

--- a/Hanami/Feed Manager/FeedManager+Pipeline.swift
+++ b/Hanami/Feed Manager/FeedManager+Pipeline.swift
@@ -264,21 +264,28 @@ public extension FeedManager {
         let maxConcurrent = 4
         var results: [String: String] = [:]
         var index = 0
-        while index < candidates.count {
-            if Task.isCancelled { return results }
-            let batch = candidates[index..<min(index + maxConcurrent, candidates.count)]
-            index += maxConcurrent
-            await withTaskGroup(of: (String, String?).self) { group in
-                for candidate in batch {
+        await withTaskGroup(of: (String, String?).self) { group in
+            while index < candidates.count && index < maxConcurrent {
+                let candidate = candidates[index]
+                index += 1
+                group.addTask {
+                    let imageURL = await HTMLMetadataImage.fetchImageURL(for: candidate.requestURL)
+                    return (candidate.articleURL, imageURL)
+                }
+            }
+            while let (articleURL, imageURL) = await group.next() {
+                if let imageURL { results[articleURL] = imageURL }
+                if Task.isCancelled {
+                    group.cancelAll()
+                    break
+                }
+                if index < candidates.count {
+                    let candidate = candidates[index]
+                    index += 1
                     group.addTask {
-                        let imageURL = await HTMLMetadataImage.fetchImageURL(
-                            for: candidate.requestURL
-                        )
+                        let imageURL = await HTMLMetadataImage.fetchImageURL(for: candidate.requestURL)
                         return (candidate.articleURL, imageURL)
                     }
-                }
-                for await (articleURL, imageURL) in group {
-                    if let imageURL { results[articleURL] = imageURL }
                 }
             }
         }

--- a/Hanami/Feed Manager/FeedManager+Preload.swift
+++ b/Hanami/Feed Manager/FeedManager+Preload.swift
@@ -10,7 +10,7 @@ public extension FeedManager {
     func preloadedArticleEntries(requireUnread: Bool = false) -> [ArticleIDEntry] {
         _ = dataRevision
         let muted = mutedFeedIDs
-        let raw = (try? database.allArticles(limit: Int.max)) ?? []
+        let raw = (try? database.allArticlesList(limit: Int.max)) ?? []
         var pool = applyAllRules(raw)
         if !muted.isEmpty {
             pool = pool.filter { !muted.contains($0.feedID) }
@@ -28,7 +28,7 @@ public extension FeedManager {
 
     func preloadedArticleEntries(for feed: Feed, requireUnread: Bool = false) -> [ArticleIDEntry] {
         _ = dataRevision
-        let raw = (try? database.articles(forFeedID: feed.id)) ?? []
+        let raw = (try? database.articlesList(forFeedID: feed.id)) ?? []
         var pool = applyRules(raw, feedID: feed.id)
         if requireUnread {
             pool = pool.filter { !$0.isRead }
@@ -92,7 +92,7 @@ public extension FeedManager {
             forEntity: topic,
             types: ["organization", "place"]
         )) ?? []
-        let raw = (try? database.articles(withIDs: ids)) ?? []
+        let raw = (try? database.articlesList(withIDs: ids)) ?? []
         var pool = applyAllRules(raw)
         if !muted.isEmpty {
             pool = pool.filter { !muted.contains($0.feedID) }
@@ -113,7 +113,7 @@ public extension FeedManager {
     func articles(withPreloadedIDs ids: [Int64]) -> [Article] {
         guard !ids.isEmpty else { return [] }
         _ = dataRevision
-        let fetched = (try? database.articles(withIDs: ids)) ?? []
+        let fetched = (try? database.articlesList(withIDs: ids)) ?? []
         let byID = Dictionary(uniqueKeysWithValues: fetched.map { ($0.id, $0) })
         let ordered = ids.compactMap { byID[$0] }
         return applyContentOverrides(ordered)
@@ -183,7 +183,7 @@ public extension FeedManager {
         muted: Set<Int64>,
         requireUnread: Bool
     ) -> [ArticleIDEntry] {
-        let raw = (try? database.allArticles(limit: Int.max)) ?? []
+        let raw = (try? database.allArticlesList(limit: Int.max)) ?? []
         var pool = applyAllRules(raw, database: database)
         if !muted.isEmpty {
             pool = pool.filter { !muted.contains($0.feedID) }
@@ -247,7 +247,7 @@ public extension FeedManager {
             forEntity: topic,
             types: ["organization", "place"]
         )) ?? []
-        let raw = (try? database.articles(withIDs: ids)) ?? []
+        let raw = (try? database.articlesList(withIDs: ids)) ?? []
         var pool = applyAllRules(raw, database: database)
         if !muted.isEmpty {
             pool = pool.filter { !muted.contains($0.feedID) }

--- a/Hanami/Feed Manager/FeedManager+Rules.swift
+++ b/Hanami/Feed Manager/FeedManager+Rules.swift
@@ -86,7 +86,7 @@ public extension FeedManager {
         guard !feedsWithRules.isEmpty else { return rawCounts }
         var result = rawCounts
         for feedID in feedsWithRules where (result[feedID] ?? 0) > 0 {
-            let unread = (try? database.unreadArticles(forFeedID: feedID)) ?? []
+            let unread = (try? database.unreadArticlesList(forFeedID: feedID)) ?? []
             result[feedID] = applyRules(unread, feedID: feedID, database: database).count
         }
         return result

--- a/Hanami/Feed Manager/FeedManager.swift
+++ b/Hanami/Feed Manager/FeedManager.swift
@@ -147,7 +147,7 @@ public final class FeedManager {
         do {
             feeds = try database.allFeeds()
             feedsByID = Dictionary(uniqueKeysWithValues: feeds.map { ($0.id, $0) })
-            articles = try database.allArticles(limit: 200)
+            articles = try database.allArticlesList(limit: 200)
             let rawUnreadCounts = (try? database.allUnreadCounts()) ?? [:]
             unreadCounts = FeedManager.applyRulesToUnreadCounts(rawUnreadCounts, database: database)
             let instagramFeedIDs = Set(feeds.filter { $0.isInstagramFeed }.map(\.id))
@@ -177,7 +177,7 @@ public final class FeedManager {
                 loadedLists
             ) = try await Task.detached {
                 let feeds = try dbm.allFeeds()
-                let articles = try dbm.allArticles(limit: 200)
+                let articles = try dbm.allArticlesList(limit: 200)
                 let rawUnreadCounts = (try? dbm.allUnreadCounts()) ?? [:]
                 let unreadCounts = FeedManager.applyRulesToUnreadCounts(rawUnreadCounts, database: dbm)
                 let instagramFeedIDs = Set(feeds.filter { $0.isInstagramFeed }.map(\.id))

--- a/Hanami/HTML Content Extractor/HTMLContentExtractor.swift
+++ b/Hanami/HTML Content Extractor/HTMLContentExtractor.swift
@@ -88,7 +88,8 @@ public final class HTMLContentExtractor {
         let text = extractText(
             fromHTML: html,
             baseURL: baseURL,
-            excludeTitle: excludeTitle
+            excludeTitle: excludeTitle,
+            preparsedDocument: doc
         )
         return ExtractionResult(
             text: text,
@@ -100,7 +101,8 @@ public final class HTMLContentExtractor {
     public static func extractText(
         fromHTML html: String,
         baseURL: URL? = nil,
-        excludeTitle: String? = nil
+        excludeTitle: String? = nil,
+        preparsedDocument: Document? = nil
     ) -> String? {
         guard !html.isEmpty else {
             log("Extract", "extractText: empty HTML, returning nil")
@@ -136,7 +138,12 @@ public final class HTMLContentExtractor {
         log("Extract", "extractText: full HTML (\(tagCount) tags, \(html.count) chars), parsing with SwiftSoup")
 
         do {
-            let doc = try SwiftSoup.parse(html)
+            let doc: Document
+            if let preparsedDocument {
+                doc = preparsedDocument
+            } else {
+                doc = try SwiftSoup.parse(html)
+            }
             normalizeAMPElements(in: doc)
             // Promote social embeds (YouTube, X) into marker paragraphs
             // before noise removal so selectors targeting twitter-tweet

--- a/Hanami/RSS Parser/RSSParser+HTML.swift
+++ b/Hanami/RSS Parser/RSSParser+HTML.swift
@@ -36,6 +36,24 @@ nonisolated private let htmlNamedEntities: [String: String] = [
     "hearts": "\u{2665}", "diams": "\u{2666}"
 ]
 
+nonisolated private let rssLinkRegex = try? NSRegularExpression(
+    pattern: #"<a\s[^>]*href=["']([^"']+)["'][^>]*>(.*?)</a>"#
+)
+nonisolated private let rssSupSubRegex = try? NSRegularExpression(
+    pattern: #"\{\{(SUP|SUB)\}\}(.+?)\{\{/(SUP|SUB)\}\}"#
+)
+nonisolated private let rssMarkdownLinkRegex = try? NSRegularExpression(
+    pattern: #"\[([^\]]+)\]\(([^)]+)\)"#
+)
+nonisolated private let rssPreTagRegex = try? NSRegularExpression(
+    pattern: #"<pre(?:\s[^>]*)?>(?:\s*<code(?:\s[^>]*)?>)?(.*?)(?:</code>\s*)?</pre>"#,
+    options: [.caseInsensitive, .dotMatchesLineSeparators]
+)
+nonisolated private let rssImgTagRegex = try? NSRegularExpression(
+    pattern: #"<img\s[^>]*src=["']([^"']+)["'][^>]*>"#,
+    options: .caseInsensitive
+)
+
 public nonisolated extension RSSParser {
 
     func decodeHTMLEntities(_ string: String) -> String {
@@ -127,9 +145,7 @@ public nonisolated extension RSSParser {
     }
 
     private func convertLinksToMarkdown(_ text: String, baseURL: URL? = nil) -> String {
-        guard let linkRegex = try? NSRegularExpression(
-            pattern: #"<a\s[^>]*href=["']([^"']+)["'][^>]*>(.*?)</a>"#
-        ) else { return text }
+        guard let linkRegex = rssLinkRegex else { return text }
 
         var result = text
         let nsResult = result as NSString
@@ -246,15 +262,13 @@ public nonisolated extension RSSParser {
     }
 
     func stripInvalidURLSupSub(_ text: String) -> String {
-        let pattern = #"\{\{(SUP|SUB)\}\}(.+?)\{\{/(SUP|SUB)\}\}"#
-        guard let regex = try? NSRegularExpression(pattern: pattern) else { return text }
+        guard let regex = rssSupSubRegex else { return text }
         var result = text
         let nsText = result as NSString
         let matches = regex.matches(in: result, range: NSRange(location: 0, length: nsText.length))
         for match in matches.reversed() {
             let content = nsText.substring(with: match.range(at: 2))
-            let linkPattern = #"\[([^\]]+)\]\(([^)]+)\)"#
-            if let linkRegex = try? NSRegularExpression(pattern: linkPattern),
+            if let linkRegex = rssMarkdownLinkRegex,
                let linkMatch = linkRegex.firstMatch(
                 in: content, range: NSRange(location: 0, length: (content as NSString).length)
                ) {
@@ -273,10 +287,7 @@ public nonisolated extension RSSParser {
     }
 
     private func replacePreTagsWithMarkers(_ text: String) -> String {
-        guard let regex = try? NSRegularExpression(
-            pattern: #"<pre(?:\s[^>]*)?>(?:\s*<code(?:\s[^>]*)?>)?(.*?)(?:</code>\s*)?</pre>"#,
-            options: [.caseInsensitive, .dotMatchesLineSeparators]
-        ) else { return text }
+        guard let regex = rssPreTagRegex else { return text }
         var result = text
         let nsResult = result as NSString
         let matches = regex.matches(in: result, range: NSRange(location: 0, length: nsResult.length))
@@ -293,9 +304,7 @@ public nonisolated extension RSSParser {
     }
 
     private func replaceImgTagsWithMarkers(_ text: String) -> String {
-        let imgPattern = #"<img\s[^>]*src=["']([^"']+)["'][^>]*>"#
-        guard let imgRegex = try? NSRegularExpression(pattern: imgPattern, options: .caseInsensitive)
-        else { return text }
+        guard let imgRegex = rssImgTagRegex else { return text }
         var result = text
         let nsResult = result as NSString
         let matches = imgRegex.matches(in: result, range: NSRange(location: 0, length: nsResult.length))

--- a/Hanami/Site Content Extractors/NineToFiveExtractor.swift
+++ b/Hanami/Site Content Extractors/NineToFiveExtractor.swift
@@ -17,10 +17,8 @@ public struct NineToFiveExtractor: SiteContentExtractor {
         guard let container = try? document.select("div.post-content").first() else {
             return nil
         }
-        // The body lives in `.post-content`; every `<article>` on the page is a
-        // clickable recirculation card, so the generic `article` selector would
-        // otherwise return a "Featured Content" carousel item. Strip those cards
-        // in case they nest inside the body container.
+        // Every <article> here is a recirculation card, so strip the featured /
+        // related modules in case they nest inside the body container.
         try? container.select(".featured-items, .related-guides, .related-guide").remove()
 
         guard let html = try? container.outerHtml(), !html.isEmpty else { return nil }

--- a/Hanami/Site Content Extractors/NineToFiveExtractor.swift
+++ b/Hanami/Site Content Extractors/NineToFiveExtractor.swift
@@ -1,0 +1,36 @@
+import Foundation
+import SwiftSoup
+
+public struct NineToFiveExtractor: SiteContentExtractor {
+
+    public func canHandle(url: URL) -> Bool {
+        matchesHost(url, ["9to5mac.com", "9to5google.com"])
+    }
+
+    public func extract(
+        document: Document,
+        baseURL: URL,
+        excludeTitle: String?
+    ) -> ExtractionResult? {
+        let metadata = HTMLContentExtractor.extractMetadata(from: document)
+
+        guard let container = try? document.select("div.post-content").first() else {
+            return nil
+        }
+        // The body lives in `.post-content`; every `<article>` on the page is a
+        // clickable recirculation card, so the generic `article` selector would
+        // otherwise return a "Featured Content" carousel item. Strip those cards
+        // in case they nest inside the body container.
+        try? container.select(".featured-items, .related-guides, .related-guide").remove()
+
+        guard let html = try? container.outerHtml(), !html.isEmpty else { return nil }
+
+        let text = HTMLContentExtractor.extractText(
+            fromHTML: html,
+            baseURL: baseURL,
+            excludeTitle: excludeTitle
+        )
+        guard text?.isEmpty == false else { return nil }
+        return ExtractionResult(text: text, metadata: metadata)
+    }
+}

--- a/Hanami/Site Content Extractors/SiteContentExtractorRegistry.swift
+++ b/Hanami/Site Content Extractors/SiteContentExtractorRegistry.swift
@@ -12,7 +12,8 @@ public enum SiteContentExtractorRegistry {
         TomsHardwareExtractor(),
         France24Extractor(),
         AppleExtractor(),
-        ZDNETExtractor()
+        ZDNETExtractor(),
+        NineToFiveExtractor()
     ]
 
     public static func extractor(for url: URL) -> SiteContentExtractor? {


### PR DESCRIPTION
## Summary

Performance-focused work targeting the four release goals: refresh without jank, fast article loads, fast feed refreshes, and fast feed subscriptions. Also includes a content-extraction fix for 9to5Mac/9to5Google and display-sized image downsampling that landed while chasing scroll performance. Each workstream is its own commit so it can be reviewed and reverted independently.

> [!IMPORTANT]
> Authored in a Linux container with **no Swift/Xcode/SwiftLint toolchain and no build CI**, so none of it was compiled or linted here. It has since been **built and exercised via TestFlight**, where scrolling — especially the image-heavy Inbox/Magazine/Masonry/Feed styles — is confirmed noticeably smoother, and the 9to5 extraction fix is verified working. A local SwiftLint pass and a full regression sweep on a Mac are still recommended.

## What's included (commits)

1. **List articles load without the `content` blob** — the keystone. List queries read every column including the heavy extracted-HTML `content` blob that no row ever displays, and on each `dataRevision` bump every visible list re-queries and re-diffs full-weight `Article` structs. Added a content-skipping column projection (`selectingListColumns`) + `rowToListArticle` mapper, and pointed the display/preload/batching/chunk-walk/unread-recount paths at new `*List` query variants. Content-bearing consumers are unchanged: the reader re-fetches the full row by id (`article(byID:)` now always hits the DB), `MediaPresenter` resolves the full article before the players, and summary/Spotlight/App-Intent paths keep the full queries. *No view or method-signature changes.*
2. **Bulk read changes & refreshes don't jank the lists** — dropped the whole-list `.animation(value: articles)` relayout in Masonry/Magazine and moved mark-all-read/unread/clear-history reloads off the main thread.
3. **Parse article HTML once** — `extractArticle` parsed the HTML, then `extractText` re-parsed the identical string; the parsed document is now threaded through. Also hoisted the repeated RSS HTML-cleaner regexes to cached instances.
4. **Image prefetch stays saturated during refresh** — `fetchMetadataImages` waited for each batch of four to fully finish; switched to a continuously refilled bounded task group.
5. **Subscriptions appear immediately** — insert the feed up front with a placeholder title + acronym icon and return so the sheet dismisses, then resolve the real title/icon and run the first refresh in the background (reusing the existing `enrichInsertedFeed` path).
6. **Idle feed icons stop re-rendering every second** — `IconProgressBadge` only runs its 1Hz timeline while a cooldown is actually elapsing.
7. **Article window fetched off the view body** — `FeedArticlesView` and `HomeSectionView` ran the windowed DB fetch + content-override pass inside `rawArticles` in the view body, so it re-ran on every scroll-driven body re-evaluation (e.g. the visibility tracker ticking). Moved the fetch into a `@State` cache refreshed only when the sliced ID window or `dataRevision` changes; `body` and the visibility trackers read in-memory state, while the infrequent visibility-capture sites use a live snapshot.
8. **Display-sized image downsampling** — `CachedAsyncImage` decoded and cached every image at up to 2000px on the long edge, so small rows (Inbox's 48pt thumbnails) held ~10MB images and thrashed the 150MB in-memory cache during scroll. Added an opt-in `maxPixelSize`: Inbox 144, Masonry & Feed-carousel 800, Magazine/Feed/Video 1200, Photos 1600. **Cards and Scroll keep the full 2000px** for their large rich media. Raw bytes stay cached at full resolution in the DB, so larger contexts still derive a sharp image from the same source; the full-size default preserves the bare-URL cache key, so existing callers and the carousel's raw-URL lookup are unchanged.
9. **9to5Mac / 9to5Google body extraction** — every `<article>` on these sites is a clickable recirculation card, so the generic `article` content selector (higher priority than `.post-content`) returned a "Featured Content" carousel item instead of the body. Added `NineToFiveExtractor` scoped to `.post-content` (stripping the featured/related-guide modules), falling back to the generic pipeline when the container is absent.
10. **Parser version bump** — re-extracts already-cached article bodies on launch so the new 9to5 extraction applies to previously-fetched articles, not just newly fetched ones.

> A misdiagnosed article-viewer navigation-identity change was committed and then reverted in this branch (net no-op) before the real "previous content" cause — broken 9to5 extraction returning identical output — was found.

## Scope decisions worth a look

- **The keystone (commit 1) was bounded** to the data/manager layer rather than splitting `Article` into a separate `ArticleListItem` type across ~120 files. Investigation showed lists render through query methods (not the observed `articles` array) and the reader always re-fetches the full row, so nulling `content` in list queries achieves the full goal with a fraction of the blast radius and no view changes.
- **The "new content" pill is already implemented** (`ArticleVisibilityTracker` + `refreshPromptOverlay`, wired in `FeedArticlesView`/`HomeSectionView`), so commit 2 just removes the surrounding relayout jank.
- **A UIKit `UICollectionView` waterfall for Masonry was intentionally not done** — the card self-sizes from an async image aspect ratio plus variable text, so a correct waterfall needs self-sizing hosted cells in a custom layout for marginal gains. The SwiftUI Masonry already benefits from commits 1, 2, 7, and 8.
- **The 9to5 extraction fix (commits 9–10) is content-correctness, not performance**, bundled here for convenience — happy to split into its own PR if preferred.
- **Image `maxPixelSize` values are tuned for phones.** Full-width styles (Magazine/Feed 1200, Photos 1600) may look slightly soft on large iPads; they can be raised or made scale-aware if needed.

## Test plan

- [ ] Build for iOS and run SwiftLint (could not be done in the container).
- [ ] Scroll a large feed while triggering "refresh all"; confirm no reflow/jank (profile Animation Hitches before/after) and that the existing new-content pill still behaves.
- [ ] Scroll the image-heavy styles (Inbox, Magazine, Masonry, Feed, Photos, Video); confirm smoothness and that images aren't visibly soft — check Photos/Magazine on a large iPad in particular.
- [ ] Confirm **Cards** and **Scroll** styles still present full-resolution media.
- [ ] Open a **9to5Mac** and a **9to5Google** article; confirm the real body text (not the Featured Content carousel) for both freshly fetched and previously cached articles.
- [ ] Open a cached article (instant) and an uncached one (network-bound); verify content is unchanged across RSS, Reddit, AMP, and paywalled feeds, and that the single-parse refactor produces identical extraction.
- [ ] Mark-all-read/unread on a large account; confirm responsiveness and correct unread badges.
- [ ] Subscribe to a feed with a slow/404 icon URL; confirm the row appears and the sheet dismisses immediately, with title/icon/articles filling in after.
- [ ] Regression sweep of the YouTube and podcast players, iPad detail column, Today/Home cards, Bookmarks, search, widgets, and App Intents (all should still receive full `content` where they read it).

https://claude.ai/code/session_019QLGdRTsr7qcbYgDA6SRhP