### PR TITLE
Reduce battery usage in feed refresh

### DIFF
--- a/App/App+BackgroundTasks.swift
+++ b/App/App+BackgroundTasks.swift
@@ -50,6 +50,13 @@ extension SakuraRSSApp {
             guard let task = task as? BGProcessingTask else { return }
             self.handleImageBackfill(task: task)
         }
+        BGTaskScheduler.shared.register(
+            forTaskWithIdentifier: SummaryBackfillScheduler.taskIdentifier,
+            using: nil
+        ) { task in
+            guard let task = task as? BGProcessingTask else { return }
+            self.handleSummaryBackfill(task: task)
+        }
     }
 
     /// Submits a `BGAppRefreshTaskRequest` per category so each one gets its
@@ -122,6 +129,7 @@ extension SakuraRSSApp {
                 "BackgroundRefresh",
                 "handleAppRefresh end category=\(category.rawValue) cancelled=\(refreshTask.isCancelled)"
             )
+            SummaryBackfillScheduler.schedule()
             completion.complete(success: !refreshTask.isCancelled)
         }
     }
@@ -291,6 +299,28 @@ extension SakuraRSSApp {
         Task {
             _ = await work.value
             log("NighttimeBackfill", "handleImageBackfill end cancelled=\(work.isCancelled)")
+            completion.complete(success: !work.isCancelled)
+        }
+    }
+
+    nonisolated func handleSummaryBackfill(task: BGProcessingTask) {
+        log("SummaryBackfill", "handleSummaryBackfill begin")
+
+        let completion = BackgroundTaskCompletion(task: task)
+
+        let work = Task {
+            await SummaryBackfillScheduler.runBackfill(isCancelled: { Task.isCancelled })
+        }
+
+        task.expirationHandler = {
+            log("SummaryBackfill", "handleSummaryBackfill expired")
+            work.cancel()
+            completion.complete(success: false)
+        }
+
+        Task {
+            _ = await work.value
+            log("SummaryBackfill", "handleSummaryBackfill end cancelled=\(work.isCancelled)")
             completion.complete(success: !work.isCancelled)
         }
     }

--- a/App/App+BackgroundTasks.swift
+++ b/App/App+BackgroundTasks.swift
@@ -9,6 +9,7 @@ extension SakuraRSSApp {
         scheduleAppRefresh()
         scheduleiCloudBackup()
         AutomaticCleanupScheduler.scheduleNextCleanup()
+        NighttimeBackfillScheduler.scheduleAll()
     }
 
     nonisolated private func registerLaunchHandlers(cloudBackupTaskID: String) {
@@ -34,6 +35,20 @@ extension SakuraRSSApp {
         ) { task in
             guard let task = task as? BGProcessingTask else { return }
             self.handleAutomaticCleanup(task: task)
+        }
+        BGTaskScheduler.shared.register(
+            forTaskWithIdentifier: NighttimeBackfillScheduler.nlpTaskIdentifier,
+            using: nil
+        ) { task in
+            guard let task = task as? BGProcessingTask else { return }
+            self.handleNLPBackfill(task: task)
+        }
+        BGTaskScheduler.shared.register(
+            forTaskWithIdentifier: NighttimeBackfillScheduler.imageTaskIdentifier,
+            using: nil
+        ) { task in
+            guard let task = task as? BGProcessingTask else { return }
+            self.handleImageBackfill(task: task)
         }
     }
 
@@ -231,6 +246,52 @@ extension SakuraRSSApp {
             let success = await cleanupTask.value
             log("AutomaticCleanup", "handleAutomaticCleanup end success=\(success)")
             completion.complete(success: success)
+        }
+    }
+
+    nonisolated func handleNLPBackfill(task: BGProcessingTask) {
+        NighttimeBackfillScheduler.scheduleNLPBackfill()
+        log("NighttimeBackfill", "handleNLPBackfill begin")
+
+        let completion = BackgroundTaskCompletion(task: task)
+
+        let work = Task {
+            await NighttimeBackfillScheduler.runNLPBackfill()
+        }
+
+        task.expirationHandler = {
+            log("NighttimeBackfill", "handleNLPBackfill expired")
+            work.cancel()
+            completion.complete(success: false)
+        }
+
+        Task {
+            _ = await work.value
+            log("NighttimeBackfill", "handleNLPBackfill end cancelled=\(work.isCancelled)")
+            completion.complete(success: !work.isCancelled)
+        }
+    }
+
+    nonisolated func handleImageBackfill(task: BGProcessingTask) {
+        NighttimeBackfillScheduler.scheduleImageBackfill()
+        log("NighttimeBackfill", "handleImageBackfill begin")
+
+        let completion = BackgroundTaskCompletion(task: task)
+
+        let work = Task {
+            await NighttimeBackfillScheduler.runImageBackfill()
+        }
+
+        task.expirationHandler = {
+            log("NighttimeBackfill", "handleImageBackfill expired")
+            work.cancel()
+            completion.complete(success: false)
+        }
+
+        Task {
+            _ = await work.value
+            log("NighttimeBackfill", "handleImageBackfill end cancelled=\(work.isCancelled)")
+            completion.complete(success: !work.isCancelled)
         }
     }
 }

