### PR TITLE
Route article viewer parsing by item URL instead of feed type

### DIFF
--- a/App/Article Viewer/ArticleDetailView+Actions.swift
+++ b/App/Article Viewer/ArticleDetailView+Actions.swift
@@ -154,8 +154,8 @@ extension ArticleDetailView: ArticleActions {
     }
 
     func resolveLinkedArticleURL() async {
-        guard let feed = feedManager.feed(forArticle: article),
-              feed.isRedditFeed else {
+        guard let url = URL(string: article.url),
+              ContentResolver.isRedditPostURL(url) else {
             linkedArticleURL = nil
             return
         }

--- a/Hanami/Content Resolver/ContentResolver+Providers.swift
+++ b/Hanami/Content Resolver/ContentResolver+Providers.swift
@@ -10,7 +10,7 @@ public extension ContentResolver {
 
     func tryRedditExtraction() async -> RedditExtractionOutcome {
         let isRedditCandidate = feed?.isRedditFeed == true
-            || (article.isEphemeral && URL(string: article.url).map { Self.isRedditPostURL($0) } == true)
+            || URL(string: article.url).map { Self.isRedditPostURL($0) } == true
         guard isRedditCandidate else { return .none }
         do {
             let redditResult = try await RedditProvider.shared.fetchContent(for: article)
@@ -32,9 +32,7 @@ public extension ContentResolver {
     }
 
     func tryHackerNewsExtraction() async -> Bool {
-        let isHackerNewsCandidate = feed?.isHackerNewsFeed == true || article.isEphemeral
-        guard isHackerNewsCandidate,
-              let url = URL(string: article.url),
+        guard let url = URL(string: article.url),
               HackerNewsPostFetcher.isSelfPostURL(url) else { return false }
         do {
             if let html = try await HackerNewsPostFetcher.fetchPostText(for: url) {
@@ -64,20 +62,20 @@ public extension ContentResolver {
 
     private func tryArXivExtraction() -> Bool {
         guard let url = URL(string: article.url), ArXivProvider.isAbstractURL(url) else { return false }
-        if let summary = article.summary, !summary.isEmpty {
-            result.text = summary
-            persistCachedContent(summary)
-        }
+        guard let summary = article.summary, !summary.isEmpty else { return false }
+        result.text = summary
+        persistCachedContent(summary)
         return true
     }
 
     private func tryInstagramExtraction() -> Bool {
         guard article.isInstagramPostURL else { return false }
         let text = renderInstagramPostContent()
+        // Articles from feeds without Instagram-populated fields render empty;
+        // fall through so the cascade can still try web extraction.
+        guard !text.isEmpty else { return feed?.isInstagramFeed == true }
         result.text = text
-        if !text.isEmpty {
-            persistCachedContent(text)
-        }
+        persistCachedContent(text)
         return true
     }
 

--- a/Hanami/Content Resolver/ContentResolver.swift
+++ b/Hanami/Content Resolver/ContentResolver.swift
@@ -5,7 +5,7 @@ import Foundation
 public final class ContentResolver {
 
     /// Bumped whenever extraction logic changes.
-    public nonisolated static let parserVersion = 20260527_000000
+    public nonisolated static let parserVersion = 20260708_000000
 
     public let article: Article
     public let articleSourceOverride: ArticleSource?

--- a/Hanami/Feed Providers/HackerNews/HackerNewsProvider+Comments.swift
+++ b/Hanami/Feed Providers/HackerNews/HackerNewsProvider+Comments.swift
@@ -9,8 +9,10 @@ extension HackerNewsProvider: CommentsProvider {
     }
 
     public nonisolated static func commentsURL(for article: Article, in feed: Feed?) -> URL? {
-        if let feed, !feed.isHackerNewsFeed { return nil }
-        if let summary = article.summary,
+        // Summary-link lookup is only trustworthy for Hacker News feeds,
+        // where the RSS summary carries the item's "Comments" link.
+        if feed?.isHackerNewsFeed == true,
+           let summary = article.summary,
            let url = threadURL(fromSummary: summary) {
             return url
         }

--- a/Hanami/Feed Providers/Instagram/InstagramProvider+Comments.swift
+++ b/Hanami/Feed Providers/Instagram/InstagramProvider+Comments.swift
@@ -13,7 +13,7 @@ extension InstagramProvider: CommentsProvider {
         return commentsURL(for: article, in: feed) != nil
     }
 
-    public nonisolated static func commentsURL(for article: Article, in feed: Feed?) -> URL? {
+    public nonisolated static func commentsURL(for article: Article, in _: Feed?) -> URL? {
         guard let url = URL(string: article.url),
               isInstagramPostURL(url),
               extractPostShortcode(from: url) != nil else {

--- a/Hanami/Feed Providers/Instagram/InstagramProvider+Comments.swift
+++ b/Hanami/Feed Providers/Instagram/InstagramProvider+Comments.swift
@@ -14,7 +14,6 @@ extension InstagramProvider: CommentsProvider {
     }
 
     public nonisolated static func commentsURL(for article: Article, in feed: Feed?) -> URL? {
-        if let feed, !feed.isInstagramFeed { return nil }
         guard let url = URL(string: article.url),
               isInstagramPostURL(url),
               extractPostShortcode(from: url) != nil else {

--- a/Hanami/Feed Providers/Reddit/RedditProvider+Comments.swift
+++ b/Hanami/Feed Providers/Reddit/RedditProvider+Comments.swift
@@ -10,7 +10,7 @@ extension RedditProvider: CommentsProvider {
         commentsURL(for: article, in: feed) != nil
     }
 
-    public nonisolated static func commentsURL(for article: Article, in feed: Feed?) -> URL? {
+    public nonisolated static func commentsURL(for article: Article, in _: Feed?) -> URL? {
         guard let url = URL(string: article.url),
               matchesHost(url.host),
               postID(from: url) != nil,

--- a/Hanami/Feed Providers/Reddit/RedditProvider+Comments.swift
+++ b/Hanami/Feed Providers/Reddit/RedditProvider+Comments.swift
@@ -11,7 +11,6 @@ extension RedditProvider: CommentsProvider {
     }
 
     public nonisolated static func commentsURL(for article: Article, in feed: Feed?) -> URL? {
-        if let feed, !feed.isRedditFeed { return nil }
         guard let url = URL(string: article.url),
               matchesHost(url.host),
               postID(from: url) != nil,

--- a/Hanami/Feed Providers/X/XProvider+Comments.swift
+++ b/Hanami/Feed Providers/X/XProvider+Comments.swift
@@ -12,7 +12,7 @@ extension XProvider: CommentsProvider {
         return commentsURL(for: article, in: feed) != nil
     }
 
-    public nonisolated static func commentsURL(for article: Article, in feed: Feed?) -> URL? {
+    public nonisolated static func commentsURL(for article: Article, in _: Feed?) -> URL? {
         guard let url = URL(string: article.url),
               isXPostURL(url) else { return nil }
         return url

--- a/Hanami/Feed Providers/X/XProvider+Comments.swift
+++ b/Hanami/Feed Providers/X/XProvider+Comments.swift
@@ -13,7 +13,6 @@ extension XProvider: CommentsProvider {
     }
 
     public nonisolated static func commentsURL(for article: Article, in feed: Feed?) -> URL? {
-        if let feed, !feed.isXFeed { return nil }
         guard let url = URL(string: article.url),
               isXPostURL(url) else { return nil }
         return url

--- a/Hanami/Feed Providers/X/XProvider.swift
+++ b/Hanami/Feed Providers/X/XProvider.swift
@@ -80,15 +80,19 @@ public final class XProvider: Authenticated {
     /// Returns true if the URL points to a specific X/Twitter post (status).
     public nonisolated static func isXPostURL(_ url: URL) -> Bool {
         guard isXHost(url.host) else { return false }
-        let components = url.pathComponents
-        return components.count >= 4 && components[2] == "status"
+        return extractTweetID(from: url) != nil
     }
 
-    /// Extracts the tweet ID from an X/Twitter status URL.
+    /// Extracts the tweet ID from an X/Twitter status URL. Accepts both the
+    /// `/<handle>/status/<id>` and `/i/web/status/<id>` path shapes so posts
+    /// linked from third-party feeds and in-article links are recognized.
     public nonisolated static func extractTweetID(from url: URL) -> String? {
         let components = url.pathComponents
-        guard components.count >= 4, components[2] == "status" else { return nil }
-        return components[3]
+        guard let statusIndex = components.lastIndex(of: "status"),
+              components.indices.contains(statusIndex + 1) else { return nil }
+        let tweetID = components[statusIndex + 1]
+        guard !tweetID.isEmpty, tweetID.allSatisfy(\.isNumber) else { return nil }
+        return tweetID
     }
 
     /// Constructs a canonical X profile URL from a handle.


### PR DESCRIPTION
Fixes #331.

The in-app article viewer routed content to the custom parsers (X, Instagram, Reddit, Hacker News) based on the *feed* the item came from, so a post URL reached from anywhere else — a generic RSS feed containing x.com links, or a link tapped inside another piece of content — fell through to plain web extraction (which fails on JS-rendered sites like x.com) or rendered blank.

## Changes

**Provider routing is now URL-based in `ContentResolver`:**
- Reddit and Hacker News extraction now trigger for any article whose URL is a matching post URL, not only for provider feeds or ephemeral (in-viewer navigation) articles.
- Instagram extraction no longer claims an article as handled when it renders empty (fields are only populated for Instagram-managed feeds); it falls through to web extraction instead. Same for arXiv abstracts with no stored summary.
- X post extraction was already URL-gated, but `XProvider.isXPostURL`/`extractTweetID` only matched the `/<handle>/status/<id>` path shape. They now also accept `/i/web/status/<id>` and other `…/status/<id>` variants (the shapes third-party RSS generators and share links emit) and validate that the ID is numeric. This fixes both example cases: an x.com item in a standard RSS feed, and tapping an x.com link inside the viewer.

**Conversations follow the URL too:**
- The four comments providers previously refused to load conversations when the article's feed wasn't the matching service feed. The feed-type gate is removed; the existing URL checks (post URL, shortcode, thread ID, subreddit) are sufficient. The Hacker News summary-link lookup stays restricted to Hacker News feeds, since only there does the RSS summary reliably carry the thread link.

**Viewer actions:**
- `resolveLinkedArticleURL` (the split "Open in Browser" menu for Reddit link posts) now keys off the article URL instead of the feed.

`ContentResolver.parserVersion` is bumped so previously cached extractions are refreshed.

## Notes
- X and Instagram parsing still require the respective Labs integration + session, unchanged.
- No new strings, no localization changes.
- Verified by review; there is no test target in the repo and the app can't be built in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MPk4HAytFpViEesgYwfoCz

---
_Generated by [Claude Code](https://claude.ai/code/session_01MPk4HAytFpViEesgYwfoCz)_