### PR TITLE
Request Focus status permission when opening Focus settings

### DIFF
--- a/App/App.swift
+++ b/App/App.swift
@@ -53,6 +53,7 @@ struct SakuraRSSApp: App {
                         )
                     }
                     UserDefaults.standard.set(false, forKey: "App.StartupInProgress")
+                    feedManager.reconcileFocusWithSystemStatus()
                     feedManager.updateBadgeCount()
                     requestReviewIfNeeded()
                     reindexSpotlightIfSchemaChanged()
@@ -68,6 +69,7 @@ struct SakuraRSSApp: App {
                     feedManager.updateBadgeCount()
                     feedManager.reloadRefreshTimestampsFromDefaults()
                     feedManager.reloadFocusFromDefaults()
+                    feedManager.reconcileFocusWithSystemStatus()
                     let now = Date()
                     if let last = lastForegroundWorkAt, now.timeIntervalSince(last) < 5 * 60 {
                         return

--- a/App/Info.plist
+++ b/App/Info.plist
@@ -66,6 +66,8 @@
 			</array>
 		</dict>
 	</array>
+	<key>NSFocusStatusUsageDescription</key>
+	<string>Sakura uses your Focus status to keep your Focus filters in sync while a Focus is on.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Location is used to show local weather on the Today tab.</string>
 	<key>LSApplicationQueriesSchemes</key>

--- a/App/InfoPlist.xcstrings
+++ b/App/InfoPlist.xcstrings
@@ -67,6 +67,71 @@
         }
       }
     },
