### PR TITLE
Fix stale context menus in lazy stacks and add Following grid context menu

### DIFF
--- a/App/Following/Edit Feed/EditFeedSheet.swift
+++ b/App/Following/Edit Feed/EditFeedSheet.swift
@@ -8,7 +8,12 @@ struct EditFeedSheet: View {
     let feedID: Int64
 
     @State private var feed: Feed?
-    @State private var selectedTab: FeedEditTab = .about
+    @State private var selectedTab: FeedEditTab
+
+    init(feedID: Int64, initialTab: FeedEditTab = .about) {
+        self.feedID = feedID
+        _selectedTab = State(initialValue: initialTab)
+    }
 
     var body: some View {
         NavigationStack {

--- a/App/Following/FollowingFeedGridContextMenu.swift
+++ b/App/Following/FollowingFeedGridContextMenu.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+import Hanami
+
+struct FollowingFeedGridContextMenu: View {
+
+    @Environment(FeedManager.self) private var feedManager
+    let feed: Feed
+    @Binding var feedToEdit: Feed?
+    @Binding var feedForRules: Feed?
+    @Binding var feedToDelete: Feed?
+
+    var body: some View {
+        Button {
+            feedToEdit = feed
+        } label: {
+            Label(String(localized: "FeedMenu.Edit", table: "Feeds"),
+                  systemImage: "pencil")
+        }
+        Button {
+            feedForRules = feed
+        } label: {
+            Label(String(localized: "FeedMenu.Rules", table: "Feeds"),
+                  systemImage: "list.bullet.rectangle")
+        }
+        Divider()
+        let availableLists = listsNotContainingFeed
+        if !availableLists.isEmpty {
+            Menu {
+                ForEach(availableLists) { list in
+                    Button {
+                        feedManager.addFeedToList(list, feed: feed)
+                    } label: {
+                        Label(list.name, systemImage: list.icon)
+                    }
+                }
+            } label: {
+                Label(String(localized: "FeedMenu.AddToList", table: "Feeds"),
+                      systemImage: "text.badge.plus")
+            }
+            Divider()
+        }
+        Button(role: .destructive) {
+            feedToDelete = feed
+        } label: {
+            Label(String(localized: "FeedMenu.Unfollow", table: "Feeds"),
+                  image: "dot.radiowaves.up.forward.slash")
+        }
+    }
+
+    private var listsNotContainingFeed: [FeedList] {
+        let assignedListIDs = feedManager.listIDsForFeed(feed)
+        return feedManager.lists
+            .filter { !assignedListIDs.contains($0.id) }
+            .sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
+    }
+}

--- a/App/Following/FollowingPage+Sections.swift
+++ b/App/Following/FollowingPage+Sections.swift
@@ -141,6 +141,16 @@ extension FollowingPage {
                 FollowingFeedGridCell(feed: feed)
             }
             .buttonStyle(.plain)
+            .contextMenu {
+                FollowingFeedGridContextMenu(
+                    feed: feed,
+                    feedToEdit: $feedToEdit,
+                    feedForRules: $feedForRules,
+                    feedToDelete: $feedToDelete
+                )
+            }
+            // Keep .id after .contextMenu: lazy grids reuse the menu interaction and can
+            // present the previously long-pressed feed's menu without an explicit identity.
             .id(feed.id)
         }
     }

--- a/App/Following/FollowingPage+Sections.swift
+++ b/App/Following/FollowingPage+Sections.swift
@@ -138,7 +138,7 @@ extension FollowingPage {
             .id(feed.id)
         } else {
             NavigationLink(value: feed) {
-                FollowingFeedGridCell(feed: feed)
+                FollowingFeedGridCell(feed: feed, editTransitionNamespace: feedEditNamespace)
             }
             .buttonStyle(.plain)
             .contextMenu {

--- a/App/Following/FollowingPage.swift
+++ b/App/Following/FollowingPage.swift
@@ -7,6 +7,7 @@ struct FollowingPage: View {
     @State var searchText = ""
     @State var isPresentingAddFeedSheet = false
     @State var feedToEdit: Feed?
+    @State var feedForRules: Feed?
     @State var feedToDelete: Feed?
     @State var isEditingFeeds = false
     @State var isSelectingFeeds = false
@@ -54,6 +55,10 @@ struct FollowingPage: View {
             EditFeedSheet(feedID: feed.id)
                 .environment(feedManager)
                 .navigationTransition(.zoom(sourceID: feed.id, in: feedEditNamespace))
+        }
+        .sheet(item: $feedForRules) { feed in
+            EditFeedSheet(feedID: feed.id, initialTab: .rules)
+                .environment(feedManager)
         }
         .sheet(isPresented: $isPresentingBulkEditSheet) {
             BulkEditFeedSheet(feedIDs: selectedFeedIDs)

--- a/App/Following/FollowingPage.swift
+++ b/App/Following/FollowingPage.swift
@@ -59,6 +59,7 @@ struct FollowingPage: View {
         .sheet(item: $feedForRules) { feed in
             EditFeedSheet(feedID: feed.id, initialTab: .rules)
                 .environment(feedManager)
+                .navigationTransition(.zoom(sourceID: feed.id, in: feedEditNamespace))
         }
         .sheet(isPresented: $isPresentingBulkEditSheet) {
             BulkEditFeedSheet(feedIDs: selectedFeedIDs)

--- a/App/Home/Today/Cards/TodayCardCarousel.swift
+++ b/App/Home/Today/Cards/TodayCardCarousel.swift
@@ -23,6 +23,10 @@ struct TodayCardCarousel<Card: View>: View {
                             .contextMenu {
                                 TodayCardContextMenu(article: article)
                             }
+                            // Lazy containers reuse the context menu interaction, which can
+                            // present the previously long-pressed item's menu without an
+                            // explicit identity.
+                            .id(article.id)
                     }
                 }
                 .padding(.horizontal)

--- a/Shared/Strings/Feeds.xcstrings
+++ b/Shared/Strings/Feeds.xcstrings
@@ -6896,61 +6896,61 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Hinzufügen zu …"
+            "value" : "Zur Liste hinzufügen …"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Add to..."
+            "value" : "Add to List..."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ajouter à…"
+            "value" : "Ajouter à une liste…"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Aggiungi a…"
+            "value" : "Aggiungi a una lista…"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "追加先…"
+            "value" : "リストに追加…"
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "추가…"
+            "value" : "리스트에 추가…"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Toevoegen aan…"
+            "value" : "Toevoegen aan lijst…"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Thêm vào…"
+            "value" : "Thêm vào danh sách…"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "添加到…"
+            "value" : "添加到列表…"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "加入到…"
+            "value" : "加入到列表…"
           }
         }
       }


### PR DESCRIPTION
## Summary

- Fixes a bug where long-pressing a card in the Today carousels (and other lazy containers) could present the previously long-pressed item's context menu. Lazy containers reuse the context menu interaction, so the cards now carry an explicit `.id` after `.contextMenu`, matching the existing pattern in the iPad sidebar.
- Implements the long-press context menu for feeds in the Following tab grid:
  - **Edit** — opens the existing edit sheet
  - **Rules** — opens the edit sheet directly on the Rules tab (new `initialTab` parameter on `EditFeedSheet`)
  - **Add to List...** — submenu listing only the lists the feed isn't already in (hidden when there are none)
  - **Unfollow** — destructive, reuses the existing confirmation alert
- Updates the previously unused `FeedMenu.AddToList` localization value from "Add to..." to "Add to List..." across all 10 languages, following each language's existing list terminology.

## Testing

No Swift toolchain is available in this environment, so the changes were not compiled; please verify the long-press menus on device/simulator in both the Today carousels and the Following grid.

https://claude.ai/code/session_01PdRcmf1JGr6mCFDF6hu8nL

---
_Generated by [Claude Code](https://claude.ai/code/session_01PdRcmf1JGr6mCFDF6hu8nL)_