--- a/App/Article Viewer/Content Blocks/ContentBlock.swift
+++ b/App/Article Viewer/Content Blocks/ContentBlock.swift
@@ -113,10 +113,17 @@ enum ContentBlock: Identifiable {
         (#"\n{3,}"#, "\n\n")
     ]
 
+    nonisolated private static let blockRegex = try? NSRegularExpression(
+        pattern: #"\{\{(IMG|CODE|VIDEO|AUDIO|YOUTUBE|XPOST|EMBED|TABLE|DL|MATH)\}\}(.*?)\{\{/\1\}\}"#,
+        options: .dotMatchesLineSeparators
+    )
+
+    nonisolated private static let imageLinkRegex = try? NSRegularExpression(
+        pattern: #"^(.+?)\{\{IMGLINK\}\}(.+?)\{\{/IMGLINK\}\}$"#
+    )
+
     nonisolated static func parse(_ text: String) -> [ContentBlock] {
-        let pattern = #"\{\{(IMG|CODE|VIDEO|AUDIO|YOUTUBE|XPOST|EMBED|TABLE|DL|MATH)\}\}(.*?)\{\{/\1\}\}"#
-        guard let regex = try? NSRegularExpression(pattern: pattern, options: .dotMatchesLineSeparators)
-        else {
+        guard let regex = blockRegex else {
             return [.text(ArticleMarker.unescape(text))]
         }
 
@@ -126,8 +133,7 @@ enum ContentBlock: Identifiable {
             return [.text(ArticleMarker.unescape(text))]
         }
 
-        let linkPattern = #"^(.+?)\{\{IMGLINK\}\}(.+?)\{\{/IMGLINK\}\}$"#
-        let linkRegex = try? NSRegularExpression(pattern: linkPattern)
+        let linkRegex = imageLinkRegex
 
         var blocks: [ContentBlock] = []
         var lastEnd = 0

--- a/App/Core/NighttimeBackfillScheduler.swift
+++ b/App/Core/NighttimeBackfillScheduler.swift
@@ -1,0 +1,92 @@
+@preconcurrency import BackgroundTasks
+import Foundation
+import Hanami
+
+/// Schedules best-effort overnight `BGProcessingTask`s that backfill NLP
+/// (3 AM) and article images (4 AM). Both require the device to be charging.
+nonisolated enum NighttimeBackfillScheduler {
+
+    static let nlpTaskIdentifier = "com.tsubuzaki.SakuraRSS.NLPBackfill"
+    static let imageTaskIdentifier = "com.tsubuzaki.SakuraRSS.ImageBackfill"
+
+    private static let nlpHour = 3
+    private static let imageHour = 4
+
+    static func scheduleAll() {
+        scheduleNLPBackfill()
+        scheduleImageBackfill()
+    }
+
+    static func scheduleNLPBackfill() {
+        submit(identifier: nlpTaskIdentifier, hour: nlpHour, requiresNetwork: false)
+    }
+
+    static func scheduleImageBackfill() {
+        submit(identifier: imageTaskIdentifier, hour: imageHour, requiresNetwork: true)
+    }
+
+    private static func submit(identifier: String, hour: Int, requiresNetwork: Bool) {
+        let request = BGProcessingTaskRequest(identifier: identifier)
+        request.requiresExternalPower = true
+        request.requiresNetworkConnectivity = requiresNetwork
+        request.earliestBeginDate = nextDate(atHour: hour)
+        do {
+            try BGTaskScheduler.shared.submit(request)
+            // swiftlint:disable:next line_length
+            log("NighttimeBackfill", "submit success id=\(identifier) at=\(request.earliestBeginDate?.description ?? "?")")
+        } catch {
+            log("NighttimeBackfill", "submit failed id=\(identifier) error=\(describe(error))")
+        }
+    }
+
+    static func runNLPBackfill() async {
+        await NLPProcessingCoordinator.processNewArticlesIfEnabled()
+    }
+
+    static func runImageBackfill() async {
+        let modeRaw = UserDefaults.standard.string(forKey: "FeedRefresh.PreloadArticleImagesMode")
+        let mode = modeRaw.flatMap(FetchImagesMode.init(rawValue:)) ?? .wifiOnly
+        switch mode {
+        case .off:
+            log("NighttimeBackfill", "image backfill skipped: preload disabled")
+            return
+        case .wifiOnly:
+            if await NetworkMonitor.currentPathIsExpensive() ?? true {
+                log("NighttimeBackfill", "image backfill skipped: expensive network path")
+                return
+            }
+        case .always:
+            break
+        }
+        await FeedManager.backfillRecentImages()
+    }
+
+    private static func nextDate(atHour hour: Int) -> Date {
+        let calendar = Calendar.current
+        let now = Date()
+        var components = calendar.dateComponents([.year, .month, .day], from: now)
+        components.hour = hour
+        components.minute = 0
+        components.second = 0
+        let candidate = calendar.date(from: components) ?? now
+        if candidate > now {
+            return candidate
+        }
+        return calendar.date(byAdding: .day, value: 1, to: candidate) ?? now.addingTimeInterval(86400)
+    }
+
+    private static func describe(_ error: Error) -> String {
+        let nsError = error as NSError
+        if nsError.domain == BGTaskScheduler.errorDomain,
+           let code = BGTaskScheduler.Error.Code(rawValue: nsError.code) {
+            switch code {
+            case .unavailable: return "unavailable (Background App Refresh disabled)"
+            case .tooManyPendingTaskRequests: return "tooManyPendingTaskRequests"
+            case .notPermitted: return "notPermitted (identifier missing from Info.plist?)"
+            case .immediateRunIneligible: return "immediateRunIneligible"
+            @unknown default: return "unknownBGCode(\(nsError.code))"
+            }
+        }
+        return "\(nsError.domain):\(nsError.code) \(nsError.localizedDescription)"
+    }
+}

--- a/App/Core/SummaryBackfillScheduler.swift
+++ b/App/Core/SummaryBackfillScheduler.swift
@@ -1,0 +1,81 @@
+@preconcurrency import BackgroundTasks
+import Foundation
+import Hanami
+
+/// Schedules a best-effort `BGProcessingTask` that pre-generates Apple
+/// Intelligence summary headlines so the Home cards load from cache instead
+/// of generating on launch. Submitted 30 minutes after a background feed
+/// refresh finishes and only runs while the device is charging.
+nonisolated enum SummaryBackfillScheduler {
+
+    static let taskIdentifier = "com.tsubuzaki.SakuraRSS.SummaryBackfill"
+
+    private static let postRefreshDelay: TimeInterval = 30 * 60
+
+    static func schedule(after delay: TimeInterval = postRefreshDelay) {
+        let request = BGProcessingTaskRequest(identifier: taskIdentifier)
+        request.requiresExternalPower = true
+        request.requiresNetworkConnectivity = false
+        request.earliestBeginDate = Date(timeIntervalSinceNow: delay)
+        do {
+            try BGTaskScheduler.shared.submit(request)
+            log("SummaryBackfill", "submit success at=\(request.earliestBeginDate?.description ?? "?")")
+        } catch {
+            log("SummaryBackfill", "submit failed error=\(describe(error))")
+        }
+    }
+
+    @MainActor
+    static func runBackfill(isCancelled: @Sendable () -> Bool = { false }) async {
+        let date = Date()
+        let manager = FeedManager()
+        for kind in [SummaryCardKind.whileYouSlept, .afternoonBrief, .todaysSummary] {
+            if isCancelled() { return }
+            await generateIfNeeded(kind: kind, manager: manager, date: date)
+        }
+    }
+
+    /// Generates and caches one summary kind, but only when it would actually
+    /// be displayable right now and isn't already cached for today.
+    @MainActor
+    private static func generateIfNeeded(
+        kind: SummaryCardKind,
+        manager: FeedManager,
+        date: Date
+    ) async {
+        guard kind.couldDisplay(in: manager) else {
+            log("SummaryBackfill", "skip kind=\(kind): not displayable now")
+            return
+        }
+        if let cached = try? DatabaseManager.shared.cachedSummaryHeadlines(
+            ofType: kind.cacheType, for: date
+        ), !cached.headlines.isEmpty {
+            log("SummaryBackfill", "skip kind=\(kind): already cached")
+            return
+        }
+        let generator = SummaryHeadlineGenerator(kind: kind, feedManager: manager)
+        switch await generator.generate(for: date) {
+        case .generated(let headlines, _, _):
+            log("SummaryBackfill", "generated kind=\(kind) headlines=\(headlines.count)")
+        case .noContent:
+            log("SummaryBackfill", "no content kind=\(kind)")
+        case .failed(let error):
+            log("SummaryBackfill", "failed kind=\(kind) error=\(error?.localizedDescription ?? "nil")")
+        }
+    }
+
+    private static func describe(_ error: Error) -> String {
+        let nsError = error as NSError
+        if nsError.domain == BGTaskScheduler.errorDomain,
+           let code = BGTaskScheduler.Error.Code(rawValue: nsError.code) {
+            switch code {
+            case .unavailable: return "unavailable (Background App Refresh disabled)"
+            case .tooManyPendingTaskRequests: return "tooManyPendingTaskRequests"
+            case .notPermitted: return "notPermitted (identifier missing from Info.plist?)"
+            case .immediateRunIneligible: return "immediateRunIneligible"
+            @unknown default: return "unknownBGCode(\(nsError.code))"
+            }
+        }
+        return "\(nsError.domain):\(nsError.code) \(nsError.localizedDescription)"
+    }
+}

--- a/App/Display Styles/Timeline/TimelineStyleView.swift
+++ b/App/Display Styles/Timeline/TimelineStyleView.swift
@@ -181,12 +181,16 @@ struct TimelineStyleView: View {
         if calendar.isDateInYesterday(date) {
             return String(localized: "Timeline.Yesterday", table: "Articles")
         }
+        return Self.daySectionFormatter.string(from: date)
+    }
+
+    private static let daySectionFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.doesRelativeDateFormatting = false
         formatter.dateStyle = .medium
         formatter.timeStyle = .none
-        return formatter.string(from: date)
-    }
+        return formatter
+    }()
 
     private func titleWeight(isFeatured: Bool, isRead: Bool) -> Font.Weight {
         if isFeatured { return .semibold }

--- a/App/Home/Summary Cards/SummaryHeadlineGenerator.swift
+++ b/App/Home/Summary Cards/SummaryHeadlineGenerator.swift
@@ -1,0 +1,302 @@
+import Foundation
+import NaturalLanguage
+import Hanami
+
+/// Headless headline-generation pipeline shared by `SummarySection` and the
+/// overnight summary background task. Gathers eligible articles for a summary
+/// kind, runs the on-device summarizer, and caches the resolved headlines so
+/// the UI can load them without regenerating on launch.
+struct SummaryHeadlineGenerator {
+
+    let kind: SummaryCardKind
+    let feedManager: FeedManager
+
+    static let snippetCharLimit = HeadlineSummarizer.snippetCharLimit
+    static let articleConsiderationLimit = HeadlineSummarizer.maxArticlesConsidered
+    static let topEntityHintLimit = 10
+
+    enum Outcome {
+        case noContent
+        case generated(headlines: [SummaryHeadline], partial: Bool, articleCount: Int)
+        case failed(Error?)
+    }
+
+    static var personalizationEnabled: Bool {
+        // Default ON: missing key means the user hasn't visited Settings yet.
+        (UserDefaults.standard.object(forKey: "Intelligence.Personalization.Enabled") as? Bool) ?? true
+    }
+
+    /// Runs the full pipeline and caches the result on success. Returns the
+    /// resolved headlines so callers can also drive UI state.
+    func generate(for date: Date) async -> Outcome {
+        let allArticles = eligibleArticles()
+        if allArticles.count < 3 {
+            log(
+                "Summary",
+                "no eligible articles to summarize (\(allArticles.count) after filter)"
+            )
+            return .noContent
+        }
+
+        let personalizationOn = Self.personalizationEnabled
+        let feedAccessCounts = loadFeedAccessCounts(personalizationOn: personalizationOn, for: date)
+        let sortedArticles = sortByEngagement(allArticles, feedAccessCounts: feedAccessCounts)
+        let articles = Array(sortedArticles.prefix(Self.articleConsiderationLimit))
+        let articlesByID = Dictionary(uniqueKeysWithValues: articles.map { ($0.id, $0) })
+        let preferredFeeds = preferredFeedIDs(from: articles, feedAccessCounts: feedAccessCounts)
+        let inputs = headlineInputs(for: articles, preferredFeedIDs: preferredFeeds)
+        let instructions = composeInstructions(
+            date: date,
+            personalizationOn: personalizationOn,
+            includePreferredHint: !preferredFeeds.isEmpty
+        )
+        let entityMap = await loadEntityMap(for: articles)
+
+        let outcome = await HeadlineSummarizer.summarize(
+            articles: inputs,
+            instructions: instructions,
+            entityMap: entityMap,
+            preferredFeedIDs: preferredFeeds
+        )
+        let resolved = resolveHeadlines(events: outcome.events, articlesByID: articlesByID)
+        guard !resolved.isEmpty else {
+            return .failed(outcome.error)
+        }
+        let partial = outcome.error != nil
+        try? DatabaseManager.shared.cacheSummaryHeadlines(
+            resolved, ofType: kind.cacheType, for: date,
+            partialGeneration: partial,
+            articleCountAtGeneration: articles.count
+        )
+        return .generated(headlines: resolved, partial: partial, articleCount: articles.count)
+    }
+
+    private func eligibleArticles() -> [Article] {
+        kind.articles(in: feedManager).filter { article in
+            guard isPlainRSSArticle(article) else { return false }
+            return BatchSummarizer.hasUsefulContent(
+                title: article.title,
+                summary: article.summary
+            )
+        }
+    }
+
+    private func loadFeedAccessCounts(personalizationOn: Bool, for date: Date) -> [Int64: Int] {
+        guard personalizationOn else { return [:] }
+        return (try? DatabaseManager.shared.feedAccessCounts(
+            since: date.addingTimeInterval(-30 * 24 * 3600)
+        )) ?? [:]
+    }
+
+    private func sortByEngagement(
+        _ articles: [Article],
+        feedAccessCounts: [Int64: Int]
+    ) -> [Article] {
+        guard !feedAccessCounts.isEmpty else { return articles }
+        return articles.sorted { lhs, rhs in
+            let lhsScore = feedAccessCounts[lhs.feedID] ?? 0
+            let rhsScore = feedAccessCounts[rhs.feedID] ?? 0
+            if lhsScore != rhsScore { return lhsScore > rhsScore }
+            let lhsDate = lhs.publishedDate ?? .distantPast
+            let rhsDate = rhs.publishedDate ?? .distantPast
+            return lhsDate > rhsDate
+        }
+    }
+
+    /// Top quartile (at minimum one) of distinct feeds present in the
+    /// candidate batch that have any positive access count. Returns empty
+    /// when personalization is off or the user has no engagement history.
+    private func preferredFeedIDs(
+        from articles: [Article],
+        feedAccessCounts: [Int64: Int]
+    ) -> Set<Int64> {
+        guard !feedAccessCounts.isEmpty else { return [] }
+        let candidateFeedIDs = Set(articles.map(\.feedID))
+        let scored: [(feedID: Int64, count: Int)] = candidateFeedIDs.compactMap { feedID in
+            let count = feedAccessCounts[feedID] ?? 0
+            guard count > 0 else { return nil }
+            return (feedID, count)
+        }
+        guard !scored.isEmpty else { return [] }
+        let sorted = scored.sorted { $0.count > $1.count }
+        let quartile = max(1, sorted.count / 4)
+        return Set(sorted.prefix(quartile).map(\.feedID))
+    }
+
+    private func composeInstructions(
+        date: Date,
+        personalizationOn: Bool,
+        includePreferredHint: Bool
+    ) -> String {
+        let template = String(localized: "SummaryHeadlines.SharedPrompt", table: "Home")
+        let timeWindow = String(localized: kind.timeWindowPhrase)
+        var baseInstructions = String(format: template, timeWindow)
+        if includePreferredHint {
+            let hint = String(localized: "SummaryHeadlines.PreferredHint", table: "Home")
+            baseInstructions = "\(baseInstructions)\n\n\(hint)"
+        }
+        let topicHints = topEntityHints(for: date, personalizationOn: personalizationOn)
+        guard !topicHints.isEmpty else { return baseInstructions }
+        let prefix = String(localized: "SummaryHeadlines.TopicHintPrefix", table: "Home")
+        return "\(baseInstructions)\n\n\(prefix)\n\(topicHints)"
+    }
+
+    /// Plain RSS only; skip research papers, social, video, podcast, and
+    /// aggregator feeds. Bluesky/Instagram/Fediverse are already excluded
+    /// by the `feedSection == .feeds` check (they have their own sections);
+    /// they're listed explicitly here as a guard against future provider
+    /// changes.
+    private func isPlainRSSArticle(_ article: Article) -> Bool {
+        guard let feed = feedManager.feed(forArticle: article) else { return false }
+        if feed.isResearchFeed
+            || feed.isBlueskyFeed
+            || feed.isInstagramFeed
+            || feed.isFediverseFeed {
+            return false
+        }
+        return feed.feedSection == .feeds
+    }
+
+    private func headlineInputs(
+        for articles: [Article],
+        preferredFeedIDs: Set<Int64>
+    ) -> [HeadlineSummarizer.Input] {
+        articles.map { article in
+            let feed = feedManager.feed(forArticle: article)
+            let baseSource = feed?.title ?? ""
+            let source = preferredFeedIDs.contains(article.feedID)
+                ? "\(baseSource) ★"
+                : baseSource
+            let raw = article.summary ?? article.content ?? ""
+            let snippet = String(raw.prefix(Self.snippetCharLimit))
+            let body = "ID: \(article.id)\n[\(source)] \(article.title)\n\(snippet)"
+            return HeadlineSummarizer.Input(
+                articleID: article.id,
+                feedID: article.feedID,
+                description: body
+            )
+        }
+    }
+
+    /// Returns a per-article entity name set for clustering. Reads from the
+    /// `nlp_entities` table when Content Insights has populated it, then
+    /// fills in any gaps with in-memory NLTagger extraction so clustering
+    /// works even when Content Insights is disabled.
+    private func loadEntityMap(for articles: [Article]) async -> [Int64: Set<String>] {
+        let ids = articles.map(\.id)
+        let dbMap = (try? DatabaseManager.shared.entities(forArticleIDs: ids)) ?? [:]
+        let missing = articles.filter { (dbMap[$0.id] ?? []).isEmpty }
+        if missing.isEmpty {
+            log("Summary", "entityMap: \(dbMap.count) articles from DB; no fallback needed")
+            return dbMap
+        }
+        log(
+            "Summary",
+            "entityMap: \(dbMap.count) from DB, \(missing.count) need in-memory extraction"
+        )
+        let extracted = await Self.extractEntitiesInMemory(for: missing)
+        var merged = dbMap
+        for (id, entities) in extracted where !entities.isEmpty {
+            merged[id] = entities
+        }
+        return merged
+    }
+
+    nonisolated private static func extractEntitiesInMemory(
+        for articles: [Article]
+    ) async -> [Int64: Set<String>] {
+        await Task.detached(priority: .utility) {
+            let tagger = NLTagger(tagSchemes: [.nameType])
+            var result: [Int64: Set<String>] = [:]
+            for article in articles {
+                let summary = article.summary ?? ""
+                let text = article.title + " " + summary
+                let entities = NLPProcessor.extractEntities(from: text, using: tagger)
+                result[article.id] = Set(entities.map { $0.name.lowercased() })
+            }
+            return result
+        }.value
+    }
+
+    /// Top topics + people. When personalization is on, ranked over the
+    /// articles the user has opened in the past 30 days; otherwise ranked
+    /// globally over the past week. Empty when Content Insights is off or
+    /// no entities were extracted.
+    private func topEntityHints(for date: Date, personalizationOn: Bool) -> String {
+        let defaults = UserDefaults.standard
+        guard defaults.bool(forKey: "Intelligence.ContentInsights.Enabled") else { return "" }
+
+        let database = DatabaseManager.shared
+        let topicsAndPlaces: [(name: String, count: Int)]
+        let people: [(name: String, count: Int)]
+        if personalizationOn {
+            let thirtyDaysAgo = date.addingTimeInterval(-30 * 24 * 3600)
+            topicsAndPlaces = (try? database.topAccessedEntities(
+                types: ["organization", "place"], since: thirtyDaysAgo, limit: Self.topEntityHintLimit
+            )) ?? []
+            people = (try? database.topAccessedEntities(
+                types: ["person"], since: thirtyDaysAgo, limit: Self.topEntityHintLimit
+            )) ?? []
+        } else {
+            let sevenDaysAgo = date.addingTimeInterval(-7 * 24 * 3600)
+            topicsAndPlaces = (try? database.topEntities(
+                types: ["organization", "place"], since: sevenDaysAgo, limit: Self.topEntityHintLimit
+            )) ?? []
+            people = (try? database.topEntities(
+                type: "person", since: sevenDaysAgo, limit: Self.topEntityHintLimit
+            )) ?? []
+        }
+
+        var ranked = topicsAndPlaces + people
+        ranked.sort { lhs, rhs in lhs.count > rhs.count }
+        let trimmed = Array(ranked.prefix(Self.topEntityHintLimit))
+        return trimmed.map(\.name).joined(separator: ", ")
+    }
+
+    private func resolveHeadlines(
+        events: [HeadlineSummarizer.ResolvedEvent],
+        articlesByID: [Int64: Article]
+    ) -> [SummaryHeadline] {
+        events.compactMap { event in
+            guard isPlausibleHeadline(event.headline) else { return nil }
+            let groupArticles = event.articleIDs.compactMap { articlesByID[$0] }
+            guard !groupArticles.isEmpty else { return nil }
+            let articleIDs = groupArticles.map(\.id)
+            var feedIDs: [Int64] = []
+            var seenFeedIDs: Set<Int64> = []
+            for article in groupArticles where !seenFeedIDs.contains(article.feedID) {
+                seenFeedIDs.insert(article.feedID)
+                feedIDs.append(article.feedID)
+            }
+            return SummaryHeadline(
+                headline: event.headline,
+                articleIDs: articleIDs,
+                thumbnailURL: pickThumbnail(from: groupArticles),
+                feedIDs: feedIDs
+            )
+        }
+    }
+
+    /// Rejects topic-list outputs the model occasionally regurgitates from
+    /// the priority hint section.
+    private func isPlausibleHeadline(_ text: String) -> Bool {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+        let separators = CharacterSet(charactersIn: ",;・、")
+        let segments = trimmed
+            .components(separatedBy: separators)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        guard segments.count >= 3 else { return true }
+        let shortSegments = segments.filter { segment in
+            segment.split { $0.isWhitespace }.count <= 2
+        }
+        return Double(shortSegments.count) / Double(segments.count) < 0.7
+    }
+
+    private func pickThumbnail(from articles: [Article]) -> String? {
+        let candidates = articles.compactMap { $0.imageURL }
+            .filter { !$0.isEmpty }
+        return candidates.randomElement()
+    }
+}

--- a/App/Home/Summary Cards/SummarySection+Generation.swift
+++ b/App/Home/Summary Cards/SummarySection+Generation.swift
@@ -1,139 +1,26 @@
 import Foundation
-import NaturalLanguage
 import SwiftUI
 import Hanami
 
 extension SummarySection {
 
-    static let snippetCharLimit = HeadlineSummarizer.snippetCharLimit
-    static let articleConsiderationLimit = HeadlineSummarizer.maxArticlesConsidered
-    static let topEntityHintLimit = 10
-
     func generateHeadlines(for date: Date) async {
-        let allArticles = eligibleArticles()
-        if allArticles.count < 3 {
-            log(
-                "Summary",
-                "no eligible articles to summarize (\(allArticles.count) after filter); marking unavailable"
-            )
-            await markNoContentAvailable()
-            return
-        }
-
         await MainActor.run { isGenerating = true }
 
-        let personalizationOn = Self.personalizationEnabled
-        let feedAccessCounts = loadFeedAccessCounts(personalizationOn: personalizationOn, for: date)
-        let sortedArticles = sortByEngagement(
-            allArticles,
-            feedAccessCounts: feedAccessCounts
-        )
-        let articles = Array(sortedArticles.prefix(Self.articleConsiderationLimit))
-        let articlesByID = Dictionary(uniqueKeysWithValues: articles.map { ($0.id, $0) })
-        let preferredFeeds = preferredFeedIDs(
-            from: articles,
-            feedAccessCounts: feedAccessCounts
-        )
-        let inputs = headlineInputs(for: articles, preferredFeedIDs: preferredFeeds)
-        let instructions = composeInstructions(
-            date: date,
-            personalizationOn: personalizationOn,
-            includePreferredHint: !preferredFeeds.isEmpty
-        )
-        let entityMap = await loadEntityMap(for: articles)
-
-        let outcome = await HeadlineSummarizer.summarize(
-            articles: inputs,
-            instructions: instructions,
-            entityMap: entityMap,
-            preferredFeedIDs: preferredFeeds
-        )
-        let resolved = resolveHeadlines(events: outcome.events, articlesByID: articlesByID)
-        if resolved.isEmpty {
-            await markGenerationFailed(error: outcome.error)
-            return
-        }
-        await applyGenerated(
-            resolved,
-            for: date,
-            partialGeneration: outcome.error != nil,
-            articleCountAtGeneration: articles.count
-        )
-    }
-
-    static var personalizationEnabled: Bool {
-        // Default ON: missing key means the user hasn't visited Settings yet.
-        (UserDefaults.standard.object(forKey: "Intelligence.Personalization.Enabled") as? Bool) ?? true
-    }
-
-    private func eligibleArticles() -> [Article] {
-        kind.articles(in: feedManager).filter { article in
-            guard isPlainRSSArticle(article) else { return false }
-            return BatchSummarizer.hasUsefulContent(
-                title: article.title,
-                summary: article.summary
+        let generator = SummaryHeadlineGenerator(kind: kind, feedManager: feedManager)
+        switch await generator.generate(for: date) {
+        case .noContent:
+            await markNoContentAvailable()
+        case .failed(let error):
+            await markGenerationFailed(error: error)
+        case .generated(let resolved, let partial, let count):
+            await applyGenerated(
+                resolved,
+                for: date,
+                partialGeneration: partial,
+                articleCountAtGeneration: count
             )
         }
-    }
-
-    private func loadFeedAccessCounts(personalizationOn: Bool, for date: Date) -> [Int64: Int] {
-        guard personalizationOn else { return [:] }
-        return (try? DatabaseManager.shared.feedAccessCounts(
-            since: date.addingTimeInterval(-30 * 24 * 3600)
-        )) ?? [:]
-    }
-
-    private func sortByEngagement(
-        _ articles: [Article],
-        feedAccessCounts: [Int64: Int]
-    ) -> [Article] {
-        guard !feedAccessCounts.isEmpty else { return articles }
-        return articles.sorted { lhs, rhs in
-            let lhsScore = feedAccessCounts[lhs.feedID] ?? 0
-            let rhsScore = feedAccessCounts[rhs.feedID] ?? 0
-            if lhsScore != rhsScore { return lhsScore > rhsScore }
-            let lhsDate = lhs.publishedDate ?? .distantPast
-            let rhsDate = rhs.publishedDate ?? .distantPast
-            return lhsDate > rhsDate
-        }
-    }
-
-    /// Top quartile (at minimum one) of distinct feeds present in the
-    /// candidate batch that have any positive access count. Returns empty
-    /// when personalization is off or the user has no engagement history.
-    private func preferredFeedIDs(
-        from articles: [Article],
-        feedAccessCounts: [Int64: Int]
-    ) -> Set<Int64> {
-        guard !feedAccessCounts.isEmpty else { return [] }
-        let candidateFeedIDs = Set(articles.map(\.feedID))
-        let scored: [(feedID: Int64, count: Int)] = candidateFeedIDs.compactMap { feedID in
-            let count = feedAccessCounts[feedID] ?? 0
-            guard count > 0 else { return nil }
-            return (feedID, count)
-        }
-        guard !scored.isEmpty else { return [] }
-        let sorted = scored.sorted { $0.count > $1.count }
-        let quartile = max(1, sorted.count / 4)
-        return Set(sorted.prefix(quartile).map(\.feedID))
-    }
-
-    private func composeInstructions(
-        date: Date,
-        personalizationOn: Bool,
-        includePreferredHint: Bool
-    ) -> String {
-        let template = String(localized: "SummaryHeadlines.SharedPrompt", table: "Home")
-        let timeWindow = String(localized: kind.timeWindowPhrase)
-        var baseInstructions = String(format: template, timeWindow)
-        if includePreferredHint {
-            let hint = String(localized: "SummaryHeadlines.PreferredHint", table: "Home")
-            baseInstructions = "\(baseInstructions)\n\n\(hint)"
-        }
-        let topicHints = topEntityHints(for: date, personalizationOn: personalizationOn)
-        guard !topicHints.isEmpty else { return baseInstructions }
-        let prefix = String(localized: "SummaryHeadlines.TopicHintPrefix", table: "Home")
-        return "\(baseInstructions)\n\n\(prefix)\n\(topicHints)"
     }
 
     private func applyGenerated(
@@ -154,11 +41,6 @@ extension SummarySection {
             hasSummary = true
             cachedIsPartial = partialGeneration
             cachedArticleCountAtGeneration = articleCountAtGeneration
-            try? DatabaseManager.shared.cacheSummaryHeadlines(
-                resolved, ofType: kind.cacheType, for: date,
-                partialGeneration: partialGeneration,
-                articleCountAtGeneration: articleCountAtGeneration
-            )
         }
     }
 
@@ -185,164 +67,5 @@ extension SummarySection {
             generationFailed = true
             generationError = String(localized: "SummaryHeadlines.NoEventsExtracted", table: "Home")
         }
-    }
-
-    /// Plain RSS only; skip research papers, social, video, podcast, and
-    /// aggregator feeds. Bluesky/Instagram/Fediverse are already excluded
-    /// by the `feedSection == .feeds` check (they have their own sections);
-    /// they're listed explicitly here as a guard against future provider
-    /// changes.
-    private func isPlainRSSArticle(_ article: Article) -> Bool {
-        guard let feed = feedManager.feed(forArticle: article) else { return false }
-        if feed.isResearchFeed
-            || feed.isBlueskyFeed
-            || feed.isInstagramFeed
-            || feed.isFediverseFeed {
-            return false
-        }
-        return feed.feedSection == .feeds
-    }
-
-    private func headlineInputs(
-        for articles: [Article],
-        preferredFeedIDs: Set<Int64>
-    ) -> [HeadlineSummarizer.Input] {
-        articles.map { article in
-            let feed = feedManager.feed(forArticle: article)
-            let baseSource = feed?.title ?? ""
-            let source = preferredFeedIDs.contains(article.feedID)
-                ? "\(baseSource) ★"
-                : baseSource
-            let raw = article.summary ?? article.content ?? ""
-            let snippet = String(raw.prefix(Self.snippetCharLimit))
-            let body = "ID: \(article.id)\n[\(source)] \(article.title)\n\(snippet)"
-            return HeadlineSummarizer.Input(
-                articleID: article.id,
-                feedID: article.feedID,
-                description: body
-            )
-        }
-    }
-
-    /// Returns a per-article entity name set for clustering. Reads from the
-    /// `nlp_entities` table when Content Insights has populated it, then
-    /// fills in any gaps with in-memory NLTagger extraction so clustering
-    /// works even when Content Insights is disabled.
-    private func loadEntityMap(for articles: [Article]) async -> [Int64: Set<String>] {
-        let ids = articles.map(\.id)
-        let dbMap = (try? DatabaseManager.shared.entities(forArticleIDs: ids)) ?? [:]
-        let missing = articles.filter { (dbMap[$0.id] ?? []).isEmpty }
-        if missing.isEmpty {
-            log("Summary", "entityMap: \(dbMap.count) articles from DB; no fallback needed")
-            return dbMap
-        }
-        log(
-            "Summary",
-            "entityMap: \(dbMap.count) from DB, \(missing.count) need in-memory extraction"
-        )
-        let extracted = await Self.extractEntitiesInMemory(for: missing)
-        var merged = dbMap
-        for (id, entities) in extracted where !entities.isEmpty {
-            merged[id] = entities
-        }
-        return merged
-    }
-
-    nonisolated private static func extractEntitiesInMemory(
-        for articles: [Article]
-    ) async -> [Int64: Set<String>] {
-        await Task.detached(priority: .utility) {
-            let tagger = NLTagger(tagSchemes: [.nameType])
-            var result: [Int64: Set<String>] = [:]
-            for article in articles {
-                let summary = article.summary ?? ""
-                let text = article.title + " " + summary
-                let entities = NLPProcessor.extractEntities(from: text, using: tagger)
-                result[article.id] = Set(entities.map { $0.name.lowercased() })
-            }
-            return result
-        }.value
-    }
-
-    /// Top topics + people. When personalization is on, ranked over the
-    /// articles the user has opened in the past 30 days; otherwise ranked
-    /// globally over the past week. Empty when Content Insights is off or
-    /// no entities were extracted.
-    private func topEntityHints(for date: Date, personalizationOn: Bool) -> String {
-        let defaults = UserDefaults.standard
-        guard defaults.bool(forKey: "Intelligence.ContentInsights.Enabled") else { return "" }
-
-        let database = DatabaseManager.shared
-        let topicsAndPlaces: [(name: String, count: Int)]
-        let people: [(name: String, count: Int)]
-        if personalizationOn {
-            let thirtyDaysAgo = date.addingTimeInterval(-30 * 24 * 3600)
-            topicsAndPlaces = (try? database.topAccessedEntities(
-                types: ["organization", "place"], since: thirtyDaysAgo, limit: Self.topEntityHintLimit
-            )) ?? []
-            people = (try? database.topAccessedEntities(
-                types: ["person"], since: thirtyDaysAgo, limit: Self.topEntityHintLimit
-            )) ?? []
-        } else {
-            let sevenDaysAgo = date.addingTimeInterval(-7 * 24 * 3600)
-            topicsAndPlaces = (try? database.topEntities(
-                types: ["organization", "place"], since: sevenDaysAgo, limit: Self.topEntityHintLimit
-            )) ?? []
-            people = (try? database.topEntities(
-                type: "person", since: sevenDaysAgo, limit: Self.topEntityHintLimit
-            )) ?? []
-        }
-
-        var ranked = topicsAndPlaces + people
-        ranked.sort { lhs, rhs in lhs.count > rhs.count }
-        let trimmed = Array(ranked.prefix(Self.topEntityHintLimit))
-        return trimmed.map(\.name).joined(separator: ", ")
-    }
-
-    private func resolveHeadlines(
-        events: [HeadlineSummarizer.ResolvedEvent],
-        articlesByID: [Int64: Article]
-    ) -> [SummaryHeadline] {
-        events.compactMap { event in
-            guard isPlausibleHeadline(event.headline) else { return nil }
-            let groupArticles = event.articleIDs.compactMap { articlesByID[$0] }
-            guard !groupArticles.isEmpty else { return nil }
-            let articleIDs = groupArticles.map(\.id)
-            var feedIDs: [Int64] = []
-            var seenFeedIDs: Set<Int64> = []
-            for article in groupArticles where !seenFeedIDs.contains(article.feedID) {
-                seenFeedIDs.insert(article.feedID)
-                feedIDs.append(article.feedID)
-            }
-            return SummaryHeadline(
-                headline: event.headline,
-                articleIDs: articleIDs,
-                thumbnailURL: pickThumbnail(from: groupArticles),
-                feedIDs: feedIDs
-            )
-        }
-    }
-
-    /// Rejects topic-list outputs the model occasionally regurgitates from
-    /// the priority hint section.
-    private func isPlausibleHeadline(_ text: String) -> Bool {
-        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return false }
-        let separators = CharacterSet(charactersIn: ",;・、")
-        let segments = trimmed
-            .components(separatedBy: separators)
-            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-            .filter { !$0.isEmpty }
-        guard segments.count >= 3 else { return true }
-        let shortSegments = segments.filter { segment in
-            segment.split { $0.isWhitespace }.count <= 2
-        }
-        return Double(shortSegments.count) / Double(segments.count) < 0.7
-    }
-
-    private func pickThumbnail(from articles: [Article]) -> String? {
-        let candidates = articles.compactMap { $0.imageURL }
-            .filter { !$0.isEmpty }
-        return candidates.randomElement()
     }
 }

--- a/App/Info.plist
+++ b/App/Info.plist
@@ -12,6 +12,8 @@
 		<string>com.tsubuzaki.SakuraRSS.RefreshFeeds.instagram</string>
 		<string>com.tsubuzaki.SakuraRSS.iCloudBackup</string>
 		<string>com.tsubuzaki.SakuraRSS.AutomaticCleanup</string>
+		<string>com.tsubuzaki.SakuraRSS.NLPBackfill</string>
+		<string>com.tsubuzaki.SakuraRSS.ImageBackfill</string>
 	</array>
 	<key>CFBundleDocumentTypes</key>
 	<array>

--- a/App/Info.plist
+++ b/App/Info.plist
@@ -14,6 +14,7 @@
 		<string>com.tsubuzaki.SakuraRSS.AutomaticCleanup</string>
 		<string>com.tsubuzaki.SakuraRSS.NLPBackfill</string>
 		<string>com.tsubuzaki.SakuraRSS.ImageBackfill</string>
+		<string>com.tsubuzaki.SakuraRSS.SummaryBackfill</string>
 	</array>
 	<key>CFBundleDocumentTypes</key>
 	<array>

--- a/App/Shared/SelectableText.swift
+++ b/App/Shared/SelectableText.swift
@@ -105,10 +105,13 @@ struct SelectableText: UIViewRepresentable {
         return attributed
     }
 
+    nonisolated private static let supSubRegex = try? NSRegularExpression(
+        pattern: #"\{\{(SUP|SUB)\}\}(.+?)\{\{/(SUP|SUB)\}\}"#
+    )
+
     /// Splits around `{{SUP/SUB}}` markers and parses remaining segments as Markdown.
     private func parseLine(_ text: String, baseFont: UIFont) -> NSAttributedString {
-        let supSubPattern = #"\{\{(SUP|SUB)\}\}(.+?)\{\{/(SUP|SUB)\}\}"#
-        guard let supSubRegex = try? NSRegularExpression(pattern: supSubPattern) else {
+        guard let supSubRegex = Self.supSubRegex else {
             return parseMarkdown(text, baseFont: baseFont)
         }
 

--- a/Hanami/Feed Manager/FeedManager+BoundedRefresh.swift
+++ b/Hanami/Feed Manager/FeedManager+BoundedRefresh.swift
@@ -116,7 +116,10 @@ public extension FeedManager {
         skipImageFetch: Bool,
         skipImagePreload: Bool
     ) async {
-        let eligible = feeds.filter(category.includes)
+        let matching = feeds.filter(category.includes)
+        let cooldownRaw = UserDefaults.standard.string(forKey: "BackgroundRefresh.Cooldown")
+        let cooldownSeconds = (cooldownRaw.flatMap(FeedRefreshCooldown.init(rawValue:)) ?? .fiveMinutes).seconds
+        let eligible = filterByRefreshCooldown(matching, cooldownSeconds: cooldownSeconds)
         guard !eligible.isEmpty else {
             log("FeedRefresh.Category", "category=\(category.rawValue) no feeds eligible")
             return

--- a/Hanami/Feed Manager/FeedManager+ImagePreload.swift
+++ b/Hanami/Feed Manager/FeedManager+ImagePreload.swift
@@ -49,6 +49,24 @@ public extension FeedManager {
         }
     }
 
+    /// Best-effort backfill of cached images for recently published articles.
+    /// `preloadImages` skips anything already cached, so this only fetches gaps.
+    nonisolated static func backfillRecentImages(
+        since cutoff: Date = Date().addingTimeInterval(-14 * 24 * 60 * 60),
+        limit: Int = 500
+    ) async {
+        let database = DatabaseManager.shared
+        let articles = (try? database.allArticles(since: cutoff, limit: limit)) ?? []
+        let urls = articles.compactMap { $0.imageURL }
+        guard !urls.isEmpty else {
+            log("ImageBackfill", "no candidate image URLs")
+            return
+        }
+        log("ImageBackfill", "begin candidates=\(urls.count)")
+        await preloadImages(urls: urls)
+        log("ImageBackfill", "end")
+    }
+
     nonisolated private static func downloadAndCacheImage(url: URL) async {
         let urlString = url.absoluteString
         let database = DatabaseManager.shared

--- a/Hanami/Feed Manager/FeedManager+Refresh.swift
+++ b/Hanami/Feed Manager/FeedManager+Refresh.swift
@@ -202,11 +202,18 @@ public extension FeedManager {
         skipAuthenticatedFetchers: Bool,
         cooldownSeconds: TimeInterval?
     ) -> [Feed] {
+        let candidates = skipAuthenticatedFetchers
+            ? feeds.filter { !$0.isXFeed && !$0.isInstagramFeed }
+            : feeds
+        return filterByRefreshCooldown(candidates, cooldownSeconds: cooldownSeconds)
+    }
+
+    func filterByRefreshCooldown(
+        _ feeds: [Feed],
+        cooldownSeconds: TimeInterval?
+    ) -> [Feed] {
         let now = Date()
         return feeds.filter { feed in
-            if skipAuthenticatedFetchers, feed.isXFeed || feed.isInstagramFeed {
-                return false
-            }
             let domainTimeout = RefreshTimeoutDomains.refreshTimeout(for: feed.domain)
             let effectiveCooldown = domainTimeout ?? cooldownSeconds
             if let effectiveCooldown,
@@ -299,10 +306,21 @@ public extension FeedManager {
             generateAcronymIcon(feedID: feed.id, title: feed.title)
         }
 
+        let maxConcurrent = FeedRefreshQueueLimits.default
         await withTaskGroup(of: Void.self) { group in
-            for feed in unfetched {
+            var iterator = unfetched.makeIterator()
+            var submitted = 0
+            while submitted < maxConcurrent, let feed = iterator.next() {
                 group.addTask {
                     try? await self.refreshFeed(feed, reloadData: false)
+                }
+                submitted += 1
+            }
+            while await group.next() != nil {
+                if let feed = iterator.next() {
+                    group.addTask {
+                        try? await self.refreshFeed(feed, reloadData: false)
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Battery usage audit

I audited the app for the main battery-draining vectors (timers/polling, background refresh & networking, continuous rendering). The app is already well-optimized in most areas — Low Power Mode is respected, background image preload is gated on plugged-in + Wi‑Fi, foreground refresh respects cooldowns and per-domain timeouts, and `IconProgressBadge` skips its periodic timeline when no cooldown is active. The audit surfaced two genuine, low-risk wins, which this PR addresses.

### Changes

**1. Background category refresh now respects the cooldown setting**
`refreshFeeds(in:)` previously refreshed *every* feed in a category on every scheduled wake, ignoring how recently each feed was fetched — even though a `BackgroundRefresh.Cooldown` setting already exists (and `FeedRefreshCooldown` is documented as applying to *automatic* refreshes). Foreground refresh honored it; background refresh did not.

Now scheduled background refreshes filter out feeds fetched within the cooldown window (also honoring per-domain refresh timeouts), avoiding redundant network + CPU work when a background task fires shortly after a foreground refresh. The cooldown filter was extracted into a reusable `filterByRefreshCooldown` helper so foreground and background share identical logic.

**2. Bounded concurrency in `refreshUnfetchedFeeds`**
This ran an unbounded `withTaskGroup` — one simultaneous network request + parse pipeline per unfetched feed. After a large OPML import followed by a foreground re-entry, that meant dozens/hundreds of concurrent requests, spiking the radio and CPU. It now uses the same sliding-window concurrency limit (`FeedRefreshQueueLimits.default`) as the other refresh paths.

### Deliberately not changed
- **Foreground scoped refresh concurrency (`fast = 24`)** — for user-initiated pull-to-refresh, higher concurrency finishes faster and lets the radio power down sooner, so lowering it is neutral-to-worse for battery.
- **`DeloreanClock` 30 Hz loop** — only runs behind the `sakura://delorean` debug deep link; not a real-world drain.
- **`.repeatForever` animations and 1 Hz `TimelineView`s** — these are tied to active states (edit-mode wiggle, transcription, playback) and 1 Hz updates are cheap; standard, expected behavior.

No build tooling is available in this environment, so changes were validated by inspection: they reuse existing public symbols/patterns, the `filterFeedsForRefresh` refactor is behavior-preserving, and all new lines are within the SwiftLint line-length limit.

https://claude.ai/code/session_018gvUqCxCwUaicKpVfoHNrW

---
_Generated by [Claude Code](https://claude.ai/code/session_018gvUqCxCwUaicKpVfoHNrW)_