### PR TITLE
Add sakura://visuallystunning URL scheme to reload feed icons

### DIFF
--- a/App/App+URLHandling.swift
+++ b/App/App+URLHandling.swift
@@ -95,24 +95,26 @@ extension SakuraRSSApp {
     }
 
     private func handleReloadAllFeedIcons() {
-        Task {
-            if UserDefaults.standard.bool(forKey: "Labs.XProfileFeeds") {
-                await XProvider.fetchQueryIDsIfNeeded()
-            }
-            let currentFeeds = feedManager.feeds
-            let domainEntries = currentFeeds
-                .filter { !$0.isXFeed && !$0.isInstagramFeed }
-                .map { ($0.domain, $0.siteURL as String?) }
-            await Iconography.shared.refreshIcons(for: domainEntries)
-            await withTaskGroup(of: Void.self) { group in
-                for feed in currentFeeds where feed.isXFeed || feed.isInstagramFeed {
-                    group.addTask {
-                        await Iconography.shared.refreshIcon(for: feed)
-                    }
+        Task { await reloadAllFeedIcons() }
+    }
+
+    private func reloadAllFeedIcons() async {
+        if UserDefaults.standard.bool(forKey: "Labs.XProfileFeeds") {
+            await XProvider.fetchQueryIDsIfNeeded()
+        }
+        let currentFeeds = feedManager.feeds
+        let domainEntries = currentFeeds
+            .filter { !$0.isXFeed && !$0.isInstagramFeed }
+            .map { ($0.domain, $0.siteURL as String?) }
+        await Iconography.shared.refreshIcons(for: domainEntries)
+        await withTaskGroup(of: Void.self) { group in
+            for feed in currentFeeds where feed.isXFeed || feed.isInstagramFeed {
+                group.addTask {
+                    await Iconography.shared.refreshIcon(for: feed)
                 }
             }
-            feedManager.notifyIconChange()
         }
+        feedManager.notifyIconChange()
     }
 
     private func handlePutOnPipBoy() {

--- a/App/App+URLHandling.swift
+++ b/App/App+URLHandling.swift
@@ -84,16 +84,34 @@ extension SakuraRSSApp {
                 feedManager.reindexAllArticlesInSpotlight()
             }
         case "visuallystunning":
-            Task {
-                let entries = feedManager.feeds.map { ($0.domain, $0.siteURL as String?) }
-                await Iconography.shared.refreshIcons(for: entries)
-            }
+            handleReloadAllFeedIcons()
         case "putonpipboy":
             handlePutOnPipBoy()
         case "forgetit":
             handleForgetIt()
         default:
             break
+        }
+    }
+
+    private func handleReloadAllFeedIcons() {
+        Task {
+            if UserDefaults.standard.bool(forKey: "Labs.XProfileFeeds") {
+                await XProvider.fetchQueryIDsIfNeeded()
+            }
+            let currentFeeds = feedManager.feeds
+            let domainEntries = currentFeeds
+                .filter { !$0.isXFeed && !$0.isInstagramFeed }
+                .map { ($0.domain, $0.siteURL as String?) }
+            await Iconography.shared.refreshIcons(for: domainEntries)
+            await withTaskGroup(of: Void.self) { group in
+                for feed in currentFeeds where feed.isXFeed || feed.isInstagramFeed {
+                    group.addTask {
+                        await Iconography.shared.refreshIcon(for: feed)
+                    }
+                }
+            }
+            feedManager.notifyIconChange()
         }
     }
 

--- a/App/App+URLHandling.swift
+++ b/App/App+URLHandling.swift
@@ -83,6 +83,11 @@ extension SakuraRSSApp {
                 SpotlightIndexer.removeAllArticles()
                 feedManager.reindexAllArticlesInSpotlight()
             }
+        case "visuallystunning":
+            Task {
+                let entries = feedManager.feeds.map { ($0.domain, $0.siteURL as String?) }
+                await Iconography.shared.refreshIcons(for: entries)
+            }
         case "putonpipboy":
             handlePutOnPipBoy()
         case "forgetit":

--- a/Hanami/Iconography/Iconography+CustomIcons.swift
+++ b/Hanami/Iconography/Iconography+CustomIcons.swift
@@ -35,6 +35,22 @@ public extension Iconography {
         return await icon(for: feed.domain, siteURL: feed.siteURL)
     }
 
+    /// X/Instagram avatars live under the `custom-feed-<id>` key, so a domain-based
+    /// refresh never touches them; re-fetch and reinstall them here instead.
+    func refreshIcon(for feed: Feed) async {
+        guard feed.isXFeed || feed.isInstagramFeed else {
+            await refreshIcons(for: [(domain: feed.domain, siteURL: feed.siteURL)])
+            return
+        }
+        if let siteURL = URL(string: feed.siteURL),
+           let provider = FeedProviderRegistry.metadataFetcher(forSiteURL: siteURL),
+           let metadata = await provider.fetchMetadata(for: siteURL),
+           let iconURL = metadata.iconURL,
+           let image = await downloadImage(from: iconURL) {
+            setCustomIcon(image, feedID: feed.id)
+        }
+    }
+
     func setCustomIcon(_ image: UIImage, feedID: Int64) {
         let key = "custom-feed-\(feedID)"
         memoryCache[key] = image


### PR DESCRIPTION
## Summary

Adds a dedicated admin URL scheme host, `sakura://visuallystunning`, that clears and re-fetches all feed icons without wiping any caches or data.

Previously the only way to refresh feed icons via URL scheme was `sakura://putonpipboy`, which first wipes all app caches and data before re-fetching icons. This adds a lightweight, icon-only alternative.

## Changes

- New `case "visuallystunning"` in `handleAdminHost` (`App/App+URLHandling.swift`) that maps the current feeds to `(domain, siteURL)` entries and calls `Iconography.shared.refreshIcons(for:)` — the same refresh mechanism already used by `putonpipboy`.

## Testing

- `Iconography.refreshIcons(for:)` clears each cached icon (memory + disk + failed-lookup record) and re-fetches, so triggering `sakura://visuallystunning` reloads all feed icons in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6RkqdswA9oWsfBtNPUkdP)_