### PR TITLE
Fix YouTube player stuck at spinner by arming autoplay on load

### DIFF
--- a/App/YouTube Player/YouTubePlayerWebView+Coordinator.swift
+++ b/App/YouTube Player/YouTubePlayerWebView+Coordinator.swift
@@ -7,6 +7,7 @@ extension YouTubePlayerWebView {
 
     @MainActor
     final class Coordinator: NSObject, WKNavigationDelegate, WKScriptMessageHandler {
+        let autoplay: Bool
         @Binding var isPlaying: Bool
         @Binding var isAd: Bool
         @Binding var isAdSkippable: Bool
@@ -18,8 +19,10 @@ extension YouTubePlayerWebView {
         let onDurationUpdate: ((TimeInterval) -> Void)?
         private var chapterRetryCount = 0
         private var chaptersLoaded = false
+        private var hasArmedAutoplay = false
 
         init(
+            autoplay: Bool,
             isPlaying: Binding<Bool>,
             isAd: Binding<Bool>,
             isAdSkippable: Binding<Bool>,
@@ -30,6 +33,7 @@ extension YouTubePlayerWebView {
             onTimeUpdate: ((TimeInterval) -> Void)?,
             onDurationUpdate: ((TimeInterval) -> Void)?
         ) {
+            self.autoplay = autoplay
             _isPlaying = isPlaying
             _isAd = isAd
             _isAdSkippable = isAdSkippable
@@ -44,9 +48,23 @@ extension YouTubePlayerWebView {
         func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
             injectStyles(into: webView)
             unmuteVideo(in: webView)
+            armAutoplayIfNeeded(in: webView)
             if !chaptersLoaded {
                 extractChapters(from: webView)
             }
+        }
+
+        /// YouTube's web player does not reliably auto-start in a WKWebView with
+        /// user interaction disabled, so the player can sit at the spinner
+        /// forever. Arm the autoplay armer once the page loads so it actively
+        /// plays the `<video>` (including a preroll ad) as soon as it is ready.
+        private func armAutoplayIfNeeded(in webView: WKWebView) {
+            guard autoplay, !hasArmedAutoplay else { return }
+            hasArmedAutoplay = true
+            webView.evaluateJavaScript(
+                "window.__yt && window.__yt.armAutoplay && window.__yt.armAutoplay(12000);",
+                completionHandler: nil
+            )
         }
 
         private func extractChapters(from webView: WKWebView) {

--- a/App/YouTube Player/YouTubePlayerWebView+Coordinator.swift
+++ b/App/YouTube Player/YouTubePlayerWebView+Coordinator.swift
@@ -54,10 +54,6 @@ extension YouTubePlayerWebView {
             }
         }
 
-        /// YouTube's web player does not reliably auto-start in a WKWebView with
-        /// user interaction disabled, so the player can sit at the spinner
-        /// forever. Arm the autoplay armer once the page loads so it actively
-        /// plays the `<video>` (including a preroll ad) as soon as it is ready.
         private func armAutoplayIfNeeded(in webView: WKWebView) {
             guard autoplay, !hasArmedAutoplay else { return }
             hasArmedAutoplay = true

--- a/App/YouTube Player/YouTubePlayerWebView.swift
+++ b/App/YouTube Player/YouTubePlayerWebView.swift
@@ -21,6 +21,7 @@ struct YouTubePlayerWebView: UIViewRepresentable {
 
     func makeCoordinator() -> Coordinator {
         Coordinator(
+            autoplay: autoplay,
             isPlaying: $isPlaying,
             isAd: $isAd,
             isAdSkippable: $isAdSkippable,


### PR DESCRIPTION
## Problem

The YouTube player sometimes sat at the loading spinner forever and never started playing.

The spinner overlay shows while `!hasStartedPlaying`, and `hasStartedPlaying` only flips to `true` once a `play`/`playing` event arrives from the page. On the initial load with `autoplay = true`, the `autoplayBlocker` is not injected and the `autoplayArmer` *is* injected — but **nothing ever called `window.__yt.armAutoplay()` on first load**. `armAutoplay` was only invoked on ad transitions, skip-ad, and PiP.

That left first-play entirely up to YouTube's own web player auto-starting. Because the WKWebView has `isUserInteractionEnabled = false` (so a tap-to-play gesture is impossible), that auto-start is unreliable and the player would stay at the spinner.

## Fix

Arm the existing autoplay armer once the page finishes loading (gated on the `autoplay` flag). The armer's tick loop already scans for the `<video>` and calls `play()` repeatedly for the armed window, so it actively starts the video as soon as it is ready — including a preroll ad, after which the existing ad→content re-arm logic takes over.

- `YouTubePlayerWebView.makeCoordinator()` now passes `autoplay` to the `Coordinator`.
- `Coordinator` stores `autoplay` and, in `webView(_:didFinish:)`, calls a new one-shot `armAutoplayIfNeeded(in:)` that evaluates `window.__yt.armAutoplay(12000)`.

Programmatic play is permitted because the WebView config sets `mediaTypesRequiringUserActionForPlayback = []`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014UdKHLNeqivYt52gnwgCo1)_