### PR TITLE
Fix read-state perf and edge cases; bottom inset for mark-all-read pill; compact view wrapping

### DIFF
--- a/App/Article Feed/ArticleListBottomInset.swift
+++ b/App/Article Feed/ArticleListBottomInset.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+private struct ArticleListBottomInsetKey: EnvironmentKey {
+    static let defaultValue: CGFloat = 0
+}
+
+extension EnvironmentValues {
+    /// Extra bottom inset applied to article scroll content so the last rows and
+    /// the load-more control clear the floating Mark All Read pill overlaid at the
+    /// bottom of home sections. Zero where no bottom overlay is present.
+    var articleListBottomInset: CGFloat {
+        get { self[ArticleListBottomInsetKey.self] }
+        set { self[ArticleListBottomInsetKey.self] = newValue }
+    }
+}

--- a/App/Article Feed/DisplayStyleContentView.swift
+++ b/App/Article Feed/DisplayStyleContentView.swift
@@ -3,6 +3,8 @@ import Hanami
 
 struct DisplayStyleContentView: View {
 
+    @Environment(\.articleListBottomInset) private var bottomInset
+
     let style: FeedDisplayStyle
     let articles: [Article]
     var onLoadMore: (() -> Void)?
@@ -14,6 +16,12 @@ struct DisplayStyleContentView: View {
     var usesStackLayout: Bool = false
 
     var body: some View {
+        styleContent
+            .safeAreaPadding(.bottom, bottomInset)
+    }
+
+    @ViewBuilder
+    private var styleContent: some View {
         switch style {
         case .inbox:
             InboxStyleView(articles: articles, onLoadMore: onLoadMore, headerView: headerView,

--- a/App/Display Styles/Compact/CompactStyleView.swift
+++ b/App/Display Styles/Compact/CompactStyleView.swift
@@ -11,14 +11,14 @@ struct CompactStyleView: View {
     var usesStackLayout: Bool = false
 
     private func articleLabel(for article: Article) -> some View {
-        HStack {
+        HStack(alignment: .top) {
             Text(article.title)
                 .font(.caption)
                 .fontWeight(feedManager.isRead(article) ? .regular : .medium)
                 .foregroundStyle(feedManager.isRead(article) ? .secondary : .primary)
-                .lineLimit(1)
-
-            Spacer()
+                .lineLimit(3)
+                .multilineTextAlignment(.leading)
+                .frame(maxWidth: .infinity, alignment: .leading)
 
             if let date = article.publishedDate {
                 RelativeTimeText(date: date)

--- a/App/Home/HomeSectionView.swift
+++ b/App/Home/HomeSectionView.swift
@@ -239,6 +239,7 @@ struct HomeSectionView: View {
         .refreshable { [scope = scopeKey, feeds = scopedFeeds] in
             startRefreshWithoutBlocking(scope: scope, feeds: feeds)
         }
+        .environment(\.articleListBottomInset, markAllReadBottomInset)
         .overlay(alignment: .bottom) {
             markAllReadPill
         }
@@ -302,6 +303,13 @@ extension HomeSectionView {
     /// Latest preloaded entry date, so the initial batch anchors on visible content.
     func latestArticleDate() -> Date? {
         preloadedEntries.compactMap(\.publishedDate).max()
+    }
+
+    /// Bottom content inset so the last rows clear the floating pill. Applied
+    /// whenever the pill can appear, not just while it is visible, so scrolling to
+    /// the end always leaves room for it.
+    var markAllReadBottomInset: CGFloat {
+        HomeLayout.usesPhoneTopBar && markAllReadPosition == .top ? 64 : 0
     }
 
     @ViewBuilder

--- a/App/View Modifiers/MarkReadOnScrollModifier.swift
+++ b/App/View Modifiers/MarkReadOnScrollModifier.swift
@@ -18,25 +18,34 @@ struct MarkReadOnScrollModifier: ViewModifier {
     @State private var hasQueued = false
     @State private var topAtOrBelowScreenTop = true
 
+    // Only install the per-row geometry/visibility observers when the feature is
+    // active. Attaching them to every row unconditionally drives continuous
+    // layout callbacks across the whole list while scrolling, even when the
+    // default (disabled) setting means the work is always discarded.
+    @ViewBuilder
     func body(content: Content) -> some View {
-        content
-            .onScrollVisibilityChange(threshold: 0.01) { isVisible in
-                if isVisible { hasBeenVisible = true }
-            }
-            .onGeometryChange(for: Bool.self) { proxy in
-                proxy.frame(in: .global).minY >= 0
-            } action: { newValue in
-                if hasQueued { return }
-                if topAtOrBelowScreenTop, !newValue,
-                   hasBeenVisible, scrollMarkAsRead, !article.isRead {
-                    hasQueued = true
-                    feedManager.markReadOnScroll(article)
-                    return
+        if scrollMarkAsRead {
+            content
+                .onScrollVisibilityChange(threshold: 0.01) { isVisible in
+                    if isVisible { hasBeenVisible = true }
                 }
-                if topAtOrBelowScreenTop != newValue {
-                    topAtOrBelowScreenTop = newValue
+                .onGeometryChange(for: Bool.self) { proxy in
+                    proxy.frame(in: .global).minY >= 0
+                } action: { newValue in
+                    if hasQueued { return }
+                    if topAtOrBelowScreenTop, !newValue,
+                       hasBeenVisible, !article.isRead {
+                        hasQueued = true
+                        feedManager.markReadOnScroll(article)
+                        return
+                    }
+                    if topAtOrBelowScreenTop != newValue {
+                        topAtOrBelowScreenTop = newValue
+                    }
                 }
-            }
+        } else {
+            content
+        }
     }
 }
 

--- a/Hanami/Feed Manager/FeedManager+Articles.swift
+++ b/Hanami/Feed Manager/FeedManager+Articles.swift
@@ -221,8 +221,15 @@ public extension FeedManager {
     /// Drops a queued scroll-mark-read for `article` so the next debounced flush
     /// doesn't write a now-superseded value back to the DB. Symmetric to
     /// `markReadOnScroll`'s pending-decrement bookkeeping.
+    ///
+    /// If the scroll-read was still unflushed, its unread decrement had not yet
+    /// reached `unreadCounts` (that happens at flush), even though `isRead`
+    /// already reports the article as read. Apply that decrement now so the live
+    /// count matches the read state the caller is about to toggle from; otherwise
+    /// `markRead`/`toggleRead`'s delta logic would drop or double-count the unread.
     private func cancelPendingScrollRead(for article: Article) {
-        guard pendingReadIDs.remove(article.id) != nil else { return }
+        pendingReadIDs.remove(article.id)
+        guard unflushedReadIDs.remove(article.id) != nil else { return }
         if let count = pendingReadDecrements[article.feedID], count > 0 {
             pendingReadDecrements[article.feedID] = count - 1
         }
@@ -230,6 +237,7 @@ public extension FeedManager {
            let count = pendingReadReelsDecrements[article.feedID], count > 0 {
             pendingReadReelsDecrements[article.feedID] = count - 1
         }
+        adjustUnreadCount(for: article, delta: -1)
     }
 
     func markAllRead(feed: Feed) {

--- a/Hanami/Feed Manager/FeedManager+PendingReads.swift
+++ b/Hanami/Feed Manager/FeedManager+PendingReads.swift
@@ -27,6 +27,7 @@ public extension FeedManager {
     func markReadOnScroll(_ article: Article) {
         guard !article.isRead,
               pendingReadIDs.insert(article.id).inserted else { return }
+        unflushedReadIDs.insert(article.id)
         pendingReadDecrements[article.feedID, default: 0] += 1
         if article.url.contains("/reel/") {
             pendingReadReelsDecrements[article.feedID, default: 0] += 1
@@ -37,7 +38,7 @@ public extension FeedManager {
     func flushDebouncedReads() {
         pendingReadsFlushWorkItem?.cancel()
         pendingReadsFlushWorkItem = nil
-        guard !pendingReadIDs.isEmpty else { return }
+        guard !unflushedReadIDs.isEmpty else { return }
         let decrements = pendingReadDecrements
         let reelsDecrements = pendingReadReelsDecrements
         pendingReadDecrements.removeAll()
@@ -46,7 +47,8 @@ public extension FeedManager {
         applyUnreadDecrements(decrements, reelsDecrements: reelsDecrements)
         updateBadgeCount()
 
-        let idArray = Array(pendingReadIDs)
+        let idArray = Array(unflushedReadIDs)
+        unflushedReadIDs.removeAll()
         readMaskRevision += 1
 
         let dbm = database

--- a/Hanami/Feed Manager/FeedManager.swift
+++ b/Hanami/Feed Manager/FeedManager.swift
@@ -96,10 +96,15 @@ public final class FeedManager {
     public private(set) var unreadReelsCounts: [Int64: Int] = [:]
     public private(set) var feedsByID: [Int64: Feed] = [:]
 
-    /// Queued mark-read IDs; flushed every 250ms while scrolling, on idle, or on backgrounding.
-    /// Kept out of observation so scroll-driven mutations don't cascade body re-evaluations
-    /// across every visible article row; views observe `readMaskRevision` instead.
+    /// Articles marked read by scrolling; consulted by `isRead` so rows stay read
+    /// until the next database reload. Persists across flushes (a flush only writes
+    /// the new delta), so it is kept out of observation to avoid cascading body
+    /// re-evaluations across every visible row; views observe `readMaskRevision`.
     @ObservationIgnored public var pendingReadIDs: Set<Int64> = []
+    /// Subset of `pendingReadIDs` not yet written to the database. A flush drains
+    /// only these, so repeated idle flushes during a long scroll don't re-write the
+    /// entire accumulated set.
+    @ObservationIgnored public var unflushedReadIDs: Set<Int64> = []
     /// Read-state overrides for explicit toggles, so `isRead` stays correct for cached
     /// `Article` snapshots held outside `articles` (e.g. TodayManager) until they refresh.
     @ObservationIgnored public var stagedReadChanges: [Int64: Bool] = [:]
@@ -164,6 +169,7 @@ public final class FeedManager {
             lists = (try? database.allLists()) ?? []
             bookmarkFolders = (try? database.allBookmarkFolders()) ?? []
             pendingReadIDs.removeAll()
+            unflushedReadIDs.removeAll()
             pendingReadDecrements.removeAll()
             pendingReadReelsDecrements.removeAll()
             let freshArticleIDs = Set(articles.map(\.id))
@@ -207,6 +213,7 @@ public final class FeedManager {
                     self.lists = loadedLists
                     self.bookmarkFolders = loadedBookmarkFolders
                     self.pendingReadIDs.removeAll()
+                    self.unflushedReadIDs.removeAll()
                     self.pendingReadDecrements.removeAll()
                     self.pendingReadReelsDecrements.removeAll()
                     let freshArticleIDs = Set(loadedArticles.map(\.id))


### PR DESCRIPTION
## Summary

Audited the **hide viewed content** and **mark-as-read-on-scroll** state machine for performance and UX issues, added the requested bottom safe-area offset for the floating Mark All Read pill, and fixed the Compact view text layout.

## Mark-read-on-scroll / hide-viewed audit

**1. Per-row observers installed even when the feature is off (performance)**
`MarkReadOnScrollModifier` attached `onScrollVisibilityChange` + `onGeometryChange` to *every* article row unconditionally. The setting defaults to **off**, so on most installs these geometry callbacks fired continuously across the whole visible list during every scroll — purely to be discarded at the `scrollMarkAsRead` guard. The observers are now only installed when the feature is active.

**2. Flushes re-wrote the entire accumulated read set (performance)**
`pendingReadIDs` intentionally persists until the next DB reload (it backs `isRead` so rows stay read), but `flushDebouncedReads()` wrote `Array(pendingReadIDs)` on *every* idle flush. During a long scroll this means each flush re-writes a set that grows with scroll distance. Added an `unflushedReadIDs` delta set so a flush drains and writes only the new IDs.

**3. Lost / double-counted unread when superseding an unflushed scroll-read (correctness)**
A scroll-read's unread decrement is applied at flush, but `isRead()` reports the article read immediately. If the user explicitly marked/toggled or swiped that article during the ~1s debounce window, `cancelPendingScrollRead` cancelled the queued decrement while `markRead`/`toggleRead` based their delta on the already-"read" state — dropping the decrement (count stuck too high) or, on toggle-to-unread, inflating it. `cancelPendingScrollRead` now applies the pending decrement immediately for unflushed reads (keyed per-article via `unflushedReadIDs`, so feeds with a mix of flushed/unflushed reads stay correct).

## Bottom safe-area offset

The Mark All Read pill is overlaid at the bottom of home sections. Added an `articleListBottomInset` environment value, published by `HomeSectionView` wherever the pill can appear and applied to the display-style scroll content via `safeAreaPadding(.bottom:)`, so the last rows and the load-more control always clear the pill. The inset is zero everywhere the bottom overlay isn't present (feed/entity/bookmark views, iPad/Mac), avoiding dead space.

## Compact view

Titles now wrap to a maximum of 3 left-aligned lines, and the row `HStack` is top-aligned so the article timestamp stays pinned to the top.

## Notes
- The new `ArticleListBottomInset.swift` is picked up automatically by the project's synchronized file groups.
- The "all views need a bottom offset" requirement was scoped to the views that actually carry the bottom pill overlay (home sections); shout if you intended the pill — and therefore the inset — to also extend to feed/entity views.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LZhEeybtBGFquEwvu17T2v)_