### PR TITLE
Show refreshing feeds popover on long press of refresh pill

### DIFF
--- a/App/Home/HomeRefreshStatusView.swift
+++ b/App/Home/HomeRefreshStatusView.swift
@@ -5,6 +5,10 @@ struct HomeRefreshStatusView: View {
 
     let state: ScopedRefreshState
     var onStop: (() -> Void)?
+    @Binding var isShowingDetails: Bool
+    let refreshingFeedIDs: Set<Int64>
+    let pendingFeedIDs: [Int64]
+    @Environment(FeedManager.self) private var feedManager
 
     var body: some View {
         Button {
@@ -33,6 +37,17 @@ struct HomeRefreshStatusView: View {
         .shadow(color: .black.opacity(0.15), radius: 8, y: 2)
         .animation(.smooth, value: state.completed)
         .accessibilityLabel(Text(String(localized: "Refresh.Stop", table: "Home")))
+        .onLongPressGesture {
+            isShowingDetails = true
+        }
+        .popover(isPresented: $isShowingDetails) {
+            RefreshingFeedsPopoverView(
+                refreshingFeedIDs: refreshingFeedIDs,
+                pendingFeedIDs: pendingFeedIDs
+            )
+            .environment(feedManager)
+            .presentationCompactAdaptation(.popover)
+        }
     }
 
     private var progressText: String {

--- a/App/Home/HomeView+Toolbar.swift
+++ b/App/Home/HomeView+Toolbar.swift
@@ -96,7 +96,10 @@ extension HomeView {
                 if homeRefreshState.hasActiveProgress {
                     HomeRefreshStatusView(
                         state: homeRefreshState,
-                        onStop: cancelHomeRefresh
+                        onStop: cancelHomeRefresh,
+                        isShowingDetails: $isShowingRefreshingFeedsPopover,
+                        refreshingFeedIDs: activeRefreshingFeedIDs,
+                        pendingFeedIDs: activePendingFeedIDs
                     )
                     .padding(.top, 8)
                     .transition(.move(edge: .top).combined(with: .opacity))


### PR DESCRIPTION
## Summary

Long pressing the refresh progress donut pill now shows the popover listing the feeds currently being refreshed (and those pending). Previously this list was only reachable by tapping the title text; on the phone redesign the pill is the only refresh indicator shown, so it had no way to reveal the list.

- Tap the pill: still stops the refresh (unchanged)
- Long press the pill: shows the refreshing/pending feeds popover

## Changes

- `HomeRefreshStatusView`: added an `.onLongPressGesture` that presents `RefreshingFeedsPopoverView` as a popover anchored to the pill, wired through a presentation binding and the active refreshing/pending feed IDs.
- `HomeView+Toolbar.swift`: passes the existing `isShowingRefreshingFeedsPopover` binding and `activeRefreshingFeedIDs` / `activePendingFeedIDs` into the pill.

The popover reuses the existing `isShowingRefreshingFeedsPopover` state, which is mutually exclusive with the title-anchored popover (only shown in the non-phone layout).

https://claude.ai/code/session_017SQsyPEoL6Z9qcotBoJnGv

---
_Generated by [Claude Code](https://claude.ai/code/session_017SQsyPEoL6Z9qcotBoJnGv)_