+    "NSFocusStatusUsageDescription" : {
+      "comment" : "Privacy - Focus Status Usage Description",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sakura verwendet deinen Fokus-Status, um deine Fokusfilter synchron zu halten, während ein Fokus aktiv ist."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sakura uses your Focus status to keep your Focus filters in sync while a Focus is on."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sakura utilise votre statut de concentration pour garder vos filtres de concentration synchronisés lorsqu’un mode de concentration est activé."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sakura usa il tuo stato Full Immersion per mantenere sincronizzati i filtri Full Immersion quando una Full Immersion è attiva."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sakuraは、集中モードがオンの間に集中モードのフィルタを同期させるため、集中モードの状況を使用します。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sakura는 집중 모드가 켜져 있는 동안 집중 모드 필터를 동기화하기 위해 집중 모드 상태를 사용합니다."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sakura gebruikt je focusstatus om je focusfilters synchroon te houden terwijl een focus actief is."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sakura sử dụng trạng thái Tập trung của bạn để giữ các bộ lọc Tập trung được đồng bộ khi chế độ Tập trung đang bật."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sakura 使用你的专注模式状态，以在专注模式开启时保持专注模式过滤器同步。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sakura 會使用你的專注模式狀態，以在專注模式開啟時保持專注模式過濾器同步。"
+          }
+        }
+      }
+    },
     "NSLocationWhenInUseUsageDescription" : {
       "comment" : "Privacy - Location When In Use Usage Description",
       "localizations" : {

--- a/App/Profile/Focus/FocusSettingsView.swift
+++ b/App/Profile/Focus/FocusSettingsView.swift
@@ -4,6 +4,8 @@ import Hanami
 struct FocusSettingsView: View {
 
     @Environment(FeedManager.self) private var feedManager
+    @Environment(\.scenePhase) private var scenePhase
+    @State private var focusStatusAuthorization = FocusStatusAuthorization()
 
     var body: some View {
         List {
@@ -11,6 +13,17 @@ struct FocusSettingsView: View {
                 Text(String(localized: "Focus.Settings.Explanation", table: "Settings"))
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
+            }
+
+            if focusStatusAuthorization.isDenied {
+                Section {
+                    Label(
+                        String(localized: "Focus.Settings.PermissionDenied", table: "Settings"),
+                        systemImage: "exclamationmark.triangle.fill"
+                    )
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                }
             }
 
             if feedManager.isFocusActive {
@@ -41,5 +54,14 @@ struct FocusSettingsView: View {
         .sakuraBackground()
         .navigationTitle(String(localized: "Section.Focus", table: "Settings"))
         .toolbarTitleDisplayMode(.inline)
+        .task {
+            await focusStatusAuthorization.requestIfNeeded()
+            feedManager.reconcileFocusWithSystemStatus()
+        }
+        .onChange(of: scenePhase) {
+            if scenePhase == .active {
+                focusStatusAuthorization.refresh()
+            }
+        }
     }
 }

--- a/App/Profile/Focus/FocusStatusAuthorization.swift
+++ b/App/Profile/Focus/FocusStatusAuthorization.swift
@@ -1,0 +1,31 @@
+import Intents
+import Observation
+
+@MainActor
+@Observable
+final class FocusStatusAuthorization {
+
+    private(set) var status: INFocusStatusAuthorizationStatus
+
+    init() {
+        status = INFocusStatusCenter.default.authorizationStatus
+    }
+
+    var isDenied: Bool {
+        status == .denied || status == .restricted
+    }
+
+    func requestIfNeeded() async {
+        refresh()
+        guard status == .notDetermined else { return }
+        status = await withCheckedContinuation { continuation in
+            INFocusStatusCenter.default.requestAuthorization { newStatus in
+                continuation.resume(returning: newStatus)
+            }
+        }
+    }
+
+    func refresh() {
+        status = INFocusStatusCenter.default.authorizationStatus
+    }
+}

--- a/Hanami/Feed Manager/FeedManager+Focus.swift
+++ b/Hanami/Feed Manager/FeedManager+Focus.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Intents
 
 public extension FeedManager {
 
@@ -52,5 +53,16 @@ public extension FeedManager {
         guard loaded != activeFocus else { return }
         activeFocus = loaded
         bumpDataRevision()
+    }
+
+    /// Clears a stale focus filter when the system reports no Focus is on,
+    /// e.g. when the deactivation `perform()` call was missed while the app
+    /// was terminated. Requires Focus status authorization.
+    func reconcileFocusWithSystemStatus() {
+        guard INFocusStatusCenter.default.authorizationStatus == .authorized else { return }
+        guard INFocusStatusCenter.default.focusStatus.isFocused == false else { return }
+        guard activeFocus.isActive else { return }
+        FocusFilterStore.clear()
+        reloadFocusFromDefaults()
     }
 }

--- a/Shared/Entitlements.entitlements
+++ b/Shared/Entitlements.entitlements
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.focus-status</key>
+	<true/>
 	<key>com.apple.developer.icloud-container-identifiers</key>
 	<array>
 		<string>iCloud.com.tsubuzaki.SakuraRSS</string>

--- a/Shared/Strings/Settings.xcstrings
+++ b/Shared/Strings/Settings.xcstrings
@@ -8908,6 +8908,71 @@
         }
       }
     },
+    "Focus.Settings.PermissionDenied" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Der Zugriff auf deinen Fokus-Status ist deaktiviert. Aktiviere ihn in den Einstellungen, damit Sakura erkennt, wann ein Fokus aktiv ist."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Access to your Focus status is turned off. Turn it on in Settings so Sakura can tell when a Focus is on."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L’accès à votre statut de concentration est désactivé. Activez-le dans Réglages pour que Sakura sache quand un mode de concentration est activé."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L’accesso allo stato Full Immersion è disattivato. Attivalo in Impostazioni per consentire a Sakura di rilevare quando una Full Immersion è attiva."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "集中モードの状況へのアクセスがオフになっています。「設定」でオンにすると、Sakuraが集中モードのオン/オフを認識できるようになります。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "집중 모드 상태에 대한 접근이 꺼져 있습니다. 설정에서 켜면 Sakura가 집중 모드가 켜져 있는지 알 수 있습니다."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toegang tot je focusstatus is uitgeschakeld. Schakel deze in via Instellingen zodat Sakura weet wanneer een focus actief is."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quyền truy cập trạng thái Tập trung đang tắt. Hãy bật trong Cài đặt để Sakura biết khi nào chế độ Tập trung đang bật."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "对专注模式状态的访问已关闭。请在“设置”中开启，以便 Sakura 识别专注模式是否开启。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "對專注模式狀態的取用已關閉。請在「設定」中開啟，讓 Sakura 得知專注模式是否開啟。"
+          }
+        }
+      }
+    },
     "Focus.Settings.Active" : {
       "extractionState" : "manual",
       "localizations" : {


### PR DESCRIPTION
## Summary

The Focus filter integration never showed the system permission prompt because the app never requested Focus status access — it had no `com.apple.developer.focus-status` entitlement, no `NSFocusStatusUsageDescription`, and no `INFocusStatusCenter` authorization call. Without that access, the app also had no way to verify whether a Focus was actually on, so a missed deactivation of the filter intent could leave feeds hidden indefinitely.

## Changes

- Added the `com.apple.developer.focus-status` entitlement to the shared entitlements file and `NSFocusStatusUsageDescription` to the app's Info.plist.
- Added `FocusStatusAuthorization`, a small observable model wrapping `INFocusStatusCenter` authorization state and the request flow.
- Opening the Focus settings view now requests Focus status authorization, which triggers the system permission prompt on first open. If access is denied or restricted, the view shows a notice directing the user to Settings, and the state refreshes when returning to the app.
- Added `FeedManager.reconcileFocusWithSystemStatus()`, which clears a stale active focus filter when the system reports no Focus is on (guarding against a missed deactivation `perform()` call). It runs on app startup, on foreground, and when opening the Focus settings view.
- Localized the new permission-denied message and the usage description for all 10 supported languages.

## Testing

- Verified both string catalogs remain valid JSON with purely additive diffs.
- Not built or run on device — this environment has no Xcode. The permission prompt flow (first open of the Focus settings view) should be verified on a device or simulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXXdUBzZ9KTjQUoKEtnQyC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PXXdUBzZ9KTjQUoKEtnQyC)_