### PR TITLE
Add Today landscape two-column layout and Following section navigation

### DIFF
--- a/App/Following/FollowingPage+Sections.swift
+++ b/App/Following/FollowingPage+Sections.swift
@@ -107,10 +107,31 @@ extension FollowingPage {
                     }
                 }
             } header: {
-                Text(section.localizedTitle)
-                    .font(.title3)
-                    .fontWeight(.bold)
+                feedSectionHeader(section)
             }
+        }
+    }
+
+    @ViewBuilder
+    func feedSectionHeader(_ section: FeedSection) -> some View {
+        if isEditingFeeds || isSelectingFeeds {
+            Text(section.localizedTitle)
+                .font(.title3)
+                .fontWeight(.bold)
+        } else {
+            NavigationLink(value: section) {
+                HStack(spacing: 4) {
+                    Text(section.localizedTitle)
+                        .font(.title3)
+                        .fontWeight(.bold)
+                        .foregroundStyle(.primary)
+                    Image(systemName: "chevron.right")
+                        .font(.subheadline)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .buttonStyle(.plain)
         }
     }
 

--- a/App/Following/FollowingView.swift
+++ b/App/Following/FollowingView.swift
@@ -53,6 +53,12 @@ struct FollowingView: View {
                         .environment(\.zoomNamespace, cardZoom)
                         .environment(\.navigateToEphemeralArticle, ephemeralAppender)
                 }
+                .navigationDestination(for: FeedSection.self) { section in
+                    HomeSectionView(section: section)
+                        .environment(\.zoomNamespace, cardZoom)
+                        .environment(\.navigateToFeed, { feed in path.append(feed) })
+                        .environment(\.navigateToEphemeralArticle, ephemeralAppender)
+                }
         }
         .onChange(of: path.count) {
             if path.isEmpty {

--- a/App/Home/Today/Cards/TodayCardCarousel.swift
+++ b/App/Home/Today/Cards/TodayCardCarousel.swift
@@ -14,7 +14,7 @@ struct TodayCardCarousel<Card: View>: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             header
-                .padding(.horizontal)
+                .todayHorizontalContentPadding()
 
             ScrollView(.horizontal, showsIndicators: false) {
                 LazyHStack(alignment: .top, spacing: 12) {
@@ -29,7 +29,7 @@ struct TodayCardCarousel<Card: View>: View {
                             .id(article.id)
                     }
                 }
-                .padding(.horizontal)
+                .todayHorizontalContentPadding()
             }
         }
     }

--- a/App/Home/Today/Greeting/TodayGreetingView.swift
+++ b/App/Home/Today/Greeting/TodayGreetingView.swift
@@ -8,6 +8,12 @@ struct TodayGreetingView: View {
     private let deloreanClock = DeloreanClock.shared
     @State private var greeting: TodayGreeting = .from(date: Date())
 
+    let usesCompactWeatherCard: Bool
+
+    init(usesCompactWeatherCard: Bool = false) {
+        self.usesCompactWeatherCard = usesCompactWeatherCard
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 2) {
             Text(formattedDate)
@@ -20,8 +26,11 @@ struct TodayGreetingView: View {
                 .fontWeight(.bold)
 
             if HomeLayout.usesPhoneTopBar {
-                TodayWeatherCard()
-                    .padding(.top, 12)
+                TodayWeatherCard(
+                    usesFlatBackground: usesCompactWeatherCard,
+                    showsHourlyTimeLabels: !usesCompactWeatherCard
+                )
+                .padding(.top, 12)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/App/Home/Today/Greeting/TodayGreetingView.swift
+++ b/App/Home/Today/Greeting/TodayGreetingView.swift
@@ -8,10 +8,10 @@ struct TodayGreetingView: View {
     private let deloreanClock = DeloreanClock.shared
     @State private var greeting: TodayGreeting = .from(date: Date())
 
-    let usesCompactWeatherCard: Bool
+    let isCompact: Bool
 
-    init(usesCompactWeatherCard: Bool = false) {
-        self.usesCompactWeatherCard = usesCompactWeatherCard
+    init(isCompact: Bool = false) {
+        self.isCompact = isCompact
     }
 
     var body: some View {
@@ -22,13 +22,13 @@ struct TodayGreetingView: View {
                 .foregroundStyle(.secondary)
 
             styledGreeting
-                .font(UIDevice.current.userInterfaceIdiom == .pad ? .title3 : .largeTitle)
+                .font(greetingFont)
                 .fontWeight(.bold)
 
             if HomeLayout.usesPhoneTopBar {
                 TodayWeatherCard(
-                    usesFlatBackground: usesCompactWeatherCard,
-                    showsHourlyTimeLabels: !usesCompactWeatherCard
+                    usesFlatBackground: isCompact,
+                    showsHourlyTimeLabels: !isCompact
                 )
                 .padding(.top, 12)
             }
@@ -49,6 +49,13 @@ struct TodayGreetingView: View {
         .onChange(of: deloreanClock.virtualMinutes) { _, _ in
             applyClockState()
         }
+    }
+
+    private var greetingFont: Font {
+        if isCompact {
+            return .title2
+        }
+        return UIDevice.current.userInterfaceIdiom == .pad ? .title3 : .largeTitle
     }
 
     private func applyClockState() {

--- a/App/Home/Today/TodayLeadingContentInset.swift
+++ b/App/Home/Today/TodayLeadingContentInset.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+private struct TodayLeadingContentInsetKey: EnvironmentKey {
+    static let defaultValue: CGFloat = 0
+}
+
+extension EnvironmentValues {
+    /// Extra leading inset applied to Today section content so the landscape
+    /// layout can lay sections out beside the leading column while letting
+    /// full-width carousels scroll beneath it.
+    var todayLeadingContentInset: CGFloat {
+        get { self[TodayLeadingContentInsetKey.self] }
+        set { self[TodayLeadingContentInsetKey.self] = newValue }
+    }
+}
+
+private struct TodayHorizontalContentPadding: ViewModifier {
+    @Environment(\.todayLeadingContentInset) private var leadingContentInset
+    let basePadding: CGFloat
+
+    func body(content: Content) -> some View {
+        content
+            .padding(.leading, basePadding + leadingContentInset)
+            .padding(.trailing, basePadding)
+    }
+}
+
+extension View {
+    func todayHorizontalContentPadding(_ basePadding: CGFloat = 16) -> some View {
+        modifier(TodayHorizontalContentPadding(basePadding: basePadding))
+    }
+}

--- a/App/Home/Today/TodayView+Landscape.swift
+++ b/App/Home/Today/TodayView+Landscape.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+
+/// Two-column landscape layout: a fixed glass column with the greeting,
+/// weather, and headlines on the leading side, and the remaining Today
+/// sections scrolling beside it. Section carousels span the full width so
+/// their cards flow beneath the glass column instead of clipping at its edge.
+extension TodayView {
+
+    var isLandscapeLayout: Bool {
+        verticalSizeClass == .compact
+    }
+
+    var landscapeLayout: some View {
+        GeometryReader { geometry in
+            let columnWidth = leadingColumnWidth(for: geometry.size.width)
+            ZStack(alignment: .topLeading) {
+                landscapeTrailingScrollView(columnWidth: columnWidth)
+                landscapeLeadingColumn
+                    .frame(width: columnWidth)
+                    .padding(.leading, 16)
+                    .padding(.vertical, 8)
+            }
+        }
+    }
+
+    private func leadingColumnWidth(for availableWidth: CGFloat) -> CGFloat {
+        min(380, max(280, availableWidth * 0.4))
+    }
+
+    private func landscapeTrailingScrollView(columnWidth: CGFloat) -> some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                if !todayManager.hasLoadedInitially {
+                    loadingIndicator
+                } else if contentSections.isEmpty {
+                    emptyContentView
+                } else {
+                    contentSectionsStack
+                }
+            }
+            .padding(.top, 8)
+            .padding(.bottom, 24)
+        }
+        .environment(\.todayLeadingContentInset, columnWidth + 16)
+        .refreshable {
+            startRefreshWithoutBlocking()
+        }
+    }
+
+    private var landscapeLeadingColumn: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                TodayGreetingView(usesCompactWeatherCard: true)
+                    .padding(.horizontal)
+
+                if isWeatherShowing || anySummaryActive {
+                    sectionDivider
+                }
+
+                if anySummaryActive {
+                    summaryCardsStack
+                }
+
+                attributionFooter
+            }
+            .padding(.vertical, 16)
+        }
+        .compatibleGlassEffect(in: .rect(cornerRadius: 24))
+        .clipShape(.rect(cornerRadius: 24))
+    }
+}

--- a/App/Home/Today/TodayView+Landscape.swift
+++ b/App/Home/Today/TodayView+Landscape.swift
@@ -50,7 +50,7 @@ extension TodayView {
     private var landscapeLeadingColumn: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 16) {
-                TodayGreetingView(usesCompactWeatherCard: true)
+                TodayGreetingView(isCompact: true)
                     .padding(.horizontal)
 
                 if isWeatherShowing || anySummaryActive {
@@ -65,7 +65,11 @@ extension TodayView {
             }
             .padding(.vertical, 16)
         }
-        .compatibleGlassEffect(in: .rect(cornerRadius: 24))
-        .clipShape(.rect(cornerRadius: 24))
+        // Inset the scroll indicator so it isn't clipped by the rounded corners.
+        .contentMargins(.vertical, leadingColumnCornerRadius, for: .scrollIndicators)
+        .compatibleGlassEffect(in: .rect(cornerRadius: leadingColumnCornerRadius))
+        .clipShape(.rect(cornerRadius: leadingColumnCornerRadius))
     }
+
+    private var leadingColumnCornerRadius: CGFloat { 24 }
 }

--- a/App/Home/Today/TodayView.swift
+++ b/App/Home/Today/TodayView.swift
@@ -7,6 +7,7 @@ struct TodayView: View {
 
     @Environment(FeedManager.self) var feedManager
     @Environment(TodayManager.self) var todayManager
+    @Environment(\.verticalSizeClass) var verticalSizeClass
     @AppStorage("Intelligence.ContentInsights.Enabled") var contentInsightsEnabled: Bool = false
     @Bindable var weatherService: TodayWeatherService = .shared
 
@@ -20,67 +21,14 @@ struct TodayView: View {
     @State var summaryRefreshTrigger: Int = 0
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 16) {
-                TodayGreetingView()
-                    .padding(.horizontal)
-
-                if isWeatherShowing {
-                    sectionDivider
-                }
-
-                if !anySummaryVisible, !isWeatherShowing,
-                   !todayManager.hasLoadedInitially || !contentSections.isEmpty || showEmptyState {
-                    sectionDivider
-                }
-
-                if anySummaryActive {
-                    VStack(spacing: 0) {
-                        WhileYouSleptView(
-                            hasSummary: $sleptHasSummary, flatStyle: true,
-                            isVisible: $sleptVisible,
-                            refreshTrigger: summaryRefreshTrigger
-                        )
-                        AfternoonBriefView(
-                            hasSummary: $afternoonHasSummary,
-                            isVisible: $afternoonVisible,
-                            refreshTrigger: summaryRefreshTrigger
-                        )
-                        TodaysSummaryView(
-                            hasSummary: $todayHasSummary, flatStyle: true,
-                            isVisible: $todayVisible,
-                            refreshTrigger: summaryRefreshTrigger
-                        )
-                    }
-                }
-
-                if anySummaryVisible,
-                   !todayManager.hasLoadedInitially || !contentSections.isEmpty || showEmptyState {
-                    sectionDivider
-                }
-
-                if !todayManager.hasLoadedInitially {
-                    loadingIndicator
-                } else if showEmptyState {
-                    emptyContentView
-                } else {
-                    ForEach(Array(contentSections.enumerated()), id: \.element) { index, section in
-                        sectionView(section)
-                        if index < contentSections.count - 1 {
-                            sectionDivider
-                        }
-                    }
-                }
-
-                attributionFooter
+        Group {
+            if isLandscapeLayout {
+                landscapeLayout
+            } else {
+                portraitLayout
             }
-            .padding(.top, 8)
-            .padding(.bottom, 24)
         }
         .sakuraBackground()
-        .refreshable {
-            startRefreshWithoutBlocking()
-        }
         #if os(visionOS)
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
@@ -101,9 +49,83 @@ struct TodayView: View {
         }
     }
 
+    // MARK: - Layouts
+
+    private var portraitLayout: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                TodayGreetingView()
+                    .padding(.horizontal)
+
+                if isWeatherShowing {
+                    sectionDivider
+                }
+
+                if !anySummaryVisible, !isWeatherShowing,
+                   !todayManager.hasLoadedInitially || !contentSections.isEmpty || showEmptyState {
+                    sectionDivider
+                }
+
+                if anySummaryActive {
+                    summaryCardsStack
+                }
+
+                if anySummaryVisible,
+                   !todayManager.hasLoadedInitially || !contentSections.isEmpty || showEmptyState {
+                    sectionDivider
+                }
+
+                if !todayManager.hasLoadedInitially {
+                    loadingIndicator
+                } else if showEmptyState {
+                    emptyContentView
+                } else {
+                    contentSectionsStack
+                }
+
+                attributionFooter
+            }
+            .padding(.top, 8)
+            .padding(.bottom, 24)
+        }
+        .refreshable {
+            startRefreshWithoutBlocking()
+        }
+    }
+
+    var summaryCardsStack: some View {
+        VStack(spacing: 0) {
+            WhileYouSleptView(
+                hasSummary: $sleptHasSummary, flatStyle: true,
+                isVisible: $sleptVisible,
+                refreshTrigger: summaryRefreshTrigger
+            )
+            AfternoonBriefView(
+                hasSummary: $afternoonHasSummary,
+                isVisible: $afternoonVisible,
+                refreshTrigger: summaryRefreshTrigger
+            )
+            TodaysSummaryView(
+                hasSummary: $todayHasSummary, flatStyle: true,
+                isVisible: $todayVisible,
+                refreshTrigger: summaryRefreshTrigger
+            )
+        }
+    }
+
+    @ViewBuilder
+    var contentSectionsStack: some View {
+        ForEach(Array(contentSections.enumerated()), id: \.element) { index, section in
+            sectionView(section)
+            if index < contentSections.count - 1 {
+                sectionDivider
+            }
+        }
+    }
+
     // MARK: - Sections
 
-    private enum ContentSection: Hashable {
+    enum ContentSection: Hashable {
         case listenNow
         case watchNow
         case topThree
@@ -112,7 +134,7 @@ struct TodayView: View {
         case recentlyViewed
     }
 
-    private var isWeatherShowing: Bool {
+    var isWeatherShowing: Bool {
         HomeLayout.usesPhoneTopBar
             && weatherService.lastError == nil
             && weatherService.weather != nil
@@ -123,17 +145,18 @@ struct TodayView: View {
     }
 
     @ViewBuilder
-    private var emptyContentView: some View {
+    var emptyContentView: some View {
         ContentUnavailableView {
             Label(String(localized: "Today.Empty.Title", table: "Home"), systemImage: "checkmark.circle")
         } description: {
             Text(String(localized: "Today.Empty.Description", table: "Home"))
         }
         .padding(.vertical, 32)
+        .todayHorizontalContentPadding(0)
     }
 
     @ViewBuilder
-    private var loadingIndicator: some View {
+    var loadingIndicator: some View {
         VStack(spacing: 12) {
             ProgressView()
             Text(String(localized: "Today.Loading", table: "Home"))
@@ -142,9 +165,10 @@ struct TodayView: View {
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, 48)
+        .todayHorizontalContentPadding(0)
     }
 
-    private var contentSections: [ContentSection] {
+    var contentSections: [ContentSection] {
         var sections: [ContentSection] = []
         if !visibleUnreadPodcastEpisodes.isEmpty {
             sections.append(.listenNow)
@@ -178,13 +202,13 @@ struct TodayView: View {
         todayManager.unreadVideoEpisodes.filter { !feedManager.isRead($0) }
     }
 
-    private var sectionDivider: some View {
+    var sectionDivider: some View {
         Divider()
-            .padding(.horizontal)
+            .todayHorizontalContentPadding()
     }
 
     @ViewBuilder
-    private func sectionView(_ section: ContentSection) -> some View {
+    func sectionView(_ section: ContentSection) -> some View {
         switch section {
         case .listenNow: listenNowSection
         case .watchNow: watchNowSection
@@ -236,13 +260,13 @@ struct TodayView: View {
             Text(String(localized: "Discover.TopicsAndPeople", table: "Feeds"))
                 .font(.title3)
                 .fontWeight(.bold)
-                .padding(.horizontal)
+                .todayHorizontalContentPadding()
 
             TodayChipsFlow(
                 topics: filteredTopics,
                 people: filteredPeople
             )
-            .padding(.horizontal)
+            .todayHorizontalContentPadding()
         }
     }
 
@@ -265,7 +289,7 @@ struct TodayView: View {
     }
 
     @ViewBuilder
-    private var attributionFooter: some View {
+    var attributionFooter: some View {
         let prefix = String(localized: "Today.WeatherAttribution.Prefix", table: "Home")
         let linkLabel = String(localized: "Today.WeatherAttribution.Link", table: "Home")
         let markdown = "\(prefix) [\(linkLabel)](https://developer.apple.com/weatherkit/data-source-attribution/)"

--- a/App/Home/Today/Weather/TodayWeatherCard.swift
+++ b/App/Home/Today/Weather/TodayWeatherCard.swift
@@ -7,10 +7,43 @@ struct TodayWeatherCard: View {
     @AppStorage("Today.Weather.GraphMode") private var graphMode: WeatherGraphMode = .temperature
     @Environment(\.colorScheme) private var colorScheme
 
+    let usesFlatBackground: Bool
+    let showsHourlyTimeLabels: Bool
+
+    init(usesFlatBackground: Bool = false, showsHourlyTimeLabels: Bool = true) {
+        self.usesFlatBackground = usesFlatBackground
+        self.showsHourlyTimeLabels = showsHourlyTimeLabels
+    }
+
     var body: some View {
         if let weather = weatherService.weather {
-            card(weather)
+            if usesFlatBackground {
+                flatCard(weather)
+            } else {
+                glassCard(weather)
+            }
         }
+    }
+
+    private func glassCard(_ weather: TodayWeather) -> some View {
+        card(weather)
+            .compatibleGlassEffect(in: .rect(cornerRadius: 14), tint: tint(weather))
+            .clipShape(.rect(cornerRadius: 14))
+    }
+
+    /// Flat-background variant for hosts that already sit on glass,
+    /// since stacking glass on glass is not supported.
+    private func flatCard(_ weather: TodayWeather) -> some View {
+        card(weather)
+            .background {
+                ZStack {
+                    Color(.secondarySystemBackground)
+                    if let tintColor = tint(weather) {
+                        tintColor
+                    }
+                }
+            }
+            .clipShape(.rect(cornerRadius: 14))
     }
 
     private func card(_ weather: TodayWeather) -> some View {
@@ -29,15 +62,16 @@ struct TodayWeatherCard: View {
                 TodayWeatherHeader(weather: weather)
                 if !weather.hourly.isEmpty {
                     Divider()
-                    TodayWeatherHourlyForecastView(hours: weather.hourly)
-                        .frame(maxWidth: .infinity)
+                    TodayWeatherHourlyForecastView(
+                        hours: weather.hourly,
+                        showsTimeLabels: showsHourlyTimeLabels
+                    )
+                    .frame(maxWidth: .infinity)
                 }
             }
             .padding()
         }
         .frame(maxWidth: .infinity)
-        .compatibleGlassEffect(in: .rect(cornerRadius: 14), tint: tint(weather))
-        .clipShape(.rect(cornerRadius: 14))
     }
 
     private func tint(_ weather: TodayWeather) -> Color? {

--- a/App/Home/Today/Weather/TodayWeatherHourlyForecastView.swift
+++ b/App/Home/Today/Weather/TodayWeatherHourlyForecastView.swift
@@ -4,6 +4,7 @@ import Hanami
 struct TodayWeatherHourlyForecastView: View {
 
     let hours: [TodayWeatherHour]
+    var showsTimeLabels: Bool = true
 
     var body: some View {
         HStack(alignment: .top, spacing: 0) {
@@ -16,11 +17,13 @@ struct TodayWeatherHourlyForecastView: View {
 
     private func column(for hour: TodayWeatherHour, isFirst: Bool) -> some View {
         VStack(spacing: 6) {
-            Text(isFirst ? nowLabel : hourLabel(hour.date))
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .lineLimit(1)
-                .minimumScaleFactor(0.7)
+            if showsTimeLabels {
+                Text(isFirst ? nowLabel : hourLabel(hour.date))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.7)
+            }
             Image(systemName: hour.symbolName)
                 .symbolVariant(.fill)
                 .symbolRenderingMode(.multicolor)


### PR DESCRIPTION
## Today view landscape layout

In landscape (compact vertical size class), the Today view now renders two columns:

- **Leading column**: a rounded glass container with its own vertical scroll, holding the greeting, the weather card, the headlines (summary cards), and the WeatherKit attribution pinned at the end of the column's content.
- **Weather card**: gains a flat-background variant (standard container color + condition tint) used inside the glass column, since glass cannot stack on glass. The hourly forecast hides its time labels in this variant for a more compact card.
- **Trailing area**: everything that previously sat below the headlines (Listen Now, Watch Now, top topics, topics & people, bookmarks, recently viewed). The scroll view spans the full width while content lays out beside the column via a new `todayLeadingContentInset` environment value, so horizontally scrolled carousel cards flow beneath the glass column instead of clipping at its edge.

Portrait rendering is unchanged (inset defaults to 0 everywhere).

## Following tab section navigation

Feed type section headers in the Following tab are now navigation links with the same chevron style as the Today view's section headers, opening the feed type's article list (`HomeSectionView` for that `FeedSection`). The plain text header is kept while editing or selecting feeds so wiggle-mode taps don't navigate.

https://claude.ai/code/session_01PQa8TMaA5LPsRpBV9Qgim3

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQa8TMaA5LPsRpBV9Qgim3)_